### PR TITLE
Refactor null handling with .orEmpty() for better readability

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/dto/V2rayConfig.kt
@@ -249,14 +249,14 @@ data class V2rayConfig(
                             tcpSetting.header.type = HTTP
                             if (!TextUtils.isEmpty(host) || !TextUtils.isEmpty(path)) {
                                 val requestObj = TcpSettingsBean.HeaderBean.RequestBean()
-                                requestObj.headers.Host = (host ?: "").split(",").map { it.trim() }.filter { it.isNotEmpty() }
-                                requestObj.path = (path ?: "").split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                                requestObj.headers.Host = (host .orEmpty()).split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                                requestObj.path = (path .orEmpty()).split(",").map { it.trim() }.filter { it.isNotEmpty() }
                                 tcpSetting.header.request = requestObj
                                 sni = requestObj.headers.Host?.getOrNull(0) ?: sni
                             }
                         } else {
                             tcpSetting.header.type = "none"
-                            sni = host ?: ""
+                            sni = host .orEmpty()
                         }
                         tcpSettings = tcpSetting
                     }
@@ -272,21 +272,21 @@ data class V2rayConfig(
                     }
                     "ws" -> {
                         val wssetting = WsSettingsBean()
-                        wssetting.headers.Host = host ?: ""
+                        wssetting.headers.Host = host .orEmpty()
                         sni = wssetting.headers.Host
                         wssetting.path = path ?: "/"
                         wsSettings = wssetting
                     }
                     "httpupgrade" -> {
                         val httpupgradeSetting = HttpupgradeSettingsBean()
-                        httpupgradeSetting.host = host ?: ""
+                        httpupgradeSetting.host = host .orEmpty()
                         sni = httpupgradeSetting.host
                         httpupgradeSetting.path = path ?: "/"
                         httpupgradeSettings = httpupgradeSetting
                     }
                     "splithttp" -> {
                         val splithttpSetting = SplithttpSettingsBean()
-                        splithttpSetting.host = host ?: ""
+                        splithttpSetting.host = host .orEmpty()
                         sni = splithttpSetting.host
                         splithttpSetting.path = path ?: "/"
                         splithttpSettings = splithttpSetting
@@ -294,7 +294,7 @@ data class V2rayConfig(
                     "h2", "http" -> {
                         network = "h2"
                         val h2Setting = HttpSettingsBean()
-                        h2Setting.host = (host ?: "").split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                        h2Setting.host = (host .orEmpty()).split(",").map { it.trim() }.filter { it.isNotEmpty() }
                         sni = h2Setting.host.getOrNull(0) ?: sni
                         h2Setting.path = path ?: "/"
                         httpSettings = h2Setting
@@ -302,18 +302,18 @@ data class V2rayConfig(
                     "quic" -> {
                         val quicsetting = QuicSettingBean()
                         quicsetting.security = quicSecurity ?: "none"
-                        quicsetting.key = key ?: ""
+                        quicsetting.key = key .orEmpty()
                         quicsetting.header.type = headerType ?: "none"
                         quicSettings = quicsetting
                     }
                     "grpc" -> {
                         val grpcSetting = GrpcSettingsBean()
                         grpcSetting.multiMode = mode == "multi"
-                        grpcSetting.serviceName = serviceName ?: ""
-                        grpcSetting.authority = authority ?: ""
+                        grpcSetting.serviceName = serviceName .orEmpty()
+                        grpcSetting.authority = authority .orEmpty()
                         grpcSetting.idle_timeout = 60
                         grpcSetting.health_check_timeout = 20
-                        sni = authority ?: ""
+                        sni = authority .orEmpty()
                         grpcSettings = grpcSetting
                     }
                 }
@@ -451,7 +451,7 @@ data class V2rayConfig(
                     "grpc" -> {
                         val grpcSetting = streamSettings?.grpcSettings ?: return null
                         listOf(if (grpcSetting.multiMode == true) "multi" else "gun",
-                                grpcSetting.authority ?: "",
+                                grpcSetting.authority .orEmpty(),
                                 grpcSetting.serviceName)
                     }
                     else -> null

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/extension/_Ext.kt
@@ -54,7 +54,7 @@ val URLConnection.responseLength: Long
     }
 
 val URI.idnHost: String
-    get() = host?.replace("[", "")?.replace("]", "") ?: ""
+    get() = host?.replace("[", "")?.replace("]", "") .orEmpty()
 
 fun String.removeWhiteSpace(): String = replace("\\s+".toRegex(), "")
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/MainRecyclerAdapter.kt
@@ -61,7 +61,7 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
 
             holder.itemMainBinding.tvName.text = profile.remarks
             holder.itemView.setBackgroundColor(Color.TRANSPARENT)
-            holder.itemMainBinding.tvTestResult.text = aff?.getTestDelayString() ?: ""
+            holder.itemMainBinding.tvTestResult.text = aff?.getTestDelayString() .orEmpty()
             if ((aff?.testDelayMillis ?: 0L) < 0L) {
                 holder.itemMainBinding.tvTestResult.setTextColor(ContextCompat.getColor(mActivity, R.color.colorPingRed))
             } else {
@@ -95,7 +95,7 @@ class MainRecyclerAdapter(val activity: MainActivity) : RecyclerView.Adapter<Mai
                 }
             }
 
-            val strState = "${profile?.server?.dropLast(3)}*** : ${profile?.serverPort ?: ""}"
+            val strState = "${profile?.server?.dropLast(3)}*** : ${profile?.serverPort .orEmpty()}"
 
             holder.itemMainBinding.tvStatistics.text = strState
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UrlSchemeActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/UrlSchemeActivity.kt
@@ -29,13 +29,13 @@ class UrlSchemeActivity : BaseActivity() {
                     when (data?.host) {
                         "install-config" -> {
                             val uri: Uri? = intent.data
-                            val shareUrl = uri?.getQueryParameter("url") ?: ""
+                            val shareUrl = uri?.getQueryParameter("url") .orEmpty()
                             parseUri(shareUrl, uri?.fragment)
                         }
 
                         "install-sub" -> {
                             val uri: Uri? = intent.data
-                            val shareUrl = uri?.getQueryParameter("url") ?: ""
+                            val shareUrl = uri?.getQueryParameter("url") .orEmpty()
                             parseUri(shareUrl, uri?.fragment)
                         }
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/AngConfigManager.kt
@@ -434,7 +434,7 @@ object AngConfigManager {
             val removedSelectedServer =
                 if (!TextUtils.isEmpty(subid) && !append) {
                     MmkvManager.decodeServerConfig(
-                        mainStorage?.decodeString(KEY_SELECTED_SERVER) ?: ""
+                        mainStorage?.decodeString(KEY_SELECTED_SERVER) .orEmpty()
                     )?.let {
                         if (it.subscriptionId == subid) {
                             return@let it

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/Utils.kt
@@ -97,7 +97,7 @@ object Utils {
      * base64 decode
      */
     fun decode(text: String?): String {
-        return tryDecodeBase64(text) ?: text?.trimEnd('=')?.let { tryDecodeBase64(it) } ?: ""
+        return tryDecodeBase64(text) ?: text?.trimEnd('=')?.let { tryDecodeBase64(it) } .orEmpty()
     }
 
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -188,25 +188,25 @@ object V2rayConfigUtil {
 
             routingUserRule(
                 settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_BLOCKED)
-                    ?: "", TAG_BLOCKED, v2rayConfig
+                    .orEmpty(), TAG_BLOCKED, v2rayConfig
             )
             if (routingMode == ERoutingMode.GLOBAL_DIRECT.value) {
                 routingUserRule(
                     settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_DIRECT)
-                        ?: "", TAG_DIRECT, v2rayConfig
+                        .orEmpty(), TAG_DIRECT, v2rayConfig
                 )
                 routingUserRule(
                     settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_AGENT)
-                        ?: "", TAG_PROXY, v2rayConfig
+                        .orEmpty(), TAG_PROXY, v2rayConfig
                 )
             } else {
                 routingUserRule(
                     settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_AGENT)
-                        ?: "", TAG_PROXY, v2rayConfig
+                        .orEmpty(), TAG_PROXY, v2rayConfig
                 )
                 routingUserRule(
                     settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_DIRECT)
-                        ?: "", TAG_DIRECT, v2rayConfig
+                        .orEmpty(), TAG_DIRECT, v2rayConfig
                 )
             }
 
@@ -352,11 +352,11 @@ object V2rayConfigUtil {
                 val geositeCn = arrayListOf("geosite:cn")
                 val proxyDomain = userRule2Domain(
                     settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_AGENT)
-                        ?: ""
+                        .orEmpty()
                 )
                 val directDomain = userRule2Domain(
                     settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_DIRECT)
-                        ?: ""
+                        .orEmpty()
                 )
                 // fakedns with all domains to make it always top priority
                 v2rayConfig.dns.servers?.add(
@@ -430,7 +430,7 @@ object V2rayConfigUtil {
             val remoteDns = Utils.getRemoteDnsServers()
             val proxyDomain = userRule2Domain(
                 settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_AGENT)
-                    ?: ""
+                    .orEmpty()
             )
             remoteDns.forEach {
                 servers.add(it)
@@ -450,7 +450,7 @@ object V2rayConfigUtil {
             val domesticDns = Utils.getDomesticDnsServers()
             val directDomain = userRule2Domain(
                 settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_DIRECT)
-                    ?: ""
+                    .orEmpty()
             )
             val routingMode = settingsStorage?.decodeString(AppConfig.PREF_ROUTING_MODE)
                 ?: ERoutingMode.BYPASS_LAN_MAINLAND.value
@@ -494,7 +494,7 @@ object V2rayConfigUtil {
             //block dns
             val blkDomain = userRule2Domain(
                 settingsStorage?.decodeString(AppConfig.PREF_V2RAY_ROUTING_BLOCKED)
-                    ?: ""
+                    .orEmpty()
             )
             if (blkDomain.size > 0) {
                 hosts.putAll(blkDomain.map { it to "127.0.0.1" })

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/ShadowsocksFmt.kt
@@ -67,7 +67,7 @@ object ShadowsocksFmt {
     private fun tryResolveResolveSip002(str: String, config: ServerConfig): Boolean {
         try {
             val uri = URI(Utils.fixIllegalUrl(str))
-            config.remarks = Utils.urlDecode(uri.fragment ?: "")
+            config.remarks = Utils.urlDecode(uri.fragment .orEmpty())
 
             val method: String
             val password: String
@@ -88,7 +88,7 @@ object ShadowsocksFmt {
                 password = base64Decode.substringAfter(":")
             }
 
-            val query = Utils.urlDecode(uri.query ?: "")
+            val query = Utils.urlDecode(uri.query .orEmpty())
             if (query != "") {
                 val queryPairs = HashMap<String, String>()
                 val pairs = query.split(";")
@@ -137,7 +137,7 @@ object ShadowsocksFmt {
                 }
                 if ("tls" in queryPairs) {
                     config.outboundBean?.streamSettings?.populateTlsSettings(
-                        "tls", false, sni ?: "", null, null, null, null, null
+                        "tls", false, sni .orEmpty(), null, null, null, null, null
                     )
                 }
 

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/TrojanFmt.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/TrojanFmt.kt
@@ -24,7 +24,7 @@ object TrojanFmt {
         val config = ServerConfig.create(EConfigType.TROJAN)
 
         val uri = URI(Utils.fixIllegalUrl(str))
-        config.remarks = Utils.urlDecode(uri.fragment ?: "")
+        config.remarks = Utils.urlDecode(uri.fragment .orEmpty())
 
         var flow = ""
         var fingerprint = config.outboundBean?.streamSettings?.tlsSettings?.fingerprint
@@ -55,19 +55,19 @@ object TrojanFmt {
                 queryParam["serviceName"],
                 queryParam["authority"]
             )
-            fingerprint = queryParam["fp"] ?: ""
-            allowInsecure = if ((queryParam["allowInsecure"] ?: "") == "1") true else allowInsecure
+            fingerprint = queryParam["fp"] .orEmpty()
+            allowInsecure = if ((queryParam["allowInsecure"] .orEmpty()) == "1") true else allowInsecure
             config.outboundBean?.streamSettings?.populateTlsSettings(
                 queryParam["security"] ?: V2rayConfig.TLS,
                 allowInsecure,
-                queryParam["sni"] ?: sni ?: "",
+                queryParam["sni"] ?: sni .orEmpty(),
                 fingerprint,
                 queryParam["alpn"],
                 null,
                 null,
                 null
             )
-            flow = queryParam["flow"] ?: ""
+            flow = queryParam["flow"] .orEmpty()
         }
         config.outboundBean?.settings?.servers?.get(0)?.let { server ->
             server.address = uri.idnHost
@@ -102,16 +102,16 @@ object TrojanFmt {
                     Utils.removeWhiteSpace(tlsSetting.alpn.joinToString()).orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.fingerprint)) {
-                dicQuery["fp"] = tlsSetting.fingerprint ?: ""
+                dicQuery["fp"] = tlsSetting.fingerprint .orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.publicKey)) {
-                dicQuery["pbk"] = tlsSetting.publicKey ?: ""
+                dicQuery["pbk"] = tlsSetting.publicKey .orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.shortId)) {
-                dicQuery["sid"] = tlsSetting.shortId ?: ""
+                dicQuery["sid"] = tlsSetting.shortId .orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.spiderX)) {
-                dicQuery["spx"] = Utils.urlEncode(tlsSetting.spiderX ?: "")
+                dicQuery["spx"] = Utils.urlEncode(tlsSetting.spiderX .orEmpty())
             }
         }
         dicQuery["type"] =

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/VlessFmt.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/VlessFmt.kt
@@ -30,13 +30,13 @@ object VlessFmt {
 
         val streamSetting = config.outboundBean?.streamSettings ?: return null
 
-        config.remarks = Utils.urlDecode(uri.fragment ?: "")
+        config.remarks = Utils.urlDecode(uri.fragment .orEmpty())
         config.outboundBean.settings?.vnext?.get(0)?.let { vnext ->
             vnext.address = uri.idnHost
             vnext.port = uri.port
             vnext.users[0].id = uri.userInfo
             vnext.users[0].encryption = queryParam["encryption"] ?: "none"
-            vnext.users[0].flow = queryParam["flow"] ?: ""
+            vnext.users[0].flow = queryParam["flow"] .orEmpty()
         }
 
         val sni = streamSetting.populateTransportSettings(
@@ -51,16 +51,16 @@ object VlessFmt {
             queryParam["serviceName"],
             queryParam["authority"]
         )
-        allowInsecure = if ((queryParam["allowInsecure"] ?: "") == "1") true else allowInsecure
+        allowInsecure = if ((queryParam["allowInsecure"] .orEmpty()) == "1") true else allowInsecure
         streamSetting.populateTlsSettings(
-            queryParam["security"] ?: "",
+            queryParam["security"] .orEmpty(),
             allowInsecure,
             queryParam["sni"] ?: sni,
-            queryParam["fp"] ?: "",
+            queryParam["fp"] .orEmpty(),
             queryParam["alpn"],
-            queryParam["pbk"] ?: "",
-            queryParam["sid"] ?: "",
-            queryParam["spx"] ?: ""
+            queryParam["pbk"] .orEmpty(),
+            queryParam["sid"] .orEmpty(),
+            queryParam["spx"] .orEmpty()
         )
 
         return config
@@ -93,16 +93,16 @@ object VlessFmt {
                     Utils.removeWhiteSpace(tlsSetting.alpn.joinToString()).orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.fingerprint)) {
-                dicQuery["fp"] = tlsSetting.fingerprint ?: ""
+                dicQuery["fp"] = tlsSetting.fingerprint .orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.publicKey)) {
-                dicQuery["pbk"] = tlsSetting.publicKey ?: ""
+                dicQuery["pbk"] = tlsSetting.publicKey .orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.shortId)) {
-                dicQuery["sid"] = tlsSetting.shortId ?: ""
+                dicQuery["sid"] = tlsSetting.shortId .orEmpty()
             }
             if (!TextUtils.isEmpty(tlsSetting.spiderX)) {
-                dicQuery["spx"] = Utils.urlEncode(tlsSetting.spiderX ?: "")
+                dicQuery["spx"] = Utils.urlEncode(tlsSetting.spiderX .orEmpty())
             }
         }
         dicQuery["type"] =

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/VmessFmt.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/VmessFmt.kt
@@ -121,7 +121,7 @@ object VmessFmt {
 
         val streamSetting = config.outboundBean?.streamSettings ?: return null
 
-        config.remarks = Utils.urlDecode(uri.fragment ?: "")
+        config.remarks = Utils.urlDecode(uri.fragment .orEmpty())
         config.outboundBean.settings?.vnext?.get(0)?.let { vnext ->
             vnext.address = uri.idnHost
             vnext.port = uri.port
@@ -143,12 +143,12 @@ object VmessFmt {
             queryParam["authority"]
         )
 
-        allowInsecure = if ((queryParam["allowInsecure"] ?: "") == "1") true else allowInsecure
+        allowInsecure = if ((queryParam["allowInsecure"] .orEmpty()) == "1") true else allowInsecure
         streamSetting.populateTlsSettings(
-            queryParam["security"] ?: "",
+            queryParam["security"] .orEmpty(),
             allowInsecure,
             queryParam["sni"] ?: sni,
-            queryParam["fp"] ?: "",
+            queryParam["fp"] .orEmpty(),
             queryParam["alpn"],
             null,
             null,

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/WireguardFmt.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/fmt/WireguardFmt.kt
@@ -13,7 +13,7 @@ object WireguardFmt {
         val uri = URI(Utils.fixIllegalUrl(str))
         if (uri.rawQuery != null) {
             val config = ServerConfig.create(EConfigType.WIREGUARD)
-            config.remarks = Utils.urlDecode(uri.fragment ?: "")
+            config.remarks = Utils.urlDecode(uri.fragment .orEmpty())
 
             val queryParam = uri.rawQuery.split("&")
                 .associate { it.split("=").let { (k, v) -> k to Utils.urlDecode(v) } }
@@ -24,7 +24,7 @@ object WireguardFmt {
                     (queryParam["address"]
                         ?: AppConfig.WIREGUARD_LOCAL_ADDRESS_V4).removeWhiteSpace()
                         .split(",")
-                wireguard.peers?.get(0)?.publicKey = queryParam["publickey"] ?: ""
+                wireguard.peers?.get(0)?.publicKey = queryParam["publickey"] .orEmpty()
                 wireguard.peers?.get(0)?.endpoint =
                     Utils.getIpv6Address(uri.idnHost) + ":${uri.port}"
                 wireguard.mtu = Utils.parseInt(queryParam["mtu"] ?: AppConfig.WIREGUARD_LOCAL_MTU)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -43,7 +43,7 @@ import java.util.Collections
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private var serverList = MmkvManager.decodeServerList()
-    var subscriptionId: String = MmkvManager.settingsStorage.decodeString(AppConfig.CACHE_SUBSCRIPTION_ID, "") ?: ""
+    var subscriptionId: String = MmkvManager.settingsStorage.decodeString(AppConfig.CACHE_SUBSCRIPTION_ID, "").orEmpty()
 
     //var keywordFilter: String = MmkvManager.settingsStorage.decodeString(AppConfig.CACHE_KEYWORD_FILTER, "")?:""
     private var keywordFilter = ""


### PR DESCRIPTION
Replaced null handling using `?: ""` with `.orEmpty()` for improved readability. The `.orEmpty()` extension function provides a more concise and expressive way to handle null strings by returning an empty string if the original string is null. This change enhances code clarity and consistency.