### PR TITLE
Fix issue #3475

### DIFF
--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_widget_name">Переключить</string>
-    <string name="app_tile_name">Переключить</string>
+    <string name="app_widget_name">v2rayNG</string>
+    <string name="app_tile_name">v2rayNG</string>
     <string name="app_tile_first_use">Первое использование этой функции, пожалуйста, используйте приложение, чтобы добавить сервер</string>
     <string name="navigation_drawer_open">Открыть панель навигации</string>
     <string name="navigation_drawer_close">Закрыть панель навигации</string>


### PR DESCRIPTION
Fix issue where the label in the tile and widget was not displaying as `v2rayNG` for Russian language users