### PR TITLE
fix a bug(ConcurrentModificationException)

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -140,9 +140,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         MmkvManager.clearAllTestDelayResults()
         updateListAction.value = -1 // update all
 
+        val serversCopy = serversCache.toList() // Create a copy of the list
+
         getApplication<AngApplication>().toast(R.string.connection_test_testing)
         viewModelScope.launch(Dispatchers.Default) { // without Dispatchers.Default viewModelScope will launch in main thread
-            for (item in serversCache) {
+            for (item in serversCopy) {
                 val config = V2rayConfigUtil.getV2rayConfig(getApplication(), item.guid)
                 if (config.status) {
                     MessageUtil.sendMsg2TestService(getApplication(), AppConfig.MSG_MEASURE_CONFIG, Pair(item.guid, config.content))


### PR DESCRIPTION
when you go to the app and when is called the testAllRealPing, during this operation, if you leave from app and going back, 
The app crashes. The reason for the crash is that we are modifying the serversCache list while iterating over it in the for loop and we encounter to the ConcurrentModificationException.
I fixed this bug.

for more detail, this is the error message:
this is the error : FATAL EXCEPTION: main
Process: com.v2ray.ang, PID: 31694
java.util.ConcurrentModificationException
at java.util.ArrayList$Itr.next(ArrayList.java:831)
at com.v2ray.ang.viewmodel.MainViewModel$testAllRealPing$1$1$1.invokeSuspend(MainViewModel.kt:164)
at com.v2ray.ang.viewmodel.MainViewModel$testAllRealPing$1$1$1.invoke(MainViewModel.kt)
at com.v2ray.ang.viewmodel.MainViewModel$testAllRealPing$1$1$1.invoke(MainViewModel.kt)
at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89)
at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:169)
at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
at com.v2ray.ang.viewmodel.MainViewModel$testAllRealPing$1$1.invokeSuspend(MainViewModel.kt:162)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@5294982, Dispatchers.Main.immediate]. 