### PR TITLE
ConfTest/UnderlayNetwork

### DIFF
--- a/V2rayNG/app/build.gradle
+++ b/V2rayNG/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     implementation project(':dpreference')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
     // Android support library
     implementation "com.android.support:support-v4:$supportLibVersion"
     implementation "com.android.support:appcompat-v7:$supportLibVersion"

--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.v2ray.ang">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <!-- <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" /> -->

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Color
+import android.net.*
 import android.net.VpnService
 import android.os.*
 import android.support.annotation.RequiresApi
@@ -35,6 +36,9 @@ import rx.Observable
 import rx.Subscription
 import java.io.FileInputStream
 import java.lang.ref.SoftReference
+import android.os.Build
+import android.annotation.TargetApi
+import android.support.v4.os.BuildCompat
 
 class V2RayVpnService : VpnService() {
     companion object {
@@ -61,6 +65,39 @@ class V2RayVpnService : VpnService() {
     private var mSubscription: Subscription? = null
     private var lastVpnBandwidth: VpnBandwidth? = null
     private var mNotificationManager: NotificationManager? = null
+
+
+
+    /**
+        * Unfortunately registerDefaultNetworkCallback is going to return our VPN interface: https://android.googlesource.com/platform/frameworks/base/+/dda156ab0c5d66ad82bdcf76cda07cbc0a9c8a2e
+        *
+        * This makes doing a requestNetwork with REQUEST necessary so that we don't get ALL possible networks that
+        * satisfies default network capabilities but only THE default network. Unfortunately we need to have
+        * android.permission.CHANGE_NETWORK_STATE to be able to call requestNetwork.
+        *
+        * Source: https://android.googlesource.com/platform/frameworks/base/+/2df4c7d/services/core/java/com/android/server/ConnectivityService.java#887
+        */
+    private val defaultNetworkRequest = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_RESTRICTED)
+            .build()
+
+
+    private val connectivity by lazy { getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager }
+    @TargetApi(Build.VERSION_CODES.P)
+    private val defaultNetworkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            setUnderlyingNetworks(arrayOf(network))
+        }
+        override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities?) {
+            // it's a good idea to refresh capabilities
+            setUnderlyingNetworks(arrayOf(network))
+        }
+        override fun onLost(network: Network) {
+            setUnderlyingNetworks(null)
+        }
+    }
+    private var listeningForDefaultNetwork = false
 
     override fun onCreate() {
         super.onCreate()
@@ -128,6 +165,10 @@ class V2RayVpnService : VpnService() {
             mInterface.close()
         } catch (ignored: Exception) {
         }
+
+
+        connectivity.requestNetwork(defaultNetworkRequest, defaultNetworkCallback)
+        listeningForDefaultNetwork = true
 
         // Create a new interface using the builder and save the parameters.
         mInterface = builder.establish()
@@ -204,6 +245,10 @@ class V2RayVpnService : VpnService() {
 //        val emptyInfo = VpnNetworkInfo()
 //        val info = loadVpnNetworkInfo(configName, emptyInfo)!! + (lastNetworkInfo ?: emptyInfo)
 //        saveVpnNetworkInfo(configName, info)
+        if (BuildCompat.isAtLeastP() && listeningForDefaultNetwork) {
+            connectivity.unregisterNetworkCallback(defaultNetworkCallback)
+            listeningForDefaultNetwork = false
+        }
 
         if (v2rayPoint.isRunning) {
             try {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -190,7 +190,11 @@ class V2RayVpnService : VpnService() {
 
             v2rayPoint.configureFileContent = configContent
             v2rayPoint.domainName = domainName
-            v2rayPoint.runLoop()
+            try {
+                v2rayPoint.runLoop()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
         //        showNotification()
     }
@@ -202,7 +206,11 @@ class V2RayVpnService : VpnService() {
 //        saveVpnNetworkInfo(configName, info)
 
         if (v2rayPoint.isRunning) {
-            v2rayPoint.stopLoop()
+            try {
+                v2rayPoint.stopLoop()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
 
         MessageUtil.sendMsg2UI(this, AppConfig.MSG_STATE_STOP_SUCCESS, "")

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
@@ -115,7 +115,9 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         }
         showCircle()
 //        toast(R.string.toast_services_start)
-        Utils.startVService(this)
+        if (!Utils.startVService(this)) {
+            hideCircle()
+        }
     }
 
     override fun onStart() {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
@@ -149,11 +149,13 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
                 } else {
                     mActivity.showCircle()
                     Utils.stopVService(mActivity)
+                    AngConfigManager.setActiveServer(position)
                     Observable.timer(1500, TimeUnit.MILLISECONDS)
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe {
-                                AngConfigManager.setActiveServer(position)
-                                Utils.startVService(mActivity)
+                                if(!Utils.startVService(mActivity)) {
+                                    mActivity.hideCircle()
+                                }
                             }
 
                 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -202,6 +202,10 @@ object AngConfigManager {
         }
     }
 
+    fun currGeneratedV2rayConfig(): String {
+        return app.defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG, "")
+    }
+
     fun currConfigName(): String {
         if (angConfig.index < 0
                 || angConfig.vmess.count() <= 0

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -41,6 +41,7 @@ import java.net.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import java.math.BigInteger
+import libv2ray.Libv2ray
 
 
 object Utils {
@@ -365,6 +366,13 @@ object Utils {
     fun startVService(context: Context): Boolean {
         context.toast(R.string.toast_services_start)
         if (AngConfigManager.genStoreV2rayConfig(-1)) {
+            val configContent = AngConfigManager.currGeneratedV2rayConfig()
+            try {
+                Libv2ray.testConfig(configContent)
+            } catch (e: Exception) {
+                context.toast(e.toString())
+                return false
+            }
             V2RayVpnService.startV2Ray(context)
             return true
         } else {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -357,6 +357,14 @@ object V2rayConfigUtil {
 
             v2rayConfig.routing.domainStrategy = app.defaultDPreference.getPrefString(SettingsActivity.PREF_ROUTING_DOMAIN_STRATEGY, "IPIfNonMatch")
             val routingMode = app.defaultDPreference.getPrefString(SettingsActivity.PREF_ROUTING_MODE, "0")
+
+            // Hardcode googleapis.cn
+            val googleapisRoute = V2rayConfig.RoutingBean.RulesBean(
+                type = "field",
+                outboundTag = AppConfig.TAG_AGENT,
+                domain = arrayListOf("domain:googleapis.cn")
+            )
+
             when (routingMode) {
                 "0" -> {
                 }
@@ -365,10 +373,12 @@ object V2rayConfigUtil {
                 }
                 "2" -> {
                     routingGeo("", "cn", AppConfig.TAG_DIRECT, v2rayConfig)
+                    v2rayConfig.routing.rules.add(0, googleapisRoute)
                 }
                 "3" -> {
                     routingGeo("ip", "private", AppConfig.TAG_DIRECT, v2rayConfig)
                     routingGeo("", "cn", AppConfig.TAG_DIRECT, v2rayConfig)
+                    v2rayConfig.routing.rules.add(0, googleapisRoute)
                 }
             }
         } catch (e: Exception) {


### PR DESCRIPTION
1. 运行core前使用序列化功能检测配置，避免出现app崩溃，并toast提示配置出错的具体信息。
2. 设置VPN Service的Underlying Network，避免Android内认为VPN是计费网络的情况（解决Google Play更新时一直等待某些等待wifi后台任务，目前仅Android Pie 9.0后有效，来自ss项目的研究 https://github.com/shadowsocks/shadowsocks-android/pull/1698/files ）
3. 设置绕过大陆地址的路由模式时候加优先匹配 `domain:googleapis.cn` 路由。