### PR TITLE
Refactor V2RayServiceManager to Use Constants for Configuration Values

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -87,6 +87,8 @@ object AppConfig {
     const val TAG_DIRECT = "direct"
     const val TAG_BLOCKED = "block"
     const val TAG_FRAGMENT = "fragment"
+    const val UPLINK = "uplink"
+    const val DOWNLINK = "downlink"
 
     const val androidpackagenamelistUrl =
         "https://raw.githubusercontent.com/2dust/androidpackagenamelist/master/proxy.txt"
@@ -128,4 +130,7 @@ object AppConfig {
     const val MSG_MEASURE_CONFIG = 7
     const val MSG_MEASURE_CONFIG_SUCCESS = 71
     const val MSG_MEASURE_CONFIG_CANCEL = 72
+
+    const val CHANNEL_ID = "RAY_NG_M_CH_ID"
+    const val CHANNEL_NAME = "V2rayNG Background Service"
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -319,8 +319,8 @@ object V2RayServiceManager {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createNotificationChannel(): String {
-        val channelId = "RAY_NG_M_CH_ID"
-        val channelName = "V2rayNG Background Service"
+        val channelId = AppConfig.CHANNEL_ID
+        val channelName = AppConfig.CHANNEL_NAME
         val chan = NotificationChannel(channelId,
                 channelName, NotificationManager.IMPORTANCE_HIGH)
         chan.lightColor = Color.DKGRAY
@@ -376,15 +376,15 @@ object V2RayServiceManager {
                         var proxyTotal = 0L
                         val text = StringBuilder()
                         outboundTags?.forEach {
-                            val up = v2rayPoint.queryStats(it, "uplink")
-                            val down = v2rayPoint.queryStats(it, "downlink")
+                            val up = v2rayPoint.queryStats(it, AppConfig.UPLINK)
+                            val down = v2rayPoint.queryStats(it, AppConfig.DOWNLINK)
                             if (up + down > 0) {
                                 appendSpeedString(text, it, up / sinceLastQueryInSeconds, down / sinceLastQueryInSeconds)
                                 proxyTotal += up + down
                             }
                         }
-                        val directUplink = v2rayPoint.queryStats(TAG_DIRECT, "uplink")
-                        val directDownlink = v2rayPoint.queryStats(TAG_DIRECT, "downlink")
+                        val directUplink = v2rayPoint.queryStats(TAG_DIRECT,  AppConfig.UPLINK)
+                        val directDownlink = v2rayPoint.queryStats(TAG_DIRECT, AppConfig.DOWNLINK)
                         val zeroSpeed = proxyTotal == 0L && directUplink == 0L && directDownlink == 0L
                         if (!zeroSpeed || !lastZeroSpeed) {
                             if (proxyTotal == 0L) {


### PR DESCRIPTION
Refactor V2RayServiceManager to Use Constants for Configuration Values.
- Replaced hardcoded string literals for 'uplink' and 'downlink' with constants from AppConfig.
- Introduced constants for notification channel ID and name.