### PR TITLE
Rollback parsed custom config

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
@@ -21,6 +21,7 @@ import me.drakeet.support.toast.ToastCompat
 class ServerCustomConfigActivity : BaseActivity() {
 
     private val mainStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
+    private val serverRawStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SERVER_RAW, MMKV.MULTI_PROCESS_MODE) }
     private val editGuid by lazy { intent.getStringExtra("guid").orEmpty() }
     private val isRunning by lazy {
         intent.getBooleanExtra("isRunning", false)
@@ -47,7 +48,12 @@ class ServerCustomConfigActivity : BaseActivity() {
      */
     private fun bindingServer(config: ServerConfig): Boolean {
         et_remarks.text = Utils.getEditable(config.remarks)
-        tv_content.text = Utils.getEditable(config.fullConfig?.toPrettyPrinting().orEmpty())
+        val raw = serverRawStorage?.decodeString(editGuid)
+        if (raw.isNullOrBlank()) {
+            tv_content.text = Utils.getEditable(config.fullConfig?.toPrettyPrinting().orEmpty())
+        } else {
+            tv_content.text = Utils.getEditable(raw)
+        }
         return true
     }
 
@@ -81,6 +87,7 @@ class ServerCustomConfigActivity : BaseActivity() {
         config.fullConfig = v2rayConfig
 
         MmkvManager.encodeServerConfig(editGuid, config)
+        serverRawStorage?.encode(editGuid, tv_content.text.toString())
         toast(R.string.toast_success)
         finish()
         return true

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -22,6 +22,7 @@ import java.util.*
 
 object AngConfigManager {
     private val mainStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
+    private val serverRawStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SERVER_RAW, MMKV.MULTI_PROCESS_MODE) }
     private val settingsStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SETTING, MMKV.MULTI_PROCESS_MODE) }
     private val subStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SUB, MMKV.MULTI_PROCESS_MODE) }
 
@@ -95,6 +96,7 @@ object AngConfigManager {
                     return@forEachIndexed
                 }
                 config.fullConfig = v2rayConfig
+                serverRawStorage?.encode(vmessBean.guid, jsonConfig)
             } else {
                 config.outboundBean?.settings?.vnext?.get(0)?.let { vnext ->
                     vnext.address = vmessBean.address

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/MmkvManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/MmkvManager.kt
@@ -9,6 +9,7 @@ import com.v2ray.ang.dto.SubscriptionItem
 object MmkvManager {
     const val ID_MAIN = "MAIN"
     const val ID_SERVER_CONFIG = "SERVER_CONFIG"
+    const val ID_SERVER_RAW = "SERVER_RAW"
     const val ID_SERVER_AFF = "SERVER_AFF"
     const val ID_SUB = "SUB"
     const val ID_SETTING = "SETTING"

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -24,6 +24,7 @@ import java.util.*
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val mainStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
+    private val serverRawStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SERVER_RAW, MMKV.MULTI_PROCESS_MODE) }
 
     var serverList= MmkvManager.decodeServerList()
         private set
@@ -61,7 +62,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val config = ServerConfig.create(EConfigType.CUSTOM)
         config.remarks = System.currentTimeMillis().toString()
         config.fullConfig = Gson().fromJson(server, V2rayConfig::class.java)
-        serverList.add(MmkvManager.encodeServerConfig("", config))
+        val key = MmkvManager.encodeServerConfig("", config)
+        serverRawStorage?.encode(key, server)
+        serverList.add(key)
     }
 
     fun swapServer(fromPosition: Int, toPosition: Int) {


### PR DESCRIPTION
fix #997
Rollback:
~~Custom config is now parsed and auto formatted
Custom config new fields in future version of core might need update in json schema, otherwise they are not saved~~
