### PR TITLE
Optimize invoke timing of store config file after dragging item.

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/ItemTouchHelperAdapter.java
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/ItemTouchHelperAdapter.java
@@ -43,6 +43,8 @@ public interface ItemTouchHelperAdapter {
     boolean onItemMove(int fromPosition, int toPosition);
 
 
+    void onItemMoveCompleted();
+
     /**
      * Called when an item has been dismissed by a swipe.<br/>
      * <br/>

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/SimpleItemTouchHelperCallback.java
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/SimpleItemTouchHelperCallback.java
@@ -112,6 +112,8 @@ public class SimpleItemTouchHelperCallback extends ItemTouchHelper.Callback {
     public void clearView(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
         super.clearView(recyclerView, viewHolder);
 
+        mAdapter.onItemMoveCompleted();
+
         viewHolder.itemView.setAlpha(ALPHA_FULL);
 
         if (viewHolder instanceof ItemTouchHelperViewHolder) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
@@ -265,4 +265,8 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
         updateSelectedItem(if (fromPosition < toPosition) fromPosition else toPosition)
         return true
     }
+
+    override fun onItemMoveCompleted() {
+        AngConfigManager.storeConfigFile()
+    }
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -133,7 +133,7 @@ object AngConfigManager {
             } else if (index == toPosition) {
                 angConfig.index = fromPosition
             }
-            storeConfigFile()
+            //storeConfigFile()
         } catch (e: Exception) {
             e.printStackTrace()
             return -1


### PR DESCRIPTION
While dragging item, the onMove() can be called more than once, but the clearView() will be called once. So I added a method called onItemMoveCompleted() and then put storeConfigFile() in here so that the store will not be called multiple times during the dragging process.