### PR TITLE
Fix logcat flush blocking call on the wrong dispatcher

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/LogcatActivity.kt
@@ -1,8 +1,8 @@
 package com.v2ray.ang.ui
 
+import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.os.Bundle
 import android.text.method.ScrollingMovementMethod
 import android.view.Menu
 import android.view.MenuItem
@@ -14,12 +14,9 @@ import com.v2ray.ang.databinding.ActivityLogcatBinding
 import com.v2ray.ang.extension.toast
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-
 import java.io.IOException
-import java.util.LinkedHashSet
 
 class LogcatActivity : BaseActivity() {
     private val binding by lazy {
@@ -57,7 +54,9 @@ class LogcatActivity : BaseActivity() {
                 lst.add("time")
                 lst.add("-s")
                 lst.add("GoLog,tun2socks,${ANG_PACKAGE},AndroidRuntime,System.err")
-                val process = Runtime.getRuntime().exec(lst.toTypedArray())
+                val process = withContext(Dispatchers.IO) {
+                    Runtime.getRuntime().exec(lst.toTypedArray())
+                }
 //                val bufferedReader = BufferedReader(
 //                        InputStreamReader(process.inputStream))
 //                val allText = bufferedReader.use(BufferedReader::readText)

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/LogcatActivity.kt
@@ -16,6 +16,7 @@ import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 import java.io.IOException
 import java.util.LinkedHashSet
@@ -44,8 +45,10 @@ class LogcatActivity : BaseActivity() {
                     val lst = LinkedHashSet<String>()
                     lst.add("logcat")
                     lst.add("-c")
-                    val process = Runtime.getRuntime().exec(lst.toTypedArray())
-                    process.waitFor()
+                    withContext(Dispatchers.IO) {
+                        val process = Runtime.getRuntime().exec(lst.toTypedArray())
+                        process.waitFor()
+                    }
                 }
                 val lst = LinkedHashSet<String>()
                 lst.add("logcat")


### PR DESCRIPTION
Moved the blocking `process.waitFor()` call to `Dispatchers.IO` to avoid potential thread starvation on `Dispatchers.Default`. This change ensures that the I/O-bound operation does not interfere with CPU-bound tasks, improving overall performance and responsiveness.