### PR TITLE
target 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A V2Ray client for Android
 
 [![API](https://img.shields.io/badge/API-17%2B-yellow.svg?style=flat)](https://developer.android.com/about/versions/jelly-bean#android-4.2)
-[![Kotlin Version](https://img.shields.io/badge/Kotlin-1.4.0-blue.svg)](https://kotlinlang.org)
+[![Kotlin Version](https://img.shields.io/badge/Kotlin-1.4.10-blue.svg)](https://kotlinlang.org)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/2dust/v2rayNG)](https://github.com/2dust/v2rayNG/commits/master)
 [![CodeFactor](https://www.codefactor.io/repository/github/2dust/v2rayng/badge)](https://www.codefactor.io/repository/github/2dust/v2rayng)
 [![GitHub Releases](https://img.shields.io/github/downloads/2dust/v2rayNG/latest/total?logo=github)](https://github.com/2dust/v2rayNG/releases)

--- a/V2rayNG/app/proguard-rules.pro
+++ b/V2rayNG/app/proguard-rules.pro
@@ -44,9 +44,6 @@
     static void throwUninitializedPropertyAccessException(java.lang.String);
 }
 
--dontwarn org.jetbrains.anko.internals.**
--keep class org.jetbrains.anko.internals.** { *;}
-
 -dontwarn rx.internal.util.unsafe.**
 -keep class rx.internal.util.unsafe.** { *;}
 

--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.v2ray.ang">
 
     <supports-screens
@@ -12,6 +13,11 @@
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
 
+
+    <!-- https://developer.android.com/about/versions/11/privacy/package-visibility -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
+
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET" />
@@ -21,6 +27,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <!-- <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /> -->
+
     <application
         android:name=".AngApplication"
         android:allowBackup="true"
@@ -35,20 +42,16 @@
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
-
                 <category android:name="android.intent.category.DEFAULT" />
-
                 <data android:mimeType="text/plain" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
             </intent-filter>
-
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -50,7 +50,7 @@ class V2RayVpnService : VpnService(), ServiceControl {
             override fun onAvailable(network: Network) {
                 setUnderlyingNetworks(arrayOf(network))
             }
-            override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities?) {
+            override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
                 // it's a good idea to refresh capabilities
                 setUnderlyingNetworks(arrayOf(network))
             }

--- a/V2rayNG/build.gradle
+++ b/V2rayNG/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         maven { url 'https://maven.google.com' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/V2rayNG/gradle.properties
+++ b/V2rayNG/gradle.properties
@@ -13,9 +13,9 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryErro
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Fri Jun 02 14:08:42 CST 2017
-kotlinVersion=1.4.0
+kotlinVersion=1.4.10
 supportLibVersion=28.0.0
-buildToolsVer=29.0.3
-compileSdkVer=29
+buildToolsVer=30.0.2
+compileSdkVer=30
 kotlin.incremental=true
-targetSdkVer=29
+targetSdkVer=30


### PR DESCRIPTION
>> In rare cases, your app might need to query or interact with all installed apps on a device, independent of the components they contain. To allow your app to see all other installed apps, the system provides the QUERY_ALL_PACKAGES permission.  
In an upcoming policy update, look for Google Play to provide guidelines for apps that need the QUERY_ALL_PACKAGES permission. https://developer.android.com/training/basics/intents/package-visibility

though package list for allowed/disallowedApplicationList used for per-app proxy, app uses `QUERY_ALL_PACKAGES` open in Google Play Store needs extra review by Google.

Package Visibility forced to any on Android 11, not determined of if its target level up to 30