### PR TITLE
Use localhost DNS server to make geosite:private work

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -107,7 +107,7 @@ object AppConfig {
 
     /** DNS server addresses. */
     const val DNS_PROXY = "1.1.1.1"
-    const val DNS_DIRECT = "223.5.5.5"
+    const val DNS_DIRECT = "localhost"
     const val DNS_VPN = "1.1.1.1"
 
     /** Ports and addresses for various services. */


### PR DESCRIPTION
`geosite:private` contains many domain names that need to be resolved to the local router (gateway) and can only be resolved using the `localhost` DNS server.

Such as:
asusrouter.com
routerlogin.com
hiwifi.com
miwifi.com

https://github.com/v2fly/domain-list-community/blob/master/data/private