### PR TITLE
Make IPIfNonMatch actually work

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -228,7 +228,11 @@ object V2rayConfigUtil {
                 ERoutingMode.GLOBAL_DIRECT.value -> {
                     val globalDirect = V2rayConfig.RoutingBean.RulesBean(
                         outboundTag = TAG_DIRECT,
-                        port = "0-65535"
+                        if (v2rayConfig.routing.domainStrategy != "IPIfNonMatch") {
+                            port = "0-65535"
+                        } else {
+                            ip = arrayListOf("0.0.0.0/0", "::/0")
+                        }
                     )
                     v2rayConfig.routing.rules.add(globalDirect)
                 }
@@ -238,7 +242,11 @@ object V2rayConfigUtil {
                 v2rayConfig.routing.rules.add(
                     V2rayConfig.RoutingBean.RulesBean(
                         outboundTag = AppConfig.TAG_PROXY,
-                        port = "0-65535"
+                        if (v2rayConfig.routing.domainStrategy != "IPIfNonMatch") {
+                            port = "0-65535"
+                        } else {
+                            ip = arrayListOf("0.0.0.0/0", "::/0")
+                        }
                     )
                 )
             }


### PR DESCRIPTION
When `"port": "0-65535"` will always match, making `IPIfNonMatch` work like `AsIs`.
Change to `"ip": ["0.0.0.0/0", "::/0"]` to make `IPIfNonMatch` actually work.