### PR TITLE
Fix: Suppress UnspecifiedRegisterReceiverFlag warning

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/QSTileService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/QSTileService.kt
@@ -31,7 +31,7 @@ class QSTileService : TileService() {
 
         qsTile?.updateTile()
     }
-
+@Suppress("UnspecifiedRegisterReceiverFlag")
     override fun onStartListening() {
         super.onStartListening()
         setState(Tile.STATE_INACTIVE)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -67,7 +67,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val updateTestResultAction by lazy { MutableLiveData<String>() }
 
     private val tcpingTestScope by lazy { CoroutineScope(Dispatchers.IO) }
-
+    @Suppress("UnspecifiedRegisterReceiverFlag")
     fun startListenBroadcast() {
         isRunning.value = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {


### PR DESCRIPTION
Suppress UnspecifiedRegisterReceiverFlag warning

Added @Suppress("UnspecifiedRegisterReceiverFlag") annotation to resolve the warning related to the unspecified register receiver flag.