### PR TITLE
Drop geolocation-cn (cn contains geolocation-cn)

### DIFF
--- a/V2rayNG/app/src/main/assets/custom_routing_direct
+++ b/V2rayNG/app/src/main/assets/custom_routing_direct
@@ -1,2 +1,1 @@
-geosite:cn,
-geosite:geolocation-cn
+geosite:cn

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -227,14 +227,12 @@ object V2rayConfigUtil {
 
                 ERoutingMode.BYPASS_MAINLAND.value -> {
                     routingGeo("", "cn", TAG_DIRECT, v2rayConfig)
-                    routingGeo("domain", "geolocation-cn", TAG_DIRECT, v2rayConfig)
                     v2rayConfig.routing.rules.add(0, googleapisRoute)
                 }
 
                 ERoutingMode.BYPASS_LAN_MAINLAND.value -> {
                     routingGeo("ip", "private", TAG_DIRECT, v2rayConfig)
                     routingGeo("", "cn", TAG_DIRECT, v2rayConfig)
-                    routingGeo("domain", "geolocation-cn", TAG_DIRECT, v2rayConfig)
                     v2rayConfig.routing.rules.add(0, googleapisRoute)
                 }
 
@@ -471,7 +469,7 @@ object V2rayConfigUtil {
                 )
             }
             if (isCnRoutingMode) {
-                val geositeCn = arrayListOf("geosite:cn", "geosite:geolocation-cn")
+                val geositeCn = arrayListOf("geosite:cn")
                 servers.add(
                     V2rayConfig.DnsBean.ServersBean(
                         domesticDns.first(),


### PR DESCRIPTION
`geosite:cn = geosite:geolocation-cn + geosite:tld-cn`

No need for `geosite:geolocation-cn` when using `geosite:cn`.