### PR TITLE
fix a crash when adding custom config

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -447,7 +447,7 @@ data class V2rayConfig(
                            var poolSize: Int = 10000) // roughly 10 times smaller than total ip pool
 
     fun getProxyOutbound(): OutboundBean? {
-        outbounds.forEach { outbound ->
+        outbounds?.forEach { outbound ->
             EConfigType.values().forEach {
                 if (outbound.protocol.equals(it.name, true)) {
                     return outbound


### PR DESCRIPTION
When adding custom config, such as an empty json string `{}`, it is valid for v2ray-core, but there's no outbounds. `getProxyOutbound` will raise `NullPointerException`, and cause app crashed. This bug will be triggered every time when app opened.