### PR TITLE
Improve RxJava Disposable Handling in V2RayServiceManager

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -428,10 +428,11 @@ object V2RayServiceManager {
     }
 
     private fun stopSpeedNotification() {
-        if (mDisposable != null) {
-            mDisposable?.dispose() //stop queryStats
+        mDisposable?.let {
+            it.dispose() //stop queryStats
             mDisposable = null
             updateNotification(currentConfig?.remarks, 0, 0)
         }
     }
+
 }


### PR DESCRIPTION
Refactored the RxJava disposable handling in the V2RayServiceManager to ensure proper disposal when the service stops. This change prevents potential memory leaks by disposing of the disposable only when it's initialized, using a more concise and reliable approach with Kotlin's let function.