### PR TITLE
Slightly improve memory by reduce unnecessary DPreference usage

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
@@ -15,6 +15,10 @@ import java.net.URLConnection
 val Context.v2RayApplication: AngApplication
     get() = applicationContext as AngApplication
 
+// Usage note: DPreference use Android ContentProvider to redirect multi process access to main process.
+// Currently, RunSoLibV2RayDaemon process will run proxy core, keep minimum configuration and long running
+// in the background, support toggle on/off. That means it should NOT use DPreference after the initial
+// creation and setup of the service
 val Context.defaultDPreference: DPreference
     get() = v2RayApplication.defaultDPreference
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/QSTileService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/QSTileService.kt
@@ -11,11 +11,9 @@ import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
-import com.v2ray.ang.extension.defaultDPreference
 import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.Utils
 import java.lang.ref.SoftReference
-
 
 @TargetApi(Build.VERSION_CODES.N)
 class QSTileService : TileService() {
@@ -27,7 +25,7 @@ class QSTileService : TileService() {
             qsTile?.icon = Icon.createWithResource(applicationContext, R.drawable.ic_v_idle)
         } else if (state == Tile.STATE_ACTIVE) {
             qsTile?.state = Tile.STATE_ACTIVE
-            qsTile?.label = defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG_NAME, "NG")
+            qsTile?.label = V2RayServiceManager.currentConfigName
             qsTile?.icon = Icon.createWithResource(applicationContext, R.drawable.ic_v)
         }
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -50,6 +50,7 @@ object V2RayServiceManager {
                 Seq.setContext(context)
             }
         }
+    var currentConfigName = "NG"
 
     private var lastQueryTime = 0L
     private var mBuilder: NotificationCompat.Builder? = null
@@ -132,6 +133,7 @@ object V2RayServiceManager {
             v2rayPoint.forwardIpv6 = service.defaultDPreference.getPrefBoolean(SettingsActivity.PREF_FORWARD_IPV6, false)
             v2rayPoint.domainName = service.defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG_DOMAIN, "")
             v2rayPoint.proxyOnly = service.defaultDPreference.getPrefString(AppConfig.PREF_MODE, "VPN") != "VPN"
+            currentConfigName = service.defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG_NAME, "NG")
 
             try {
                 v2rayPoint.runLoop()
@@ -235,7 +237,7 @@ object V2RayServiceManager {
 
         mBuilder = NotificationCompat.Builder(service, channelId)
                 .setSmallIcon(R.drawable.ic_v)
-                .setContentTitle(service.defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG_NAME, ""))
+                .setContentTitle(currentConfigName)
                 .setPriority(NotificationCompat.PRIORITY_MIN)
                 .setOngoing(true)
                 .setShowWhen(false)
@@ -346,13 +348,10 @@ object V2RayServiceManager {
     }
 
     fun stopSpeedNotification() {
-        val service = serviceControl?.get()?.getService() ?: return
         if (mSubscription != null) {
             mSubscription?.unsubscribe() //stop queryStats
             mSubscription = null
-
-            val cfName = service.defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG_NAME, "")
-            updateNotification(cfName, 0, 0)
+            updateNotification(currentConfigName, 0, 0)
         }
     }
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -10,7 +10,6 @@ import android.os.ParcelFileDescriptor
 import android.os.StrictMode
 import android.support.annotation.RequiresApi
 import android.util.Log
-import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.extension.defaultDPreference
 import com.v2ray.ang.ui.PerAppProxyActivity
@@ -127,7 +126,7 @@ class V2RayVpnService : VpnService(), ServiceControl {
                 }
         }
 
-        builder.setSession(defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG_NAME, ""))
+        builder.setSession(V2RayServiceManager.currentConfigName)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
                 defaultDPreference.getPrefBoolean(SettingsActivity.PREF_PER_APP_PROXY, false)) {


### PR DESCRIPTION
Fix "when user expand status bar to see tiles, system will launch main process" mentioned in https://github.com/2dust/v2rayNG/pull/320

See more details in _Ext.kt.
In the future, change will be made to our config storage, so that
the service started through TileService/Widget/ScSwitchActivity will
also not launch main process. That will greatly reduce memory usage