### PR TITLE
Refactor updateMuxConcurrency for Null Safety and Code Simplification

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/ui/SettingsActivity.kt
@@ -316,12 +316,10 @@ class SettingsActivity : BaseActivity() {
         }
 
         private fun updateMuxConcurrency(value: String?) {
-            if (value == null) {
-            } else {
-                val concurrency = value.toIntOrNull() ?: 8
-                muxConcurrency?.summary = concurrency.toString()
-            }
+            val concurrency = value?.toIntOrNull() ?: 8
+            muxConcurrency?.summary = concurrency.toString()
         }
+
 
         private fun updateMuxXudpConcurrency(value: String?) {
             if (value == null) {


### PR DESCRIPTION
Refactored the updateMuxConcurrency function by removing redundant null checks and improving code readability. The concurrency value now defaults to 8 if null or invalid input is provided.