### PR TITLE
routing: First block, then direct, and finally proxy

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -182,16 +182,16 @@ object V2rayConfigUtil {
     private fun routing(v2rayConfig: V2rayConfig): Boolean {
         try {
             routingUserRule(
-                settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_AGENT)
-                    ?: "", AppConfig.TAG_PROXY, v2rayConfig
+                settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_BLOCKED)
+                    ?: "", AppConfig.TAG_BLOCKED, v2rayConfig
             )
             routingUserRule(
                 settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_DIRECT)
                     ?: "", TAG_DIRECT, v2rayConfig
             )
             routingUserRule(
-                settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_BLOCKED)
-                    ?: "", AppConfig.TAG_BLOCKED, v2rayConfig
+                settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_AGENT)
+                    ?: "", AppConfig.TAG_PROXY, v2rayConfig
             )
 
             v2rayConfig.routing.domainStrategy =


### PR DESCRIPTION
Make the `block` really work, otherwise most of the `block` rules will be `proxy` or `direct` first.

And first `block`, then `direct`, and finally `proxy` is also the official recommended order.

https://xtls.github.io/document/level-0/ch08-xray-clients.html