### PR TITLE
Add observatory to V2rayConfig, to enable load balancing features in a custom config

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -22,7 +22,9 @@ data class V2rayConfig(
         val transport: Any? = null,
         val reverse: Any? = null,
         var fakedns: Any? = null,
-        val browserForwarder: Any? = null) {
+        val browserForwarder: Any? = null,
+        var observatory: Any? = null,
+        var burstObservatory: Any? = null) {
     companion object {
         const val DEFAULT_PORT = 443
         const val DEFAULT_SECURITY = "auto"


### PR DESCRIPTION
**Purpose:**
Before this pull request, there was a problem with v2rayNG where observatory objects in json were not being parsed correctly. This resulted in inconsistencies in how configurations were handled.
This pull request aims to add Load Balancing Features in custom configuration by accepting observatory and brust observatory object in custom config.

**Overview:**
This pull request seeks to include the observatory, burst observatory, and load balancing strategies present in both [V2ray](https://www.v2fly.org/config/observatory.html) (added in [2021](https://github.com/v2fly/v2fly-github-io/commit/5a92a85a9c9001581006b4b421b9dc95e18c4da5)) and Xray Core (added in[ 2021](https://github.com/XTLS/Xray-core/blob/e2439c04834f19269a1daa8feb849dc358ae65e2/infra/conf/xray.go#L418)).
leastload is based on brust observatory and introduced to Xray core [last month](https://github.com/XTLS/Xray-core/commit/fa5d7a255b95215916d93bf371aaea55ea758381)
you also find the burst observatory documented in [V2Fly](https://www.v2fly.org/en_US/v5/config/service/burstObservatory.html).

In both [V2ray](https://www.v2fly.org/config/observatory.html) and Xray Core projects, the observatory, burst observatory, leastPing, and leastload features are crucial for load balancing strategies. While well-documented in V2ray, some of these features lack documentation in Xray Core.

**Test the changes**
If anyone wants to test this pull, here is a [build ](https://github.com/xfree-man/v2rayNG/actions/runs/8435364555)