### PR TITLE
Optimize strState Handling by Removing Redundant try-catch

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
@@ -98,11 +98,7 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
                 }
             }
 
-            val strState = try{
-                "${outbound?.getServerAddress()?.dropLast(3)}*** : ${outbound?.getServerPort()}"
-            }catch(e: Exception){
-                ""
-            }
+            val strState = "${outbound?.getServerAddress()?.dropLast(3)}*** : ${outbound?.getServerPort() ?: ""}"
 
             holder.itemMainBinding.tvStatistics.text = strState
 


### PR DESCRIPTION
Refactored the code for handling the `strState` string to remove the redundant `try-catch` block. Updated to use safe call with the Elvis operator for improved readability and efficiency. This change simplifies the code and reduces the need for exception handling in this context.