### PR TITLE
Simplify parseInt function

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -63,14 +63,9 @@ object Utils {
     }
 
     fun parseInt(str: String?, default: Int): Int {
-        str ?: return default
-        return try {
-            Integer.parseInt(str)
-        } catch (e: Exception) {
-            e.printStackTrace()
-            default
-        }
+        return str?.toIntOrNull() ?: default
     }
+
 
     /**
      * get text from clipboard


### PR DESCRIPTION
Refactored the parseInt function to use toIntOrNull() for more concise and idiomatic error handling. This change simplifies the code and avoids the need for manual exception handling