### PR TITLE
Add Dark Mode manual switch in application's settings

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -40,6 +40,7 @@ object AppConfig {
     const val PREF_BYPASS_APPS = "pref_bypass_apps"
     const val PREF_CONFIRM_REMOVE = "pref_confirm_remove"
     const val PREF_START_SCAN_IMMEDIATE = "pref_start_scan_immediate"
+    const val PREF_DARK_MODE_ENABLED = "pref_dark_mode_enabled"
     const val PREF_MUX_ENABLED = "pref_mux_enabled"
     const val PREF_MUX_CONCURRENCY = "pref_mux_concurency"
     const val PREF_MUX_XUDP_CONCURRENCY = "pref_mux_xudp_concurency"

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -361,6 +361,9 @@ object Utils {
     }
 
     fun getDarkModeStatus(context: Context): Boolean {
+        if (settingsStorage?.decodeBool(AppConfig.PREF_DARK_MODE_ENABLED) == true) {
+            return true
+        }
         val mode = context.resources.configuration.uiMode and UI_MODE_NIGHT_MASK
         return mode != UI_MODE_NIGHT_NO
     }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/SettingsViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/SettingsViewModel.kt
@@ -57,6 +57,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             AppConfig.PREF_BYPASS_APPS,
             AppConfig.PREF_CONFIRM_REMOVE,
             AppConfig.PREF_START_SCAN_IMMEDIATE,
+            AppConfig.PREF_DARK_MODE_ENABLED,
             AppConfig.SUBSCRIPTION_AUTO_UPDATE,
             AppConfig.PREF_FRAGMENT_ENABLED,
             AppConfig.PREF_MUX_ENABLED, -> {

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -178,6 +178,9 @@
     <string name="title_pref_start_scan_immediate">Start scanning immediately</string>
     <string name="summary_pref_start_scan_immediate">Open the camera to scan immediately at startup, otherwise you can choose to scan the code or select a photo in the toolbar</string>
 
+    <string name="title_pref_dark_mode_enabled">Enable dark mode</string>
+    <string name="summary_pref_dark_mode_enabled">Always use dark mode theme</string>
+
     <string name="title_pref_feedback">Feedback</string>
     <string name="summary_pref_feedback">Feedback enhancements or bugs to GitHub</string>
     <string name="summary_pref_tg_group">Join Telegram Group</string>

--- a/V2rayNG/app/src/main/res/xml/pref_settings.xml
+++ b/V2rayNG/app/src/main/res/xml/pref_settings.xml
@@ -124,6 +124,11 @@
 
     <PreferenceCategory android:title="@string/title_ui_settings">
         <CheckBoxPreference
+            android:key="pref_dark_mode_enabled"
+            android:summary="@string/summary_pref_dark_mode_enabled"
+            android:title="@string/title_pref_dark_mode_enabled" />
+        
+        <CheckBoxPreference
             android:key="pref_speed_enabled"
             android:summary="@string/summary_pref_speed_enabled"
             android:title="@string/title_pref_speed_enabled" />


### PR DESCRIPTION
First of all, thanks for the Dark Mode theme. I like it, although I haven't been able to use it yet! 
The Dark Mode theme was added a while ago, but since its introduction, a lot of people (myself included) have been longing for a "manual toggle/switch" in comments and issues:
https://github.com/2dust/v2rayNG/pull/2478#issuecomment-1733310953 https://github.com/2dust/v2rayNG/pull/2478#issuecomment-1737327878 https://github.com/2dust/v2rayNG/pull/2478#issuecomment-1740533631 https://github.com/2dust/v2rayNG/pull/2478#issuecomment-1806514745
close https://github.com/2dust/v2rayNG/issues/2688, close https://github.com/2dust/v2rayNG/issues/2720

This change adds a manual switch for Dark Mode theme. I don't have the environment to build and test this myself, but I tried my best to follow on the footsteps of similar settings and make a correct change. Please tell me if anything needs to be fixed.