### PR TITLE
Replace deprecated onBackPressed with onBackPressedDispatcher

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -133,7 +133,7 @@ dependencies {
     implementation(libs.language.json)
     implementation(libs.quickie.bundled)
     implementation(libs.core)
-
+    // Updating these 2 dependencies may cause some errors. Be careful.
     implementation(libs.work.runtime.ktx)
     implementation(libs.work.multiprocess)
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/BaseActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/BaseActivity.kt
@@ -23,7 +23,9 @@ abstract class BaseActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
         android.R.id.home -> {
-            onBackPressed()
+            // Handles the home button press by delegating to the onBackPressedDispatcher.
+            // This ensures consistent back navigation behavior.
+            onBackPressedDispatcher.onBackPressed()
             true
         }
         else -> super.onOptionsItemSelected(item)


### PR DESCRIPTION
Replaced deprecated `onBackPressed` with `onBackPressedDispatcher`. The `onBackPressedDispatcher` handles the home button press by delegating to the appropriate back navigation method.