### PR TITLE
Added remarks to all custom configs

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
@@ -91,7 +91,7 @@ class ServerCustomConfigActivity : BaseActivity() {
         }
 
         val config = MmkvManager.decodeServerConfig(editGuid) ?: ServerConfig.create(EConfigType.CUSTOM)
-        config.remarks = binding.etRemarks.text.toString().trim()
+        config.remarks = v2rayConfig.remarks ?: binding.etRemarks.text.toString().trim()
         config.fullConfig = v2rayConfig
 
         MmkvManager.encodeServerConfig(editGuid, config)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -1008,17 +1008,15 @@ object AngConfigManager {
                 if (serverList.isNotEmpty()) {
                     var count = 0
                     for (srv in serverList) {
-                        if (srv.inbounds != null && srv.outbounds != null && srv.routing != null) {
-                            val config = ServerConfig.create(EConfigType.CUSTOM)
-                            config.remarks = srv.remarks
-                                ?: "%04d-".format(count + 1) + System.currentTimeMillis()
-                                    .toString()
-                            config.subscriptionId = subid
-                            config.fullConfig = srv
-                            val key = MmkvManager.encodeServerConfig("", config)
-                            serverRawStorage?.encode(key, gson.toJson(srv))
-                            count += 1
-                        }
+                        val config = ServerConfig.create(EConfigType.CUSTOM)
+                        config.remarks = srv.remarks
+                            ?: ("%04d-".format(count + 1) + System.currentTimeMillis()
+                                .toString())
+                        config.subscriptionId = subid
+                        config.fullConfig = srv
+                        val key = MmkvManager.encodeServerConfig("", config)
+                        serverRawStorage?.encode(key, gson.toJson(srv))
+                        count += 1
                     }
                     return count
                 }
@@ -1030,8 +1028,7 @@ object AngConfigManager {
             val config = ServerConfig.create(EConfigType.CUSTOM)
             config.subscriptionId = subid
             config.fullConfig = Gson().fromJson(server, V2rayConfig::class.java)
-            config.remarks = System.currentTimeMillis().toString()
-            //config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
+            config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
             val key = MmkvManager.encodeServerConfig("", config)
             serverRawStorage?.encode(key, server)
             return 1

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -49,7 +49,7 @@ object V2rayConfigUtil {
                 return Result(true, customConfig)
             }
             val outbound = config.getProxyOutbound() ?: return Result(false, "")
-            val result = getV2rayNonCustomConfig(context, outbound)
+            val result = getV2rayNonCustomConfig(context, outbound, config.remarks)
             //Log.d(ANG_PACKAGE, result.content)
             return result
         } catch (e: Exception) {
@@ -63,7 +63,8 @@ object V2rayConfigUtil {
      */
     private fun getV2rayNonCustomConfig(
         context: Context,
-        outbound: V2rayConfig.OutboundBean
+        outbound: V2rayConfig.OutboundBean,
+        remarks: String,
     ): Result {
         val result = Result(false, "")
         //取得默认配置
@@ -98,6 +99,9 @@ object V2rayConfigUtil {
             v2rayConfig.stats = null
             v2rayConfig.policy = null
         }
+
+        v2rayConfig.remarks = remarks
+
         result.status = true
         result.content = v2rayConfig.toPrettyPrinting()
         return result

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -97,9 +97,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun appendCustomConfigServer(server: String) {
         val config = ServerConfig.create(EConfigType.CUSTOM)
-        config.remarks = System.currentTimeMillis().toString()
         config.subscriptionId = subscriptionId
         config.fullConfig = Gson().fromJson(server, V2rayConfig::class.java)
+        config.remarks = config.fullConfig?.remarks ?: System.currentTimeMillis().toString()
         val key = MmkvManager.encodeServerConfig("", config)
         serverRawStorage?.encode(key, server)
         serverList.add(0, key)


### PR DESCRIPTION
Added remarks to all custom configs in order to list by their original name instead of timestamp. This includes import/export of custom configs and those added by subscription links.