### PR TITLE
Refactor getString call to use orEmpty for null safety

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/receiver/TaskerReceiver.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/receiver/TaskerReceiver.kt
@@ -16,9 +16,9 @@ class TaskerReceiver : BroadcastReceiver() {
         try {
             val bundle = intent?.getBundleExtra(AppConfig.TASKER_EXTRA_BUNDLE)
             val switch = bundle?.getBoolean(AppConfig.TASKER_EXTRA_BUNDLE_SWITCH, false)
-            val guid = bundle?.getString(AppConfig.TASKER_EXTRA_BUNDLE_GUID, "")
+            val guid = bundle?.getString(AppConfig.TASKER_EXTRA_BUNDLE_GUID).orEmpty()
 
-            if (switch == null || guid == null || TextUtils.isEmpty(guid)) {
+            if (switch == null || TextUtils.isEmpty(guid)) {
                 return
             } else if (switch) {
                 if (guid == AppConfig.TASKER_DEFAULT_GUID) {


### PR DESCRIPTION
Updated `getString` call to use `orEmpty()` instead of specifying a default empty string, making the code cleaner and handling nullability more effectively.