### PR TITLE
Fix sniffing default value again

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -101,7 +101,7 @@ object V2rayConfigUtil {
             v2rayConfig.inbounds[0].port = 10808
             val fakedns = settingsStorage?.decodeBool(AppConfig.PREF_FAKE_DNS_ENABLED)
                     ?: false
-            val sniffAllTlsAndHttp = settingsStorage?.decodeBool(AppConfig.PREF_SNIFFING_ENABLED)
+            val sniffAllTlsAndHttp = settingsStorage?.decodeBool(AppConfig.PREF_SNIFFING_ENABLED, true)
                     ?: true
             v2rayConfig.inbounds[0].sniffing?.enabled = fakedns || sniffAllTlsAndHttp
             if (!sniffAllTlsAndHttp) {


### PR DESCRIPTION
I made a mistake, thought it would return null when key is not in storage,
But it is found default "true" must be specified