### PR TITLE
Fix ABI split configuration for updated Gradle plugin API

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -14,15 +14,19 @@ android {
         versionCode = 580
         versionName = "1.8.36"
         multiDexEnabled = true
-        splits.abi {
-            reset()
-            include(
-                "arm64-v8a",
-                "armeabi-v7a",
-                "x86_64",
-                "x86"
-            )
+        splits {
+            abi {
+                isEnable = true
+                include(
+                    "arm64-v8a",
+                    "armeabi-v7a",
+                    "x86_64",
+                    "x86"
+                )
+                universalApk = true
+            }
         }
+
     }
 
     compileOptions {
@@ -48,13 +52,6 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
-    }
-
-    splits {
-        abi {
-            isEnable = true
-            isUniversalApk = true
-        }
     }
 
     applicationVariants.all {

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
                     "x86_64",
                     "x86"
                 )
-                universalApk = true
+                isUniversalApk = true
             }
         }
 


### PR DESCRIPTION
Updated the ABI split configuration in the build.gradle file to use the new syntax. Replaced deprecated `reset()` method with the updated `splits.abi` configuration block and added `isUniversalApk = true` to include a universal APK.