### PR TITLE
Add support in subscription url for http basic authentication.

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -466,7 +466,7 @@ object Utils {
         conn.setRequestProperty("User-agent", "v2rayNG/${BuildConfig.VERSION_NAME}")
         url.userInfo?.let {
             conn.setRequestProperty("Authorization",
-                "Basic ${encode(URLDecoder.decode(it,"UTF-8"))}")
+                "Basic ${encode(urlDecode(it))}")
         }
         conn.useCaches = false
         return conn.inputStream.use {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -459,10 +459,15 @@ object Utils {
     }
 
     @Throws(IOException::class)
-    fun getUrlContentWithCustomUserAgent(url: String?): String {
-        val conn = URL(url).openConnection()
+    fun getUrlContentWithCustomUserAgent(urlStr: String?): String {
+        val url = URL(urlStr)
+        val conn = url.openConnection()
         conn.setRequestProperty("Connection", "close")
         conn.setRequestProperty("User-agent", "v2rayNG/${BuildConfig.VERSION_NAME}")
+        url.userInfo?.let {
+            conn.setRequestProperty("Authorization",
+                "Basic ${encode(URLDecoder.decode(it,"UTF-8"))}")
+        }
         conn.useCaches = false
         return conn.inputStream.use {
             it.bufferedReader().readText()


### PR DESCRIPTION
Add support in subscription url for http basic authentication. In order to obtain the resources correctly from the URL of the following form:

    http://username:password@example.com/