### PR TITLE
Fix invalid VPN DNS

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayVpnService.kt
@@ -137,16 +137,12 @@ class V2RayVpnService : VpnService(), ServiceControl {
             }
         }
 
-        if (settingsStorage?.decodeBool(AppConfig.PREF_LOCAL_DNS_ENABLED) == true) {
-            builder.addDnsServer(PRIVATE_VLAN4_ROUTER)
-        } else {
-            Utils.getVpnDnsServers()
-                .forEach {
-                    if (Utils.isPureIpAddress(it)) {
-                        builder.addDnsServer(it)
-                    }
+        Utils.getVpnDnsServers()
+            .forEach {
+                if (Utils.isPureIpAddress(it)) {
+                    builder.addDnsServer(it)
                 }
-        }
+            }
 
         builder.setSession(V2RayServiceManager.currentConfig?.remarks.orEmpty())
 


### PR DESCRIPTION
尝试修复#3586。
无论是否启用本地DNS都使用设置中提供的DNS。
如果DNS请求以UDP发送，可以由dnsgw转发至Xray-core的本地DNS服务器，其他协议的DNS请求以常规流量的方式进入Xray-core。