### PR TITLE
Remove unnecessary null check from keywordFilter

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -281,7 +281,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun removeAllServer() {
-        if (subscriptionId.isEmpty() && keywordFilter.isNullOrEmpty()) {
+        if (subscriptionId.isEmpty() && keywordFilter.isEmpty()) {
             MmkvManager.removeAllServer()
         } else {
             val serversCopy = serversCache.toList()
@@ -292,7 +292,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun removeInvalidServer() {
-        if (subscriptionId.isEmpty() && keywordFilter.isNullOrEmpty()) {
+        if (subscriptionId.isEmpty() && keywordFilter.isEmpty()) {
             MmkvManager.removeInvalidServer("")
         } else {
             val serversCopy = serversCache.toList()

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -163,7 +163,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun exportAllServer(): Int {
         val serverListCopy =
-            if (subscriptionId.isEmpty() && keywordFilter.isNullOrEmpty()) {
+            if (subscriptionId.isEmpty() && keywordFilter.isEmpty()) {
                 serverList
             } else {
                 serversCache.map { it.guid }.toList()


### PR DESCRIPTION
- Replaced `keywordFilter.isNullOrEmpty()` with `keywordFilter.isEmpty()` since `keywordFilter` is guaranteed to never be null.
- Simplified the logic by removing the redundant null check, improving code readability.