### PR TITLE
Refactor EConfigType to use constants from AppConfig

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -140,4 +140,12 @@ object AppConfig {
     const val RAY_NG_CHANNEL_NAME = "V2rayNG Background Service"
     const val SUBSCRIPTION_UPDATE_CHANNEL = "subscription_update_channel"
     const val SUBSCRIPTION_UPDATE_CHANNEL_NAME = "Subscription Update Service"
+    /** Protocols Scheme **/
+    const val VMESS = "vmess://"
+    const val CUSTOM = ""
+    const val SHADOWSOCKS = "ss://"
+    const val SOCKS = "socks://"
+    const val VLESS = "vless://"
+    const val TROJAN = "trojan://"
+    const val WIREGUARD = "wireguard://"
 }

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/EConfigType.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/EConfigType.kt
@@ -1,13 +1,16 @@
 package com.v2ray.ang.dto
 
+import com.v2ray.ang.AppConfig
+
+
 enum class EConfigType(val value: Int, val protocolScheme: String) {
-    VMESS(1, "vmess://"),
-    CUSTOM(2, ""),
-    SHADOWSOCKS(3, "ss://"),
-    SOCKS(4, "socks://"),
-    VLESS(5, "vless://"),
-    TROJAN(6, "trojan://"),
-    WIREGUARD(7, "wireguard://");
+    VMESS(1, AppConfig.VMESS),
+    CUSTOM(2, AppConfig.CUSTOM),
+    SHADOWSOCKS(3,AppConfig.SHADOWSOCKS),
+    SOCKS(4, AppConfig.SOCKS),
+    VLESS(5, AppConfig.VLESS),
+    TROJAN(6, AppConfig.TROJAN),
+    WIREGUARD(7, AppConfig.WIREGUARD);
 
     companion object {
         fun fromInt(value: Int) = values().firstOrNull { it.value == value }


### PR DESCRIPTION
Updated the EConfigType enum to use protocol scheme constants from AppConfig. This change improves maintainability by centralizing protocol scheme definitions in a single location.