### PR TITLE
More fragment options + Fix for reality configs

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -581,10 +581,21 @@ object V2rayConfigUtil {
                     tag = TAG_FRAGMENT,
                     mux = null
                 )
+
+            var packets = settingsStorage?.decodeString(AppConfig.PREF_FRAGMENT_PACKETS) ?: "tlshello"
+            if (v2rayConfig.outbounds[0].streamSettings?.security == V2rayConfig.REALITY
+                && packets == "tlshello"
+            ) {
+                packets = "1-3"
+            } else if (v2rayConfig.outbounds[0].streamSettings?.security == V2rayConfig.TLS
+                && packets != "tlshello"
+            ) {
+                packets = "tlshello"
+            }
+
             fragmentOutbound.settings = V2rayConfig.OutboundBean.OutSettingsBean(
                 fragment = V2rayConfig.OutboundBean.OutSettingsBean.FragmentBean(
-                    packets = settingsStorage?.decodeString(AppConfig.PREF_FRAGMENT_PACKETS)
-                        ?: "tlshello",
+                    packets = packets,
                     length = settingsStorage?.decodeString(AppConfig.PREF_FRAGMENT_LENGTH)
                         ?: "50-100",
                     interval = settingsStorage?.decodeString(AppConfig.PREF_FRAGMENT_INTERVAL)

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -62,6 +62,9 @@
 
     <string-array name="fragment_packets" translatable="false">
         <item>tlshello</item>
+        <item>1-2</item>
+        <item>1-3</item>
+        <item>1-5</item>
     </string-array>
 
     <string-array name="streamsecurity_utls" translatable="false">


### PR DESCRIPTION
I added 3 more fragment packets option for reality configs.
Furthermore, since the fragment option is global and will apply on all configs, and since tlshello will destroy reality configs,  I added a condition to detect invalid fragment packets option per config type and replaced it with proper packets type.