### PR TITLE
useless multiDex

### DIFF
--- a/V2rayNG/app/build.gradle
+++ b/V2rayNG/app/build.gradle
@@ -15,7 +15,6 @@ android {
         applicationId "com.v2ray.ang"
         minSdkVersion 17
         targetSdkVersion Integer.parseInt("$targetSdkVer")
-        multiDexEnabled true
         versionCode 212
         versionName "1.0.2"
     }
@@ -77,7 +76,6 @@ dependencies {
     implementation "com.android.support:cardview-v7:$supportLibVersion"
     implementation "com.android.support:preference-v7:$supportLibVersion"
     implementation "com.android.support:recyclerview-v7:$supportLibVersion"
-    implementation "com.android.support:multidex:1.0.3"
     implementation 'com.android.support.constraint:constraint-layout:2.0.1'
 
     // DSL

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AngApplication.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AngApplication.kt
@@ -1,11 +1,11 @@
 package com.v2ray.ang
 
-import android.support.multidex.MultiDexApplication
+import android.app.Application
 import android.support.v7.preference.PreferenceManager
 import com.v2ray.ang.util.AngConfigManager
 import me.dozen.dpreference.DPreference
 
-class AngApplication : MultiDexApplication() {
+class AngApplication : Application() {
     companion object {
         const val PREF_LAST_VERSION = "pref_last_version"
     }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -483,7 +483,7 @@ object V2rayConfigUtil {
         }
     }
 
-    private fun userRule2Domian(userRule: String): ArrayList<String> {
+    private fun userRule2Domain(userRule: String): ArrayList<String> {
         val domain = ArrayList<String>()
         userRule.trim().replace("\n", "").split(",").forEach {
             if ((it.startsWith("geosite:") || it.startsWith("domain:")) &&
@@ -508,12 +508,12 @@ object V2rayConfigUtil {
 
             val domesticDns = Utils.getDomesticDnsServers(app.defaultDPreference)
 
-            val agDomain = userRule2Domian(app.defaultDPreference.getPrefString(AppConfig.PREF_V2RAY_ROUTING_AGENT, ""))
+            val agDomain = userRule2Domain(app.defaultDPreference.getPrefString(AppConfig.PREF_V2RAY_ROUTING_AGENT, ""))
             if (agDomain.size > 0) {
                 servers.add(V2rayConfig.DnsBean.ServersBean(remoteDns.first(), 53, agDomain))
             }
 
-            val dirDomain = userRule2Domian(app.defaultDPreference.getPrefString(AppConfig.PREF_V2RAY_ROUTING_DIRECT, ""))
+            val dirDomain = userRule2Domain(app.defaultDPreference.getPrefString(AppConfig.PREF_V2RAY_ROUTING_DIRECT, ""))
             if (dirDomain.size > 0) {
                 servers.add(V2rayConfig.DnsBean.ServersBean(domesticDns.first(), 53, dirDomain))
             }
@@ -523,7 +523,7 @@ object V2rayConfigUtil {
                 servers.add(V2rayConfig.DnsBean.ServersBean(domesticDns.first(), 53, arrayListOf("geosite:cn")))
             }
 
-            val blkDomain = userRule2Domian(app.defaultDPreference.getPrefString(AppConfig.PREF_V2RAY_ROUTING_BLOCKED, ""))
+            val blkDomain = userRule2Domain(app.defaultDPreference.getPrefString(AppConfig.PREF_V2RAY_ROUTING_BLOCKED, ""))
             if (blkDomain.size > 0) {
                 hosts.putAll(blkDomain.map { it to "127.0.0.1" })
             }


### PR DESCRIPTION
remove useless multiDex http://developer.android.com/tools/building/multidex.html
>> the feature is: it allows your complex app to compile. The scenarios for using it are when your app fails to compile due to hitting the 64K DEX method reference limit. This appears as a build error, such as: Conversion to Dalvik format failed: Unable to execute dex: method ID not in [0, 0xffff]: 65536