### PR TITLE
Ability to override built in `geosite.dat` and `geoip.dat`

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UserAssetActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UserAssetActivity.kt
@@ -224,13 +224,14 @@ class UserAssetActivity : BaseActivity() {
     }
     private fun addBuiltInGeoItems(assets: List<Pair<String, AssetUrlItem>>): List<Pair<String, AssetUrlItem>> {
         val list = mutableListOf<Pair<String, AssetUrlItem>>()
-        builtInGeoFiles.forEach {
-            list.add(Utils.getUuid() to AssetUrlItem(
-                it,
-                AppConfig.geoUrl + it
-            )
-            )
-        }
+        builtInGeoFiles
+            .filter { geoFile -> assets.none { it.second.remarks == geoFile } }
+            .forEach { 
+                list.add(Utils.getUuid() to AssetUrlItem(
+                    it,
+                    AppConfig.geoUrl + it
+                ))
+            }
 
         return list + assets
     }
@@ -263,7 +264,7 @@ class UserAssetActivity : BaseActivity() {
                 holder.itemUserAssetBinding.assetProperties.text = getString(R.string.msg_file_not_found)
             }
 
-            if (item.second.remarks in builtInGeoFiles) {
+            if (item.second.remarks in builtInGeoFiles && item.second.url == AppConfig.geoUrl + item.second.remarks) {
                 holder.itemUserAssetBinding.layoutEdit.visibility = GONE
                 holder.itemUserAssetBinding.layoutRemove.visibility = GONE
             } else {


### PR DESCRIPTION
When user adds a custom `geosite.dat` or `geoip.dat` asset, it will replace the built in one. Fixes #2990