### PR TITLE
Quic Support

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -99,7 +99,7 @@ data class V2rayConfig(
 
             data class QuicsettingBean(var security: String = "none",
                                         var key: String = "",
-                                        var header： HeaderBean()) {
+                                        var header: HeaderBean = HeaderBean()) {
                 data class HeaderBean(var type: String = "none")
             }
         }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -64,7 +64,8 @@ data class V2rayConfig(
                                       var kcpsettings: KcpsettingsBean?,
                                       var wssettings: WssettingsBean?,
                                       var httpsettings: HttpsettingsBean?,
-                                      var tlssettings: TlssettingsBean?
+                                      var tlssettings: TlssettingsBean?,
+                                      var quicsettings: QuicsettingBean?
         ) {
 
             data class TcpsettingsBean(var connectionReuse: Boolean = true,
@@ -95,6 +96,12 @@ data class V2rayConfig(
 
             data class TlssettingsBean(var allowInsecure: Boolean = true,
                                        var serverName: String = "")
+
+            data class QuicsettingBean(var security: String = "none",
+                                        var key: String = "",
+                                        var header： HeaderBean()) {
+                data class HeaderBean(var type: String = "none")
+            }
         }
 
         data class MuxBean(var enabled: Boolean)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -279,6 +279,19 @@ object V2rayConfigUtil {
                     tlssettings.allowInsecure = true
                     streamSettings.tlssettings = tlssettings
                 }
+                "quic" -> {
+                    val quicsettings = V2rayConfig.OutboundBean.StreamSettingsBean.QuicsettingBean()
+                    val host = vmess.requestHost.trim()
+                    val path = vmess.path.trim()
+
+                    quicsettings.security = host
+                    quicsettings.key = path
+
+                    quicsettings.header = V2rayConfig.OutboundBean.StreamSettingsBean.QuicsettingBean.HeaderBean()
+                    quicsettings.header.type = vmess.headerType
+
+                    streamSettings.quicsettings = quicsettings
+                }
                 else -> {
                     //tcp带http伪装
                     if (vmess.headerType == "http") {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -224,7 +224,7 @@ object V2rayConfigUtil {
      * 远程服务器底层传输配置
      */
     private fun boundStreamSettings(vmess: VmessBean): V2rayConfig.OutboundBean.StreamSettingsBean {
-        val streamSettings = V2rayConfig.OutboundBean.StreamSettingsBean("", "", null, null, null, null, null)
+        val streamSettings = V2rayConfig.OutboundBean.StreamSettingsBean("", "", null, null, null, null, null, null)
         try {
             //远程服务器底层传输配置
             streamSettings.network = vmess.network

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -41,8 +41,8 @@
     <string name="server_lab_network">传输协议(network)</string>
     <string name="server_lab_more_function">功能设置（不清楚则保持默认值）</string>
     <string name="server_lab_head_type">伪装类型(type)</string>
-    <string name="server_lab_request_host">伪装域名host(host/ws host/h2 host)</string>
-    <string name="server_lab_path">path(ws path/h2 path)</string>
+    <string name="server_lab_request_host">伪装域名host(host/ws host/h2 host)/QUIC 加密方式</string>
+    <string name="server_lab_path">path(ws path/h2 path)/QUIC 加密密钥</string>
     <string name="server_lab_stream_security">底层传输安全</string>
     <string name="server_lab_allow_insecure">allowInsecure</string>
     <string name="server_lab_address3">服务器地址</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -41,8 +41,8 @@
     <string name="server_lab_network">網路</string>
     <string name="server_lab_more_function">更多功能</string>
     <string name="server_lab_head_type">標頭類型</string>
-    <string name="server_lab_request_host">要求 主機(host/ws host/h2 host)</string>
-    <string name="server_lab_path">path(ws path/h2 path)</string>
+    <string name="server_lab_request_host">要求主機(host/ws host/h2 host)/QUIC加密方式</string>
+    <string name="server_lab_path">path(ws path/h2 path)/QUIC加密密鑰</string>
     <string name="server_lab_stream_security">傳輸層安全性</string>
     <string name="server_lab_allow_insecure">allowInsecure</string>
     <string name="server_lab_address3">伺服器位址</string>

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -22,6 +22,7 @@
         <item>kcp</item>
         <item>ws</item>
         <item>h2</item>
+        <item>quic</item>
     </string-array>
 
     <string-array name="headertypes" translatable="false">

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -41,8 +41,8 @@
     <string name="server_lab_network">network</string>
     <string name="server_lab_more_function">more function</string>
     <string name="server_lab_head_type">head type</string>
-    <string name="server_lab_request_host">request host(host/ws host/h2 host)</string>
-    <string name="server_lab_path">path(ws path/h2 path)</string>
+    <string name="server_lab_request_host">request host(host/ws host/h2 host)/QUIC securty</string>
+    <string name="server_lab_path">path(ws path/h2 path)/QUIC key</string>
     <string name="server_lab_stream_security">tls</string>
     <string name="server_lab_allow_insecure">allowInsecure</string>
     <string name="server_lab_address3">address</string>


### PR DESCRIPTION
按此前讨论 https://github.com/2dust/v2rayN/issues/282#issuecomment-456309187 的实现：vmess结构里按`host->quic.security` `path->quic.key`配置。

quic的配置相对简单（比mkcp还少参数），已测试正常通信。

NG生成的outbound配置
```
   "outbounds": [
     {
       "mux": {
         "enabled": false
       },
       "protocol": "vmess",
       "settings": {
         "vnext": [
           {
             "address": "myhost.com",
             "port": 8443,
             "users": [
               {
                 "alterId": 64,
                 "id": "uuiduuiduuid",
                 "level": 8,
                 "security": "auto"
               }
             ]
           }
         ]
       },
       "streamSettings": {
         "network": "quic",
         "quicsettings": {
           "header": {
             "type": "none"
           },
           "key": "password",
           "security": "aes-128-gcm"
         },
         "security": ""
       },
       "tag": "proxy"
     },
```


服务器的inbounds配置
```
"inbounds":[
                {
                        "tag": "quic",
                        "port": 8443,
                        "protocol": "vmess",
                        "settings": {
                                "clients": [
                                        {
                                                "email": "u3@user.com",
                                                "id": "uuiduuiduuid",
                                                "alterId": 64
                                        }
                                ]
                        },
                        "streamSettings": {
                                "network": "quic",
                                "quicSettings": {
                                        "security": "aes-128-gcm",
                                        "key": "password",
                                        "header": {
                                                "type": "none"
                                        }
                                }
                        }
                }
]
```