### PR TITLE
Fix: Refactor to use lazy initialization for binding

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/AboutActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/AboutActivity.kt
@@ -21,14 +21,12 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 class AboutActivity : BaseActivity() {
-    private lateinit var binding: ActivityAboutBinding
+    private val binding by lazy {ActivityAboutBinding.inflate(layoutInflater)}
     private val extDir by lazy { File(Utils.backupPath(this)) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityAboutBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         title = getString(R.string.title_about)
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/LogcatActivity.kt
@@ -21,13 +21,13 @@ import java.io.IOException
 import java.util.LinkedHashSet
 
 class LogcatActivity : BaseActivity() {
-    private lateinit var binding: ActivityLogcatBinding
+    private val binding by lazy {
+        ActivityLogcatBinding.inflate(layoutInflater)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityLogcatBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         title = getString(R.string.title_logcat)
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainActivity.kt
@@ -30,6 +30,7 @@ import com.tbruyelle.rxpermissions.RxPermissions
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
+import com.v2ray.ang.databinding.ActivityLogcatBinding
 import com.v2ray.ang.databinding.ActivityMainBinding
 import com.v2ray.ang.databinding.LayoutProgressBinding
 import com.v2ray.ang.dto.EConfigType
@@ -49,7 +50,9 @@ import rx.android.schedulers.AndroidSchedulers
 import java.util.concurrent.TimeUnit
 
 class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedListener {
-    private lateinit var binding: ActivityMainBinding
+    private val binding by lazy {
+        ActivityMainBinding.inflate(layoutInflater)
+    }
 
     private val adapter by lazy { MainRecyclerAdapter(this) }
     private val mainStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
@@ -81,9 +84,7 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         title = getString(R.string.title_server)
         setSupportActionBar(binding.toolbar)
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/PerAppProxyActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/PerAppProxyActivity.kt
@@ -28,7 +28,9 @@ import rx.schedulers.Schedulers
 import java.text.Collator
 
 class PerAppProxyActivity : BaseActivity() {
-    private lateinit var binding: ActivityBypassListBinding
+    private val binding by lazy {
+        ActivityBypassListBinding.inflate(layoutInflater)
+    }
 
     private var adapter: PerAppProxyAdapter? = null
     private var appsAll: List<AppInfo>? = null
@@ -36,9 +38,7 @@ class PerAppProxyActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityBypassListBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         val dividerItemDecoration = DividerItemDecoration(this, LinearLayoutManager.VERTICAL)
         binding.recyclerView.addItemDecoration(dividerItemDecoration)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/RoutingSettingsActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/RoutingSettingsActivity.kt
@@ -8,7 +8,7 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.databinding.ActivityRoutingSettingsBinding
 
 class RoutingSettingsActivity : BaseActivity() {
-    private lateinit var binding: ActivityRoutingSettingsBinding
+    private val binding by lazy { ActivityRoutingSettingsBinding.inflate(layoutInflater) }
 
     private val titles: Array<out String> by lazy {
         resources.getStringArray(R.array.routing_tag)
@@ -16,9 +16,7 @@ class RoutingSettingsActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityRoutingSettingsBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         title = getString(R.string.title_pref_routing_custom)
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/RoutingSettingsFragment.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/RoutingSettingsFragment.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class RoutingSettingsFragment : Fragment() {
-    private lateinit var binding: FragmentRoutingSettingsBinding
+    private val binding by lazy { FragmentRoutingSettingsBinding.inflate(layoutInflater) }
     companion object {
         private const val routing_arg = "routing_arg"
     }
@@ -33,7 +33,6 @@ class RoutingSettingsFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment
-        binding = FragmentRoutingSettingsBinding.inflate(layoutInflater)
         return binding.root// inflater.inflate(R.layout.fragment_routing_settings, container, false)
     }
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
@@ -21,7 +21,7 @@ import com.v2ray.ang.util.Utils
 import me.drakeet.support.toast.ToastCompat
 
 class ServerCustomConfigActivity : BaseActivity() {
-    private lateinit var binding: ActivityServerCustomConfigBinding
+    private val binding by lazy { ActivityServerCustomConfigBinding.inflate(layoutInflater) }
 
     private val mainStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
     private val serverRawStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SERVER_RAW, MMKV.MULTI_PROCESS_MODE) }
@@ -34,9 +34,7 @@ class ServerCustomConfigActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityServerCustomConfigBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         title = getString(R.string.title_server)
 
         if (!Utils.getDarkModeStatus(this)) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SubEditActivity.kt
@@ -23,7 +23,7 @@ import com.v2ray.ang.util.Utils
 import java.util.concurrent.TimeUnit
 
 class SubEditActivity : BaseActivity() {
-    private lateinit var binding: ActivitySubEditBinding
+    private val binding by lazy {ActivitySubEditBinding.inflate(layoutInflater)}
 
     var del_config: MenuItem? = null
     var save_config: MenuItem? = null
@@ -33,9 +33,7 @@ class SubEditActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySubEditBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         title = getString(R.string.title_sub_setting)
 
         val json = subStorage?.decodeString(editSubId)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SubSettingActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SubSettingActivity.kt
@@ -19,16 +19,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class SubSettingActivity : BaseActivity() {
-    private lateinit var binding: ActivitySubSettingBinding
+    private val binding by lazy { ActivitySubSettingBinding.inflate(layoutInflater) }
 
     var subscriptions: List<Pair<String, SubscriptionItem>> = listOf()
     private val adapter by lazy { SubSettingRecyclerAdapter(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySubSettingBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         title = getString(R.string.title_sub_setting)
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/TaskerActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/TaskerActivity.kt
@@ -17,7 +17,7 @@ import com.v2ray.ang.databinding.ActivityTaskerBinding
 import com.v2ray.ang.util.MmkvManager
 
 class TaskerActivity : BaseActivity() {
-    private lateinit var binding: ActivityTaskerBinding
+    private val binding by lazy { ActivityTaskerBinding.inflate(layoutInflater) }
 
     private var listview: ListView? = null
     private var lstData: ArrayList<String> = ArrayList()
@@ -27,9 +27,7 @@ class TaskerActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityTaskerBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         //add def value
         lstData.add("Default")

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UrlSchemeActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UrlSchemeActivity.kt
@@ -11,13 +11,11 @@ import com.v2ray.ang.util.AngConfigManager
 import java.net.URLDecoder
 
 class UrlSchemeActivity : BaseActivity() {
-    private lateinit var binding: ActivityLogcatBinding
+    private val binding by lazy { ActivityLogcatBinding.inflate(layoutInflater) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityLogcatBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
 
         try {
             intent.apply {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UserAssetActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UserAssetActivity.kt
@@ -39,7 +39,7 @@ import java.text.DateFormat
 import java.util.*
 
 class UserAssetActivity : BaseActivity() {
-    private lateinit var binding: ActivitySubSettingBinding
+    private val binding by lazy { ActivitySubSettingBinding.inflate(layoutInflater) }
     private val settingsStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_SETTING, MMKV.MULTI_PROCESS_MODE) }
     private val assetStorage by lazy { MMKV.mmkvWithID(MmkvManager.ID_ASSET, MMKV.MULTI_PROCESS_MODE) }
 
@@ -49,9 +49,7 @@ class UserAssetActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivitySubSettingBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         title = getString(R.string.title_user_asset_setting)
 
         binding.recyclerView.setHasFixedSize(true)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UserAssetUrlActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UserAssetUrlActivity.kt
@@ -16,7 +16,7 @@ import com.v2ray.ang.util.Utils
 import java.io.File
 
 class UserAssetUrlActivity : BaseActivity() {
-    private lateinit var binding: ActivityUserAssetUrlBinding
+    private val binding by lazy { ActivityUserAssetUrlBinding.inflate(layoutInflater) }
 
     var del_config: MenuItem? = null
     var save_config: MenuItem? = null
@@ -27,9 +27,7 @@ class UserAssetUrlActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityUserAssetUrlBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         title = getString(R.string.title_user_asset_add_url)
 
         val json = assetStorage?.decodeString(editAssetId)


### PR DESCRIPTION
Refactor binding initialization to use lazy delegation

Replaced direct initialization of binding with lazy initialization to improve performance and resource management. This change defers the creation of the binding object until it is actually needed, which can reduce memory usage and improve efficiency.

- Updated binding initialization to use lazy
- Ensured proper access and lifecycle handling

This update ensures that the binding is initialized only when required, leading to a more efficient use of resources.