### PR TITLE
Always add domestic dns to config

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -369,7 +369,7 @@ data class V2rayConfig(
         }
     }
 
-    data class DnsBean(var servers: List<Any>? = null,
+    data class DnsBean(var servers: ArrayList<Any>? = null,
                        var hosts: Map<String, String>? = null,
                        val clientIp: String? = null,
                        val disableCache: Boolean? = null,


### PR DESCRIPTION
Previously, domestic dns is only added to config under
"local dns mode". However, it should be used for V2ray
core routing DNS as well.