### PR TITLE
Addressing issue #2880

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,8 +988,8 @@ object AngConfigManager {
         ) {
             try {
                 val gson = GsonBuilder().setPrettyPrinting().create()
-                val serverList: Array<String> =
-                    Gson().fromJson(server, Array<String>::class.java)
+                val serverList: Array<V2rayConfig> =
+                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
                 if (serverList.isNotEmpty()) {
                     var count = 0
                     for (srv in serverList) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -990,7 +990,6 @@ object AngConfigManager {
                 //val gson = GsonBuilder().setPrettyPrinting().create()
                  val gson = GsonBuilder()
 			    .setLenient()
-			    .setPrettyPrinting()
 			    .create();
                 val serverList: Array<V2rayConfig> =
                     Gson().fromJson(server, Array<V2rayConfig>::class.java)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,10 +988,7 @@ object AngConfigManager {
         ) {
             try {
                 //val gson = GsonBuilder().setPrettyPrinting().create()
-                 val gson = GsonBuilder()
-			    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
-			    .setLenient()
-			    .create();
+                 val gson = GsonBuilder().create();
                 val serverList: Array<V2rayConfig> =
                     Gson().fromJson(server, Array<V2rayConfig>::class.java)
                 if (serverList.isNotEmpty()) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -8,6 +8,11 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
 import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,10 +988,10 @@ object AngConfigManager {
         ) {
             try {
                 //val gson = GsonBuilder().setPrettyPrinting().create()
-                 val gson = new GsonBuilder()
-	            	.setLenient()
-	            	.setPrettyPrinting()
-                    .create();
+                 val gson = GsonBuilder()
+			    .setLenient()
+			    .setPrettyPrinting()
+			    .create();
                 val serverList: Array<V2rayConfig> =
                     Gson().fromJson(server, Array<V2rayConfig>::class.java)
                 if (serverList.isNotEmpty()) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,8 +988,8 @@ object AngConfigManager {
         ) {
             try {
                 val gson = GsonBuilder().setPrettyPrinting().create()
-                val serverList: Array<V2rayConfig> =
-                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
+                val serverList: Array<ServerConfig> =
+                    Gson().fromJson(server, Array<ServerConfig>::class.java)
                 if (serverList.isNotEmpty()) {
                     var count = 0
                     for (srv in serverList) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,8 +988,8 @@ object AngConfigManager {
         ) {
             try {
                 val gson = GsonBuilder().setPrettyPrinting().create()
-                val serverList: Array<V2rayConfig> =
-                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
+                val serverList: Array<String> =
+                    Gson().fromJson(server, Array<String>::class.java)
                 if (serverList.isNotEmpty()) {
                     var count = 0
                     for (srv in serverList) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -1002,12 +1002,8 @@ object AngConfigManager {
                                     JsonSerializer { src: Double?, _: Type?, _: JsonSerializationContext? -> JsonPrimitive(src?.toInt()) }
                             )
                             .create()
-                    val serverList: Array<V2rayConfig> =
-                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
-                //val gson = Gson()
-                // Assuming your JSON is an array of V2rayConfig objects
-                //val typeToken: Type = object : TypeToken<List<V2rayConfig>>() {}.type
-                //val serverList: List<V2rayConfig> = gson.fromJson<List<V2rayConfig>>(server, typeToken) // Use generics for clarity
+                val serverList: Array<V2rayConfig> =
+                Gson().fromJson(server, Array<V2rayConfig>::class.java)
 
                 if (serverList.isNotEmpty()) {
                     var count = 0
@@ -1034,8 +1030,8 @@ object AngConfigManager {
             val config = ServerConfig.create(EConfigType.CUSTOM)
             config.subscriptionId = subid
             config.fullConfig = Gson().fromJson(server, V2rayConfig::class.java)
-            //config.remarks = System.currentTimeMillis().toString()
-            config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
+            config.remarks = System.currentTimeMillis().toString()
+            //config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
             val key = MmkvManager.encodeServerConfig("", config)
             serverRawStorage?.encode(key, server)
             return 1

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -13,7 +13,6 @@ import com.google.gson.JsonSerializationContext
 import com.google.gson.JsonSerializer
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
-import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.ANG_CONFIG

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -987,7 +987,11 @@ object AngConfigManager {
             && server.contains("routing")
         ) {
             try {
-                val gson = GsonBuilder().setPrettyPrinting().create()
+                //val gson = GsonBuilder().setPrettyPrinting().create()
+                 val gson = new GsonBuilder()
+	            	.setLenient()
+	            	.setPrettyPrinting()
+                    .create();
                 val serverList: Array<V2rayConfig> =
                     Gson().fromJson(server, Array<V2rayConfig>::class.java)
                 if (serverList.isNotEmpty()) {
@@ -1001,7 +1005,7 @@ object AngConfigManager {
                             config.subscriptionId = subid
                             config.fullConfig = srv
                             val key = MmkvManager.encodeServerConfig("", config)
-                            serverRawStorage?.encode(key, Gson.toJson(srv))
+                            serverRawStorage?.encode(key, gson.toJson(srv))
                             count += 1
                         }
                     }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.preference.PreferenceManager
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.ANG_CONFIG
@@ -22,6 +23,7 @@ import com.v2ray.ang.dto.V2rayConfig.Companion.TLS
 import com.v2ray.ang.util.MmkvManager.KEY_SELECTED_SERVER
 import java.net.URI
 import java.util.*
+import java.lang.reflect.Type
 import com.v2ray.ang.extension.idnHost
 import com.v2ray.ang.extension.removeWhiteSpace
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -1001,7 +1001,7 @@ object AngConfigManager {
                             config.subscriptionId = subid
                             config.fullConfig = srv
                             val key = MmkvManager.encodeServerConfig("", config)
-                            serverRawStorage?.encode(key, gson.toJson(srv))
+                            serverRawStorage?.encode(key, Gson.toJson(srv))
                             count += 1
                         }
                     }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,8 +988,8 @@ object AngConfigManager {
         ) {
             try {
                 val gson = GsonBuilder().setPrettyPrinting().create()
-                val serverList: Array<ServerConfig> =
-                    Gson().fromJson(server, Array<ServerConfig>::class.java)
+                val serverList: Array<V2rayConfig> =
+                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
                 if (serverList.isNotEmpty()) {
                     var count = 0
                     for (srv in serverList) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -995,7 +995,7 @@ object AngConfigManager {
                 val gson = Gson()
                 // Assuming your JSON is an array of V2rayConfig objects
                 val typeToken: Type = object : TypeToken<List<V2rayConfig>>() {}.type
-                val serverList: List<V2rayConfig> = gson.fromJson(server, typeToken)
+                val serverList: List<V2rayConfig> = gson.fromJson<List<V2rayConfig>>(server, typeToken) // Use generics for clarity
 
                 if (serverList.isNotEmpty()) {
                     var count = 0

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -990,12 +990,20 @@ object AngConfigManager {
         ) {
             try {
                 //val gson = GsonBuilder().setPrettyPrinting().create()
-                    //val serverList: Array<V2rayConfig> =
-                    //Gson().fromJson(server, Array<V2rayConfig>::class.java)
-                val gson = Gson()
+                val gson = GsonBuilder()
+                            .setPrettyPrinting()
+                            .disableHtmlEscaping()
+                            .registerTypeAdapter( // custom serialiser is needed here since JSON by default parse number as Double, core will fail to start
+                                    object : TypeToken<Double>() {}.type,
+                                    JsonSerializer { src: Double?, _: Type?, _: JsonSerializationContext? -> JsonPrimitive(src?.toInt()) }
+                            )
+                            .create()
+                    val serverList: Array<V2rayConfig> =
+                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
+                //val gson = Gson()
                 // Assuming your JSON is an array of V2rayConfig objects
-                val typeToken: Type = object : TypeToken<List<V2rayConfig>>() {}.type
-                val serverList: List<V2rayConfig> = gson.fromJson<List<V2rayConfig>>(server, typeToken) // Use generics for clarity
+                //val typeToken: Type = object : TypeToken<List<V2rayConfig>>() {}.type
+                //val serverList: List<V2rayConfig> = gson.fromJson<List<V2rayConfig>>(server, typeToken) // Use generics for clarity
 
                 if (serverList.isNotEmpty()) {
                     var count = 0
@@ -1022,8 +1030,8 @@ object AngConfigManager {
             val config = ServerConfig.create(EConfigType.CUSTOM)
             config.subscriptionId = subid
             config.fullConfig = Gson().fromJson(server, V2rayConfig::class.java)
-            config.remarks = System.currentTimeMillis().toString()
-            // config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
+            //config.remarks = System.currentTimeMillis().toString()
+            config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
             val key = MmkvManager.encodeServerConfig("", config)
             serverRawStorage?.encode(key, server)
             return 1

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -989,6 +989,7 @@ object AngConfigManager {
             try {
                 //val gson = GsonBuilder().setPrettyPrinting().create()
                  val gson = GsonBuilder()
+			    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
 			    .setLenient()
 			    .create();
                 val serverList: Array<V2rayConfig> =

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -988,9 +988,13 @@ object AngConfigManager {
         ) {
             try {
                 //val gson = GsonBuilder().setPrettyPrinting().create()
-                 val gson = GsonBuilder().create();
-                val serverList: Array<V2rayConfig> =
-                    Gson().fromJson(server, Array<V2rayConfig>::class.java)
+                    //val serverList: Array<V2rayConfig> =
+                    //Gson().fromJson(server, Array<V2rayConfig>::class.java)
+                val gson = Gson()
+                // Assuming your JSON is an array of V2rayConfig objects
+                val typeToken: Type = object : TypeToken<List<V2rayConfig>>() {}.type
+                val serverList: List<V2rayConfig> = gson.fromJson(server, typeToken)
+
                 if (serverList.isNotEmpty()) {
                     var count = 0
                     for (srv in serverList) {


### PR DESCRIPTION
Addressing the issue #2880 Importing Custom Configurations from Sub-Link Results in Incorrect Display of Integer Values as Floats #2880 I added  custom serialiser, because GSON by default parse number as Double.