### PR TITLE
Handling JCenter Shutdown Issues

### DIFF
--- a/V2rayNG/gradle/libs.versions.toml
+++ b/V2rayNG/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "r
 preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preferenceKtx" }
 rxandroid = { module = "io.reactivex:rxandroid", version.ref = "rxandroid" }
 rxjava = { module = "io.reactivex:rxjava", version.ref = "rxjava" }
-rxpermissions = { module = "com.tbruyelle.rxpermissions:rxpermissions", version.ref = "rxpermissions" }
+rxpermissions = { module = "io.github.mayampi01:com.tbruyelle.rxpermissions", version.ref = "rxpermissions" }
 toastcompat = { module = "me.drakeet.support:toastcompat", version.ref = "toastcompat" }
 viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager2" }
 work-multiprocess = { module = "androidx.work:work-multiprocess", version.ref = "workRuntimeKtx" }

--- a/V2rayNG/settings.gradle.kts
+++ b/V2rayNG/settings.gradle.kts
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 rootProject.name = "V2rayNG"


### PR DESCRIPTION
`com.tbruyelle.rxpermissions:rxpermissions` is only in JCenter, but JCenter has been shutdown and redirected to Maven Central.

Now compiling the APK will report an error.

I moved it to Maven Central as `io.github.mayampi01:com.tbruyelle.rxpermissions`.

https://blog.gradle.org/portal-jcenter-impact

https://jfrog.com/blog/jcenter-sunset/

https://central.sonatype.com/search?q=rxpermissions

https://central.sonatype.com/artifact/io.github.mayampi01/com.tbruyelle.rxpermissions