### PR TITLE
fix: the problem that importing SS URL not support standard format

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -318,7 +318,7 @@ object AngConfigManager {
                     result = Utils.decode(result)
                 }
 
-                val legacyPattern = "^(.+?):(.*)@(.+?):(\\d+?)$".toRegex()
+                val legacyPattern = "^(.+?):(.*)@(.+?):(\\d+?)/?$".toRegex()
                 val match = legacyPattern.matchEntire(result)
                 if (match == null) {
                     return R.string.toast_incorrect_protocol


### PR DESCRIPTION
For example, an address can be generated with path '/' and it will be like ss://username:password@example.com:port/#anchor

v2rayNG cannot import it while v2rayN can.