### PR TITLE
Remove unnecessary null check from subscriptionId

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/V2rayConfigUtil.kt
@@ -566,7 +566,7 @@ object V2rayConfigUtil {
             return returnPair
         }
 
-        if (subscriptionId.isNullOrEmpty()) {
+        if (subscriptionId.isEmpty()) {
             return returnPair
         }
         try {


### PR DESCRIPTION
- Replaced `subscriptionId.isNullOrEmpty()` with `subscriptionId.isEmpty()` since `subscriptionId` is not nullable.
- This refactor simplifies the logic and improves code readability by eliminating the redundant null check.