### PR TITLE
add ALWAYS-ON VPN support

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -69,7 +69,14 @@
             android:exported="false"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:process=":RunSoLibV2RayDaemon" />
+            android:process=":RunSoLibV2RayDaemon">
+            <intent-filter>
+                <action android:name="android.net.VpnService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
+                android:value="true" />
+        </service>
 
         <!--<receiver android:name=".receiver.WidgetProvider">-->
         <!--<meta-data-->


### PR DESCRIPTION
fix #134  #112 

说明：启用“始终开启”模式，可以避免app被电源管理被杀、断流等情况。

文档：https://developer.android.com/reference/android/net/VpnService#SERVICE_META_DATA_SUPPORTS_ALWAYS_ON

配置路径：配置 - WLAN和移动网络 - VPN - V2rayNG

效果截图：
![photo_2019-02-11_16-39-55](https://user-images.githubusercontent.com/1033514/52552563-b78d5b80-2e1b-11e9-99d1-b4d4b50eda8f.jpg)
