### PR TITLE
Fix ANR error

### DIFF
--- a/V2rayNG/app/src/main/res/layout/view_loading.xml
+++ b/V2rayNG/app/src/main/res/layout/view_loading.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:background="@color/white"
+    android:id="@+id/loadingView">
+    <ProgressBar
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"/>
+</FrameLayout>


### PR DESCRIPTION
When the importClipboard button is clicked, if the list size is large, it will be freeze and this error occurs:

SkiaDisplayList() ##### pid = 9302
2024-03-12 16:22:32.315 983-9377 ActivityManager system_server E ANR in com.v2ray.ang
(com.v2ray.ang/.ui.MainActivity)
PID: 9302
Reason: Input dispatching timed out (c967606
PopupWindow:8b3f663 (server) is not
responding. Waited 10006ms for MotionEvent)
Parent: com.v2ray.ang/.ui.MainActivity
Load: 6.52 / 5.55 / 5.37

Because importBatchConfig() function performs some time-consuming operations that block the UI thread, causing the ANR.
to fix this I have define a separate thread to excute the long-running task and when the task is in progress, A progress bar is displayed.


https://github.com/2dust/v2rayNG/assets/108512702/f64ddfd7-5dc2-4ed1-92f2-022dcd5eacd9


