### PR TITLE
All inbounds speed

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -11,6 +11,7 @@ object AppConfig {
     const val PREF_CURR_CONFIG_GUID = "pref_v2ray_config_guid"
     const val PREF_CURR_CONFIG_NAME = "pref_v2ray_config_name"
     const val PREF_CURR_CONFIG_DOMAIN = "pref_v2ray_config_domain"
+    const val PREF_CURR_CONFIG_INBOUND_TAGS = "pref_v2ray_config_inbound_tags"
     const val PREF_INAPP_BUY_IS_PREMIUM = "pref_inapp_buy_is_premium"
     const val VMESS_PROTOCOL: String = "vmess://"
     const val SS_PROTOCOL: String = "ss://"

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
@@ -27,34 +27,37 @@ const val divisor = 1024F
 fun Long.toSpeedString() = toTrafficString() + "/s"
 
 fun Long.toTrafficString(): String {
+    if (this == 0L)
+        return "\t\t\t0\t  B"
+
     if (this < threshold)
-        return "$this B"
+        return "${this.toFloat().toShortString()}\t  B"
 
     val kib = this / divisor
     if (kib < threshold)
-        return "${kib.toShortString()} KB"
+        return "${kib.toShortString()}\t KB"
 
     val mib = kib / divisor
     if (mib < threshold)
-        return "${mib.toShortString()} MB"
+        return "${mib.toShortString()}\t MB"
 
     val gib = mib / divisor
     if (gib < threshold)
-        return "${gib.toShortString()} GB"
+        return "${gib.toShortString()}\t GB"
 
     val tib = gib / divisor
     if (tib < threshold)
-        return "${tib.toShortString()} TB"
+        return "${tib.toShortString()}\t TB"
 
     val pib = tib / divisor
     if (pib < threshold)
-        return "${pib.toShortString()} PB"
+        return "${pib.toShortString()}\t PB"
 
     return "∞"
 }
 
 private fun Float.toShortString(): String {
-    val s = toString()
+    val s = "%.2f".format(this)
     if (s.length <= 4)
         return s
     return s.substring(0, 4).removeSuffix(".")

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/Server2Activity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/Server2Activity.kt
@@ -12,8 +12,10 @@ import com.v2ray.ang.extension.defaultDPreference
 import com.v2ray.ang.dto.AngConfig
 import com.v2ray.ang.util.AngConfigManager
 import com.v2ray.ang.util.Utils
+import com.v2ray.ang.util.V2rayConfigUtil.parseInboundTags
 import kotlinx.android.synthetic.main.activity_server2.*
 import org.jetbrains.anko.*
+import org.json.JSONObject
 import java.lang.Exception
 
 
@@ -93,7 +95,7 @@ class Server2Activity : BaseActivity() {
             Gson().fromJson<Object>(tv_content.text.toString(), Object::class.java)
         } catch (e: Exception) {
             e.printStackTrace()
-            toast(R.string.toast_malformed_josn)
+            toast("${getString(R.string.toast_malformed_josn)} : ${e.cause?.message}")
             saveSuccess = false
         }
 
@@ -153,9 +155,18 @@ class Server2Activity : BaseActivity() {
             true
         }
         R.id.save_config -> {
-            saveServer()
+            if (saveServer()) {
+                checkForWarnings()
+            }
             true
         }
         else -> super.onOptionsItemSelected(item)
+    }
+
+    private fun checkForWarnings() {
+        val inboundTags = parseInboundTags(JSONObject(tv_content.text.toString()))
+        if (inboundTags.isEmpty()) {
+            longToast(R.string.toast_missing_inbound_tags)
+        }
     }
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -626,7 +626,7 @@ object V2rayConfigUtil {
         }
     }
 
-    private fun parseInboundTags(jObj: JSONObject): Set<String> {
+    fun parseInboundTags(jObj: JSONObject): Set<String> {
         val tags = HashSet<String>()
         if (jObj.has("inbounds")) {
             val inbounds = jObj.optJSONArray("inbounds")

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -186,5 +186,6 @@
     <string name="toast_warning_pref_proxysharing">其他设备可以使用socks/http协议通过您的IP地址连接到代理\nHttp  代理: http://您的ip:10809\nSocks 代理: socks(4/5)://您的ip:10808\n仅在受信任的网络中启用以避免未经授权的连接</string>
     <string name="toast_warning_pref_proxysharing_short">代理共享已启用，请确保处于受信网络</string>
     <string name="toast_malformed_josn">配置格式错误</string>
+    <string name="toast_missing_inbound_tags">缺少inbound tag，通知中将无法显示速度</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -188,4 +188,6 @@
     <string name="toast_warning_pref_proxysharing">其他設備可以使用socks/http協議通過您的IP地址連接到代理\nHttp 代理: http://您的ip:10809\nSocks 代理: socks(4/5)://您的ip:10808\n僅在受信任的網絡中啟用以避免未經授權的連接</string>
     <string name="toast_warning_pref_proxysharing_short">代理共享已啟用，請確保處於受信網絡</string>
     <string name="toast_malformed_josn">配置格式錯誤</string>
+    <string name="toast_missing_inbound_tags">缺少inbound tag，通知中將無法顯示速度</string>
+
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -187,5 +187,6 @@
     <string name="toast_warning_pref_proxysharing">Other devices can connect to proxy by your ip address through socks/http protocol\nHttp  Proxy: http://yourIP:10809\nSocks Proxy: socks(4/5)://yourIP:10808\nOnly enable in trusted network to avoid unauthorized connection</string>
     <string name="toast_warning_pref_proxysharing_short">Proxy sharing enabled\nMake sure you are in a trusted network</string>
     <string name="toast_malformed_josn">Config malformed</string>
+    <string name="toast_missing_inbound_tags">Missing inbound tag. The speed display will be off in notification</string>
 
 </resources>


### PR DESCRIPTION
The first commit
- Parse inbound tags for preload Json and custom config
- When more than two tags available, show the one with higher traffic
- Also, improve the notification title so that the text won't bounce too much

The second
- When user save custom config and don't have a tag, show a toast for warning
- Also, improve the error message toast when custom config is malformed 

I've tested the notification speed works for socks and http inbound