### PR TITLE
Re-arrange process in order to save memory

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -22,16 +22,17 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <!-- <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /> -->
     <application
-        android:name=".AngApplication"
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+            android:name=".AngApplication"
+            android:allowBackup="true"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme">
         <activity
-            android:name=".ui.MainActivity"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:launchMode="singleTask">
+                android:name=".ui.MainActivity"
+                android:theme="@style/AppTheme.NoActionBar"
+                android:launchMode="singleTask"
+                android:process=":UiProcess">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -49,48 +50,60 @@
             </intent-filter>
 
             <meta-data
-                android:name="android.app.shortcuts"
-                android:resource="@xml/shortcuts" />
+                    android:name="android.app.shortcuts"
+                    android:resource="@xml/shortcuts" />
         </activity>
         <activity
-            android:name=".ui.ServerActivity"
-            android:windowSoftInputMode="stateUnchanged" />
+                android:name=".ui.ServerActivity"
+                android:windowSoftInputMode="stateUnchanged"
+                android:process=":UiProcess"/>
         <activity
-            android:name=".ui.Server2Activity"
-            android:windowSoftInputMode="stateUnchanged" />
+                android:name=".ui.Server2Activity"
+                android:windowSoftInputMode="stateUnchanged"
+                android:process=":UiProcess"/>
         <activity
-            android:name=".ui.Server3Activity"
-            android:windowSoftInputMode="stateUnchanged" />
+                android:name=".ui.Server3Activity"
+                android:windowSoftInputMode="stateUnchanged"
+                android:process=":UiProcess"/>
         <activity
-            android:name=".ui.Server4Activity"
-            android:windowSoftInputMode="stateUnchanged" />
-        <activity android:name=".ui.SettingsActivity" />
-        <activity android:name=".ui.PerAppProxyActivity" />
-        <activity android:name=".ui.ScannerActivity" />
-<!--        <activity android:name=".InappBuyActivity" />-->
-        <activity android:name=".ui.LogcatActivity" />
+                android:name=".ui.Server4Activity"
+                android:windowSoftInputMode="stateUnchanged"
+                android:process=":UiProcess"/>
+        <activity android:name=".ui.SettingsActivity"
+                android:process=":UiProcess"/>
+        <activity android:name=".ui.PerAppProxyActivity"
+                android:process=":UiProcess"/>
+        <activity android:name=".ui.ScannerActivity"
+                android:process=":UiProcess"/>
+        <!--        <activity android:name=".InappBuyActivity" />-->
+        <activity android:name=".ui.LogcatActivity"
+                android:process=":UiProcess"/>
         <activity
-            android:name=".ui.RoutingSettingsActivity"
-            android:windowSoftInputMode="stateUnchanged" />
-        <activity android:name=".ui.SubSettingActivity" />
+                android:name=".ui.RoutingSettingsActivity"
+                android:windowSoftInputMode="stateUnchanged"
+                android:process=":UiProcess"/>
+        <activity android:name=".ui.SubSettingActivity"
+                android:process=":UiProcess"/>
 
-        <activity android:name=".ui.SubEditActivity" />
-        <activity android:name=".ui.ScScannerActivity" />
-        <activity android:name=".ui.ScSwitchActivity" />
+        <activity android:name=".ui.SubEditActivity"
+                android:process=":UiProcess"/>
+        <activity android:name=".ui.ScScannerActivity"
+                android:process=":UiProcess"/>
+        <activity android:name=".ui.ScSwitchActivity"
+                android:process=":UiProcess"/>
 
         <service
-            android:name=".service.V2RayVpnService"
-            android:enabled="true"
-            android:exported="false"
-            android:label="@string/app_name"
-            android:permission="android.permission.BIND_VPN_SERVICE"
-            android:process=":RunSoLibV2RayDaemon">
+                android:name=".service.V2RayVpnService"
+                android:enabled="true"
+                android:exported="false"
+                android:label="@string/app_name"
+                android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
             </intent-filter>
             <meta-data
-                android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
-                android:value="true" />
+                    android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
+                    android:value="true" />
         </service>
 
         <!--<receiver android:name=".receiver.WidgetProvider">-->
@@ -105,25 +118,27 @@
         <!--</receiver>-->
 
         <service
-            android:name=".service.QSTileService"
-            android:icon="@drawable/ic_v"
-            android:label="@string/app_tile_name"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+                android:name=".service.QSTileService"
+                android:icon="@drawable/ic_v"
+                android:label="@string/app_tile_name"
+                android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
         </service>
         <!-- =====================Tasker===================== -->
         <activity
-            android:name=".ui.TaskerActivity"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name">
+                android:name=".ui.TaskerActivity"
+                android:icon="@mipmap/ic_launcher"
+                android:label="@string/app_name"
+                android:process=":UiProcess">
             <intent-filter>
                 <action android:name="com.twofortyfouram.locale.intent.action.EDIT_SETTING" />
             </intent-filter>
         </activity>
 
-        <receiver android:name=".receiver.TaskerReceiver">
+        <receiver android:name=".receiver.TaskerReceiver"
+                android:process=":UiProcess">
             <intent-filter>
                 <action android:name="com.twofortyfouram.locale.intent.action.FIRE_SETTING" />
             </intent-filter>


### PR DESCRIPTION
- V2Ray core service is moved to main process
- All activities are moved to UI process
- Tile service stay at main process
- Also, adjust white space to match with Android Studio standards

Before:
![before1](https://user-images.githubusercontent.com/1588741/77233716-c4809080-6b7f-11ea-85af-5b90102a2cdd.png)
After:
![after](https://user-images.githubusercontent.com/1588741/77233765-fabe1000-6b7f-11ea-8b50-f98944f5e6ef.png)

v2rayNG has a good design with multiple processes. However, I found even if user wan't look at the v2rayNG, as soon as user expand status bar to see tiles, system will launch main process. As you can see on my device both processes take at least 300MB memory.
I tried to move TileService to a different process but that didn't help.
I think we should inverse it, assign activities to a separate process. User can still activate vpn from the tile. During my test, the UI process is never launched unless if you navigate to the app. This could cut memory usage by almost half.