### PR TITLE
Fix toast BadTokenException in OS 7.1.2

### DIFF
--- a/V2rayNG/app/build.gradle
+++ b/V2rayNG/app/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     implementation 'me.dm7.barcodescanner:core:1.9.8'
     implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation 'com.github.jorgecastilloprz:fabprogresscircle:1.01@aar'
+    implementation 'me.drakeet.support:toastcompat:1.1.0'
 
     implementation(name: 'libv2ray', ext: 'aar')
     //implementation(name: 'tun2socks', ext: 'aar')

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.widget.Toast
 import com.v2ray.ang.AngApplication
 import me.dozen.dpreference.DPreference
+import me.drakeet.support.toast.ToastCompat
 import org.json.JSONObject
 import java.net.URLConnection
 
@@ -22,13 +23,13 @@ val Context.v2RayApplication: AngApplication
 val Context.defaultDPreference: DPreference
     get() = v2RayApplication.defaultDPreference
 
-inline fun Context.toast(message: Int): Toast = Toast
+inline fun Context.toast(message: Int): Toast = ToastCompat
         .makeText(this, message, Toast.LENGTH_SHORT)
         .apply {
             show()
         }
 
-inline fun Context.toast(message: CharSequence): Toast = Toast
+inline fun Context.toast(message: CharSequence): Toast = ToastCompat
         .makeText(this, message, Toast.LENGTH_SHORT)
         .apply {
             show()


### PR DESCRIPTION
https://github.com/2dust/v2rayNG/issues/782

Apparently recent changes with ViewModel affect the internal of
Activity which lead to toast throwing BadTokenException in OS
7.1.2.
The error is not easily catchable. This library use reflection
to override a key function in WindowManager to catch the error.
I have audit the code of the library.

See https://github.com/PureWriter/ToastCompat for more details