### PR TITLE
wifi连接状态变化后重启vpn

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <!-- https://developer.android.com/about/versions/11/privacy/package-visibility -->
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
             tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/NetworkReceiver.java
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/NetworkReceiver.java
@@ -1,0 +1,52 @@
+package com.v2ray.ang;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+import com.v2ray.ang.service.V2RayServiceManager;
+import com.v2ray.ang.util.MessageUtil;
+
+/**
+ * @author MrLiu
+ * @date 2020/5/11
+ * desc 广播接收者
+ */
+public class NetworkReceiver extends BroadcastReceiver {
+    private boolean inStop;
+    public static boolean isRunning;
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        // 监听网络连接，包括wifi和移动数据的打开和关闭,以及连接上可用的连接都会接到监听
+        // 特殊注意：如果if条件生效，那么证明当前是有连接wifi或移动网络的，如果有业务逻辑最好把esle场景酌情考虑进去！
+        if(inStop)
+        {
+            return;
+        }
+        if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
+            //获取联网状态的NetworkInfo对象
+            NetworkInfo info = intent.getParcelableExtra(ConnectivityManager.EXTRA_NETWORK_INFO);
+            if (info != null) {
+                if (info.getType() == ConnectivityManager.TYPE_WIFI) {
+                    //如果当前的网络连接成功并且网络连接可用
+                    if (NetworkInfo.State.CONNECTED == info.getState() || NetworkInfo.State.DISCONNECTED == info.getState()) {
+                        if(isRunning)
+                        {
+                            inStop = true;
+                            MessageUtil.sendMsg2Service(context, AppConfig.MSG_STATE_STOP, "");
+                            try {
+                                Thread.sleep(1000);
+                            } catch (InterruptedException e) {
+
+                            }
+                            V2RayServiceManager.startV2Ray(context);
+                            inStop = false;
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -59,6 +59,7 @@ object V2RayServiceManager {
     private var mSubscription: Subscription? = null
     private var mNotificationManager: NotificationManager? = null
 
+    @JvmStatic
     fun startV2Ray(context: Context) {
         if (settingsStorage?.decodeBool(AppConfig.PREF_PROXY_SHARING) == true) {
             context.toast(R.string.toast_warning_pref_proxysharing_short)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
@@ -14,6 +14,8 @@ import android.text.TextUtils
 import android.view.KeyEvent
 import com.v2ray.ang.AppConfig
 import android.content.res.ColorStateList
+import android.net.ConnectivityManager
+import android.net.wifi.WifiManager
 import com.google.android.material.navigation.NavigationView
 import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
@@ -28,6 +30,7 @@ import androidx.lifecycle.lifecycleScope
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig.ANG_PACKAGE
 import com.v2ray.ang.BuildConfig
+import com.v2ray.ang.NetworkReceiver
 import com.v2ray.ang.databinding.ActivityMainBinding
 import com.v2ray.ang.dto.EConfigType
 import com.v2ray.ang.extension.toast
@@ -56,6 +59,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
     }
     private var mItemTouchHelper: ItemTouchHelper? = null
     val mainViewModel: MainViewModel by viewModels()
+    private var netWorkReceiver : NetworkReceiver? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -107,6 +111,13 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         setupViewModel()
         copyAssets()
         migrateLegacy()
+
+        netWorkReceiver = NetworkReceiver();
+        val filter = IntentFilter();
+        filter.addAction(WifiManager.WIFI_STATE_CHANGED_ACTION);
+        filter.addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION);
+        filter.addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        registerReceiver(netWorkReceiver, filter);
     }
 
     private fun setupViewModel() {
@@ -201,6 +212,14 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
 
     public override fun onPause() {
         super.onPause()
+    }
+
+    public override fun onDestroy() {
+        super.onDestroy()
+        if(netWorkReceiver != null)
+        {
+            unregisterReceiver(netWorkReceiver)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/MessageUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/MessageUtil.kt
@@ -10,6 +10,7 @@ import java.io.Serializable
 
 object MessageUtil {
 
+    @JvmStatic
     fun sendMsg2Service(ctx: Context, what: Int, content: Serializable) {
         sendMsg(ctx, AppConfig.BROADCAST_ACTION_SERVICE, what, content)
     }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -14,6 +14,7 @@ import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.ANG_PACKAGE
+import com.v2ray.ang.NetworkReceiver
 import com.v2ray.ang.R
 import com.v2ray.ang.databinding.DialogConfigFilterBinding
 import com.v2ray.ang.dto.*
@@ -40,6 +41,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun startListenBroadcast() {
         isRunning.value = false
+        NetworkReceiver.isRunning = false;
         getApplication<AngApplication>().registerReceiver(mMsgReceiver, IntentFilter(AppConfig.BROADCAST_ACTION_ACTIVITY))
         MessageUtil.sendMsg2Service(getApplication(), AppConfig.MSG_REGISTER_CLIENT, "")
     }
@@ -206,20 +208,25 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             when (intent?.getIntExtra("key", 0)) {
                 AppConfig.MSG_STATE_RUNNING -> {
                     isRunning.value = true
+                    NetworkReceiver.isRunning = true
                 }
                 AppConfig.MSG_STATE_NOT_RUNNING -> {
                     isRunning.value = false
+                    NetworkReceiver.isRunning = false
                 }
                 AppConfig.MSG_STATE_START_SUCCESS -> {
                     getApplication<AngApplication>().toast(R.string.toast_services_success)
                     isRunning.value = true
+                    NetworkReceiver.isRunning = true
                 }
                 AppConfig.MSG_STATE_START_FAILURE -> {
                     getApplication<AngApplication>().toast(R.string.toast_services_failure)
                     isRunning.value = false
+                    NetworkReceiver.isRunning = false
                 }
                 AppConfig.MSG_STATE_STOP_SUCCESS -> {
                     isRunning.value = false
+                    NetworkReceiver.isRunning = false
                 }
                 AppConfig.MSG_MEASURE_DELAY_SUCCESS -> {
                     updateTestResultAction.value = intent.getStringExtra("content")


### PR DESCRIPTION
使用中因为走动，离开或进入wifi，会有wifi信号和手机流量之间的切换，经常会导致代理无法使用，需要重启代理才行。
所以加了wifi状态的监视，当wifi的连接状态变化，就自动重启vpn。
只是提供个思路，还要要完善的地方，比如加个设置是否开启这个功能。