### PR TITLE
Fix test crash if node is removed

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
@@ -262,11 +262,13 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
                     serverPort = serverOutbound.getServerPort() ?: continue
                 }
                 testingJobs.add(GlobalScope.launch(Dispatchers.IO) {
-                    configs.vmess[k].testResult = Utils.tcping(serverAddress, serverPort)
-                    val myJob = coroutineContext[Job]
-                    launch(Dispatchers.Main) {
-                        testingJobs.remove(myJob)
-                        adapter.updateSelectedItem(k)
+                    configs.vmess.getOrNull(k)?.let {  // check null in case array is modified during testing
+                        it.testResult = Utils.tcping(serverAddress, serverPort)
+                        val myJob = coroutineContext[Job]
+                        launch(Dispatchers.Main) {
+                            testingJobs.remove(myJob)
+                            adapter.updateSelectedItem(k)
+                        }
                     }
                 })
             }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -795,10 +795,16 @@ object AngConfigManager {
                 return 0
             }
             val removedSelectedServer =
-                    if (!TextUtils.isEmpty(subid) && configs.vmess.count() > 0 && configs.vmess[configs.index].subid.equals(subid))
-                        configs.vmess[configs.index]
-                    else
+                    if (!TextUtils.isEmpty(subid)) {
+                        configs.vmess.getOrNull(configs.index)?.let {
+                            if (it.subid == subid) {
+                                return@let it
+                            }
+                            return@let null
+                        }
+                    } else {
                         null
+                    }
             removeServerViaSubid(subid)
 
 //            var servers = server


### PR DESCRIPTION
This should fix almost all issues when the testing is in progress
and the array is changed. However, there might be uncovered edge
cases since the vmess array is in both process and accessed by
multiple threads.