### PR TITLE
Fix protect() when there is no service

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -88,7 +88,7 @@ object V2RayServiceManager {
         }
 
         override fun protect(l: Long): Long {
-            val serviceControl = serviceControl?.get() ?: return 1
+            val serviceControl = serviceControl?.get() ?: return 0
             return if (serviceControl.vpnProtect(l.toInt())) 0 else 1
         }
 


### PR DESCRIPTION
If user perform "True test" before activate proxy. Currently the test will fail with "fdConn fail to protect" error. This is because the default return value of protect() is false. It should return true as protect is not needed.