### PR TITLE
[Issue Fixes]: #2058, #2076

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayTestService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayTestService.kt
@@ -15,7 +15,7 @@ import libv2ray.Libv2ray
 import java.util.concurrent.Executors
 
 class V2RayTestService : Service() {
-    private val realTestScope by lazy { CoroutineScope(Executors.newFixedThreadPool(10).asCoroutineDispatcher()) }
+    private val realTestScope by lazy { CoroutineScope(new ThreadPoolExecutor(10, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>()).asCoroutineDispatcher()) }
 
     override fun onCreate() {
         super.onCreate()

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/MmkvManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/MmkvManager.kt
@@ -46,7 +46,7 @@ object MmkvManager {
         serverStorage?.encode(key, Gson().toJson(config))
         val serverList = decodeServerList()
         if (!serverList.contains(key)) {
-            serverList.add(key)
+            serverList.add(0, key)
             mainStorage?.encode(KEY_ANG_CONFIGS, Gson().toJson(serverList))
             if (mainStorage?.decodeString(KEY_SELECTED_SERVER).isNullOrBlank()) {
                 mainStorage?.encode(KEY_SELECTED_SERVER, key)


### PR DESCRIPTION
1. [75af126](https://github.com/2dust/v2rayNG/pull/2072/commits/75af126102c0e9fd47de7697a6e64ce6c2598d45):
https://github.com/2dust/v2rayNG/issues/2058
**After this fix:**
Adding new configs (servers) cause them being on top of the list because most of the users, a moment after adding a new config, need to see it at the top, to click it.
**Before this fix:**
The user was forced to scroll a long list after adding each new config, or clear the list frequently before adding new configs to be able to access and click them.
Also, batch tests would never reach the latest added config when the list was too long.
The first added config (the oldest one, which is useless and expired or dead in most of the cases), was always staying at row 0 at the top of the list with no reason.

2. [01777db](https://github.com/2dust/v2rayNG/pull/2072/commits/01777db88430b431c863a434f9bd3a268b298996)
https://github.com/2dust/v2rayNG/issues/2076
**After this fix:**
More concurrent tests can be ran for tests. Test concurrency has no CPU usage practically because it is IO burst.
Having concurrent tests only lets the tests not being queued or locked or waited for each other.
The fixed 10 threads which in previous versions was being used, still exists. But more cached threads can get added to.
**Before this fix:**
Tests was being queued while there were no need to do this.