### PR TITLE
通过core读取流量速度信息

### DIFF
--- a/V2rayNG/app/src/main/assets/v2ray_config.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config.json
@@ -1,4 +1,5 @@
 {
+  "stats":{},
   "log": {
     "loglevel": "warning"
   },

--- a/V2rayNG/app/src/main/assets/v2ray_config.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config.json
@@ -10,9 +10,14 @@
           "uplinkOnly": 2,
           "downlinkOnly": 5
         }
+      },
+      "system": {
+        "statsInboundUplink": true,
+        "statsInboundDownlink": true
       }
   },
   "inbounds": [{
+    "tag": "socks",
     "port": 10808,
     "protocol": "socks",
     "settings": {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.dto
 
 data class V2rayConfig(
+        val stats: Any?=null,
         val log: LogBean,
         val policy: PolicyBean,
         val inbounds: ArrayList<InboundBean>,
@@ -119,14 +120,11 @@ data class V2rayConfig(
     }
 
     data class PolicyBean(var levels: Map<String, LevelBean>,
-                            var system: SystemBean) {
+                            var system: Any?=null) {
         data class LevelBean(
                   var handshake: Int? = null,
                   var connIdle: Int? = null,
                   var uplinkOnly: Int? = null,
                   var downlinkOnly: Int? = null)
-        data class SystemBean(
-                  var statsInboundUplink: Boolean? = false,
-                  var statsInboundDownlink: Boolean? = false)
     }
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -13,6 +13,7 @@ data class V2rayConfig(
                        val loglevel: String)
 
     data class InboundBean(
+            var tag: String,
             var port: Int,
             var protocol: String,
             val settings: InSettingsBean,
@@ -117,11 +118,15 @@ data class V2rayConfig(
                              var port: String? = null)
     }
 
-    data class PolicyBean(var levels: Map<String, LevelBean>) {
+    data class PolicyBean(var levels: Map<String, LevelBean>,
+                            var system: SystemBean) {
         data class LevelBean(
                   var handshake: Int? = null,
                   var connIdle: Int? = null,
                   var uplinkOnly: Int? = null,
                   var downlinkOnly: Int? = null)
+        data class SystemBean(
+                  var statsInboundUplink: Boolean? = false,
+                  var statsInboundDownlink: Boolean? = false)
     }
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -313,6 +313,8 @@ class V2RayVpnService : VpnService() {
                     }
                 }
                 netDev.close()
+                val stats = v2rayPoint.queryStats()
+                Log.d("v2raystats", stats.toString())
                 return bandWidth
             } catch (e: Exception) {
                 e.printStackTrace()

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -298,23 +298,25 @@ class V2RayVpnService : VpnService() {
     private val vpnBandwidth: VpnBandwidth?
         get() {
             try {
-                val netDev = FileInputStream("/proc/net/dev").bufferedReader()
-                var bandWidth: VpnBandwidth? = null
-                val prefix = "tun0:"
-                while (true) {
-                    val line = netDev.readLine().trim()
-                    if (line.startsWith(prefix)) {
-                        val numbers = line.substring(prefix.length).split(' ')
-                                .filter(String::isNotEmpty)
-                                .map(String::toLong)
-                        if (numbers.size > 10)
-                            bandWidth = VpnBandwidth(numbers[0], numbers[8])
-                        break
-                    }
-                }
-                netDev.close()
-                val stats = v2rayPoint.queryStats()
-                Log.d("v2raystats", stats.toString())
+                // val netDev = FileInputStream("/proc/net/dev").bufferedReader()
+                // var bandWidth: VpnBandwidth? = null
+                // val prefix = "tun0:"
+                // while (true) {
+                //     val line = netDev.readLine().trim()
+                //     if (line.startsWith(prefix)) {
+                //         val numbers = line.substring(prefix.length).split(' ')
+                //                 .filter(String::isNotEmpty)
+                //                 .map(String::toLong)
+                //         if (numbers.size > 10)
+                //             bandWidth = VpnBandwidth(numbers[0], numbers[8])
+                //         break
+                //     }
+                // }
+                // netDev.close()
+
+                var uplink = v2rayPoint.queryStats("socks", "uplink")
+                var downlink = v2rayPoint.queryStats("socks", "downlink")
+                var bandWidth = VpnBandwidth(downlink, uplink)
                 return bandWidth
             } catch (e: Exception) {
                 e.printStackTrace()


### PR DESCRIPTION
原来app通过读取`/proc/net/dev`，但是这个做法以后可能有兼容问题，根据 https://www.xda-developers.com/android-restrict-apps-monitor-network-activity/  Android以后引入的安全机制将限制app访问/proc目录。

目前已经看到有用户报告app速度无法显示的问题，主要是三星用户。

另外一个办法是通过core的流量统计接口，直接读取core提供的socks的流量信息，对比下这个做法开销更小（不需打开文件、解析内容），代码也简单。