### PR TITLE
Set UseIP in Direct to break the Android Private DNS dead loop

### DIFF
--- a/V2rayNG/app/src/main/assets/v2ray_config.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config.json
@@ -81,7 +81,9 @@
   },
   {
     "protocol": "freedom",
-    "settings": {},
+    "settings": {
+      "domainStrategy": "UseIP"
+    },
     "tag": "direct"
   },
   {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -173,10 +173,6 @@ object V2rayConfigUtil {
             && settingsStorage?.decodeBool(AppConfig.PREF_FAKE_DNS_ENABLED) == true
         ) {
             v2rayConfig.fakedns = listOf(V2rayConfig.FakednsBean())
-            v2rayConfig.outbounds.filter { it.protocol == PROTOCOL_FREEDOM && it.tag == TAG_DIRECT }
-                .forEach {
-                    it.settings?.domainStrategy = "UseIP"
-                }
         }
     }
 


### PR DESCRIPTION
This fixes https://github.com/2dust/v2rayNG/issues/586 and https://github.com/2dust/v2rayNG/issues/758