### PR TITLE
Fix select node of two processes in sync

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/receiver/TaskerReceiver.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/receiver/TaskerReceiver.kt
@@ -21,7 +21,7 @@ class TaskerReceiver : BroadcastReceiver() {
                 return
             } else if (switch) {
                 if (guid == AppConfig.TASKER_DEFAULT_GUID) {
-                    Utils.startVService(context)
+                    Utils.startVServiceFromToggle(context)
                 } else {
                     Utils.startVService(context, guid)
                 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -18,6 +18,8 @@ import com.v2ray.ang.AppConfig.TAG_DIRECT
 import com.v2ray.ang.R
 import com.v2ray.ang.extension.defaultDPreference
 import com.v2ray.ang.extension.toSpeedString
+import com.v2ray.ang.extension.toast
+import com.v2ray.ang.extension.v2RayApplication
 import com.v2ray.ang.ui.MainActivity
 import com.v2ray.ang.ui.SettingsActivity
 import com.v2ray.ang.util.MessageUtil
@@ -57,8 +59,13 @@ object V2RayServiceManager {
     private var mSubscription: Subscription? = null
     private var mNotificationManager: NotificationManager? = null
 
-    fun startV2Ray(context: Context, mode: String) {
-        val intent = if (mode == "VPN") {
+    fun startV2Ray(context: Context) {
+        if (context.v2RayApplication.defaultDPreference.getPrefBoolean(SettingsActivity.PREF_PROXY_SHARING, false)) {
+            context.toast(R.string.toast_warning_pref_proxysharing_short)
+        }else{
+            context.toast(R.string.toast_services_start)
+        }
+        val intent = if (context.v2RayApplication.defaultDPreference.getPrefString(AppConfig.PREF_MODE, "VPN") == "VPN") {
             Intent(context.applicationContext, V2RayVpnService::class.java)
         } else {
             Intent(context.applicationContext, V2RayProxyOnlyService::class.java)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
@@ -128,7 +128,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         }
         showCircle()
 //        toast(R.string.toast_services_start)
-        if (!Utils.startVService(this)) {
+        if (!Utils.startVService(this, AngConfigManager.configs.index)) {
             hideCircle()
         }
     }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
@@ -143,16 +143,14 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
                 } else {
                     mActivity.showCircle()
                     Utils.stopVService(mActivity)
-                    AngConfigManager.setActiveServer(position)
                     Observable.timer(500, TimeUnit.MILLISECONDS)
                             .observeOn(AndroidSchedulers.mainThread())
                             .subscribe {
                                 mActivity.showCircle()
-                                if (!Utils.startVService(mActivity)) {
+                                if (!Utils.startVService(mActivity, position)) {
                                     mActivity.hideCircle()
                                 }
                             }
-
                 }
                 notifyDataSetChanged()
             }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SettingsActivity.kt
@@ -7,6 +7,7 @@ import android.view.View
 import com.v2ray.ang.R
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.extension.toast
+import com.v2ray.ang.util.AngConfigManager
 import com.v2ray.ang.util.Utils
 
 class SettingsActivity : BaseActivity() {
@@ -74,7 +75,7 @@ class SettingsActivity : BaseActivity() {
 
         private fun restartProxy() {
             Utils.stopVService(requireContext())
-            Utils.startVService(requireContext())
+            Utils.startVService(requireContext(), AngConfigManager.configs.index)
         }
 
         private fun isRunning(): Boolean {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -2,6 +2,7 @@ package com.v2ray.ang.util
 
 import android.graphics.Bitmap
 import android.text.TextUtils
+import android.util.Log
 import com.google.gson.Gson
 import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
@@ -154,6 +155,10 @@ object AngConfigManager {
             angConfig.index = index
             app.curIndex = index
             storeConfigFile()
+            if (!genStoreV2rayConfig(index)) {
+                Log.d(AppConfig.ANG_PACKAGE, "set active index $index but generate full configuration failed!")
+                return -1
+            }
         } catch (e: Exception) {
             e.printStackTrace()
             app.curIndex = -1
@@ -586,9 +591,9 @@ object AngConfigManager {
      */
     fun shareFullContent2Clipboard(index: Int): Int {
         try {
-            if (AngConfigManager.genStoreV2rayConfig(index)) {
-                val configContent = app.defaultDPreference.getPrefString(AppConfig.PREF_CURR_CONFIG, "")
-                Utils.setClipboard(app.applicationContext, configContent)
+            val result = V2rayConfigUtil.getV2rayConfig(app, angConfig.vmess[index])
+            if (result.status) {
+                Utils.setClipboard(app.applicationContext, result.content)
             } else {
                 return -1
             }


### PR DESCRIPTION
As proxy only mode is added in 1.4.0, I moved the toggle components to the daemon process
When user start service from toggle, the full config is generated from a cached list.
However, this cache is not in sync with the main process list.
In fact, we don't need to generate full config right before the service start. We only
need to when active node is changed.
This way, code logic and daemon process is kept simple