### PR TITLE
Use Android ID as XUDP basekey

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -50,7 +50,7 @@ object V2RayServiceManager {
         set(value) {
             field = value
             Seq.setContext(value?.get()?.getService()?.applicationContext)
-            Libv2ray.initV2Env(Utils.userAssetPath(value?.get()?.getService()))
+            Libv2ray.initV2Env(Utils.userAssetPath(value?.get()?.getService()), Utils.getDeviceIdForXUDPBaseKey())
         }
     var currentConfig: ServerConfig? = null
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayTestService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayTestService.kt
@@ -20,7 +20,7 @@ class V2RayTestService : Service() {
     override fun onCreate() {
         super.onCreate()
         Seq.setContext(this)
-        Libv2ray.initV2Env(Utils.userAssetPath(this))
+        Libv2ray.initV2Env(Utils.userAssetPath(this), Utils.getDeviceIdForXUDPBaseKey())
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -13,6 +13,7 @@ import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.net.Uri
 import android.os.Build
 import android.os.LocaleList
+import android.provider.Settings
 import android.util.Log
 import android.util.Patterns
 import android.webkit.URLUtil
@@ -315,6 +316,11 @@ object Utils {
         val extDir = context.getExternalFilesDir(AppConfig.DIR_ASSETS)
                 ?: return context.getDir(AppConfig.DIR_ASSETS, 0).absolutePath
         return extDir.absolutePath
+    }
+
+    fun getDeviceIdForXUDPBaseKey(): String {
+        val androidId = Settings.Secure.ANDROID_ID.toByteArray(charset("UTF-8"))
+        return Base64.encodeToString(androidId.copyOf(32), Base64.NO_PADDING.or(Base64.URL_SAFE))
     }
 
     fun getUrlContext(url: String, timeout: Int): String {


### PR DESCRIPTION
Since Xray 1.8.1, XUDP pass basekey as the global ID. It can maintain the same UDP port on the proxy server outbound. To enable maximum UDP connectivity, client should pass the device unique ID in the environment variable.
https://github.com/2dust/AndroidLibXrayLite/pull/28
https://github.com/XTLS/Xray-core/pull/2781
@2dust when you have time, please see what you can do for Windows
