### PR TITLE
Tcp test cleanup

### DIFF
--- a/V2rayNG/app/build.gradle
+++ b/V2rayNG/app/build.gradle
@@ -84,6 +84,10 @@ dependencies {
     implementation project(':dpreference')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.2" // 1.3.x has compile error:
+    // More than one file was found with OS independent path 'META-INF/proguard/coroutines.pro'
+
     // Android support library
     implementation "com.android.support:support-v4:$supportLibVersion"
     implementation "com.android.support:appcompat-v7:$supportLibVersion"

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
@@ -240,6 +240,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         }
 
         R.id.ping_all -> {
+            Utils.closeAllTcpSockets()
             for (k in 0 until configs.vmess.count()) {
                 configs.vmess[k].testResult = ""
                 adapter.updateConfigList()

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -31,6 +31,7 @@ import com.v2ray.ang.extension.v2RayApplication
 import com.v2ray.ang.service.V2RayVpnService
 import com.v2ray.ang.ui.SettingsActivity
 import kotlinx.android.synthetic.main.activity_logcat.*
+import kotlinx.coroutines.isActive
 import me.dozen.dpreference.DPreference
 import org.jetbrains.anko.toast
 import org.jetbrains.anko.uiThread
@@ -44,6 +45,7 @@ import java.util.regex.Pattern
 import java.math.BigInteger
 import java.util.concurrent.TimeUnit
 import libv2ray.Libv2ray
+import kotlin.coroutines.coroutineContext
 
 
 object Utils {
@@ -485,10 +487,13 @@ object Utils {
     /**
      * tcping
      */
-    fun tcping(url: String, port: Int): String {
+    suspend fun tcping(url: String, port: Int): String {
         var time = -1L
         for (k in 0 until 2) {
             val one = socketConnectTime(url, port)
+            if (!coroutineContext.isActive) {
+                break
+            }
             if (one != -1L  )
                 if(time == -1L || one < time) {
                 time = one

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -48,6 +48,8 @@ import libv2ray.Libv2ray
 
 object Utils {
 
+    val tcpTestingSockets = ArrayList<Socket?>()
+
     /**
      * convert string to editalbe for kotlin
      *
@@ -497,19 +499,35 @@ object Utils {
 
     fun socketConnectTime(url: String, port: Int): Long {
         try {
+            val socket = Socket()
+            synchronized(this) {
+                tcpTestingSockets.add(socket)
+            }
             val start = System.currentTimeMillis()
-            val socket = Socket(url, port)
+            socket.connect(InetSocketAddress(url, port))
             val time = System.currentTimeMillis() - start
+            synchronized(this) {
+                tcpTestingSockets.remove(socket)
+            }
             socket.close()
             return time
         } catch (e: UnknownHostException) {
             e.printStackTrace()
         } catch (e: IOException) {
-            e.printStackTrace()
+            Log.d(AppConfig.ANG_PACKAGE, "socketConnectTime IOException: $e")
         } catch (e: Exception) {
             e.printStackTrace()
         }
         return -1
+    }
+
+    fun closeAllTcpSockets() {
+        synchronized(this) {
+            tcpTestingSockets.forEach {
+                it?.close()
+            }
+            tcpTestingSockets.clear()
+        }
     }
 }
 


### PR DESCRIPTION
If user has some unreachable nodes in the list and keep using the tcp test function. Our thread pool will run out with all threads waiting on the Socket timeout. All later tests will not be done for a long time.
Fix it by adding a logic to cancel Socket and cancel coroutine.