### PR TITLE
Fixing the problem of connecting to the Internet after publishing the application on Google Play in aab format 

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppThemeDayNight"
         android:usesCleartextTraffic="true"
+        android:extractNativeLibs="true"
         tools:targetApi="m">
 
         <activity

--- a/V2rayNG/gradle.properties
+++ b/V2rayNG/gradle.properties
@@ -4,3 +4,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+android.bundle.enableUncompressedNativeLibs = false


### PR DESCRIPTION
fixed #2375 , #1971 , #2267 , #1553 issues

When we release our app as a bundle (aab) to publish on Google Play, after approval by **Google Play** and after downloading the app from **Google Play**, there is an internet connection problem.
In this pull request, this problem has been solved