### PR TITLE
Add tags in AndroidManifest to support PlayStore filtering

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -2,6 +2,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.v2ray.ang">
 
+    <supports-screens
+            android:anyDensity="true"
+            android:smallScreens="true"
+            android:normalScreens="true"
+            android:largeScreens="true"
+            android:xlargeScreens="true"/>
+
+    <uses-feature android:name="android.hardware.camera" android:required="false"/>
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
+
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Google Playstore is using uses-feature and supports-screens to filter devices.
By setting all screens to true and specifying features as "not required" should make app compatible with more devices. Particularly it includes Chrome OS devices.

Based on https://developer.android.com/topic/arc/manifest
Since we use camera permission, it will be implied that we require two camera related features. So we need to explicitly declare it as not required.
Although I can't test it on Playstore, I have tested on Chrome OS emulators that the basic feature is working. In "import config from QR code" screen, the camera view will be blank.