### PR TITLE
Update null safety handling with orEmpty()

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
@@ -164,7 +164,7 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
                 if (guid != selected) {
                     mainStorage?.encode(MmkvManager.KEY_SELECTED_SERVER, guid)
                     if (!TextUtils.isEmpty(selected)) {
-                        notifyItemChanged(mActivity.mainViewModel.getPosition(selected?:""))
+                        notifyItemChanged(mActivity.mainViewModel.getPosition(selected.orEmpty()))
                     }
                     notifyItemChanged(mActivity.mainViewModel.getPosition(guid))
                     if (isRunning) {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/PerAppProxyActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/PerAppProxyActivity.kt
@@ -193,7 +193,7 @@ class PerAppProxyActivity : BaseActivity() {
                 }
 
                 override fun onQueryTextChange(newText: String?): Boolean {
-                    filterProxyApp(newText?:"")
+                    filterProxyApp(newText.orEmpty())
                     return false
                 }
             })

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ScannerActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ScannerActivity.kt
@@ -45,7 +45,7 @@ class ScannerActivity : BaseActivity(){
 
     private fun handleResult(result: QRResult) {
         if (result is QRResult.QRSuccess ) {
-            finished(result.content.rawValue?:"")
+            finished(result.content.rawValue.orEmpty())
         } else {
             finish()
         }
@@ -110,7 +110,7 @@ class ScannerActivity : BaseActivity(){
             try {
                 val bitmap = BitmapFactory.decodeStream(contentResolver.openInputStream(uri))
                 val text = QRCodeDecoder.syncDecodeQRCode(bitmap)
-                finished(text?:"")
+                finished(text.orEmpty())
             } catch (e: Exception) {
                 e.printStackTrace()
                 toast(e.message.toString())

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/ServerActivity.kt
@@ -322,7 +322,7 @@ class ServerActivity : BaseActivity() {
                 tlsSetting.alpn?.let {
                     val alpnIndex = Utils.arrayFind(
                         alpns,
-                        Utils.removeWhiteSpace(tlsSetting.alpn.joinToString())?:""
+                        Utils.removeWhiteSpace(tlsSetting.alpn.joinToString()).orEmpty()
                     )
                     sp_stream_alpn?.setSelection(alpnIndex)
                 }
@@ -450,7 +450,7 @@ class ServerActivity : BaseActivity() {
             saveStreamSettings(it)
         }
         if (config.subscriptionId.isEmpty() && !subscriptionId.isNullOrEmpty()) {
-            config.subscriptionId = subscriptionId?:""
+            config.subscriptionId = subscriptionId.orEmpty()
         }
 
         MmkvManager.encodeServerConfig(editGuid, config)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -40,7 +40,7 @@ object Utils {
      * @return
      */
     fun getEditable(text: String?): Editable {
-        return Editable.Factory.getInstance().newEditable(text?:"")
+        return Editable.Factory.getInstance().newEditable(text.orEmpty())
     }
 
     /**


### PR DESCRIPTION
Replaced ?: "" with orEmpty() for improved null safety

Updated all instances of the null-coalescing operator (?: "") with orEmpty() to enhance null safety across the codebase. This change ensures that an empty string is used when a nullable value is null, improving consistency and reducing potential null-related issues.