### PR TITLE
Replace deprecated packagingOptions with packaging for jniLibs config…

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -84,7 +84,7 @@ android {
         buildConfig = true
     }
 
-    packagingOptions {
+    packaging {
         jniLibs {
             useLegacyPackaging = true
         }


### PR DESCRIPTION
Replaced deprecated packagingOptions with packaging for jniLibs configuration.

Updated build.gradle file to use the new packaging configuration method as the previous packagingOptions method is deprecated. This change ensures compatibility with the latest Gradle plugin versions and avoids any potential issues with outdated configuration.

Changes:
- Updated from `packagingOptions { jniLibs { useLegacyPackaging = true } }` to `packaging { jniLibs { useLegacyPackaging = true } }`