### PR TITLE
更改captive portal链接

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -334,8 +334,7 @@ object Utils {
 
         try {
             val url = URL("https",
-                    "www.google.com",
-                    "/generate_204")
+                    "cp.cloudflare.com","")
 
             conn = url.openConnection(
                 Proxy(Proxy.Type.HTTP,


### PR DESCRIPTION
使用google的captive portal的话会导致国内服务器测试失败，更换成cloudflare的captive portal可以避免这种情况