### PR TITLE
Remove redundant Boolean comparison in runLoop call

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/handler/MmkvManager.kt
@@ -336,7 +336,7 @@ object MmkvManager {
     }
 
     fun decodeSettingsBool(key: String): Boolean {
-        return settingsStorage.decodeBool(key)
+        return settingsStorage.decodeBool(key,false)
     }
 
     fun decodeSettingsBool(key: String, defaultValue: Boolean): Boolean {

--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/service/V2RayServiceManager.kt
@@ -168,7 +168,7 @@ object V2RayServiceManager {
         currentConfig = config
 
         try {
-            v2rayPoint.runLoop(MmkvManager.decodeSettingsBool(AppConfig.PREF_PREFER_IPV6) == true)
+            v2rayPoint.runLoop(MmkvManager.decodeSettingsBool(AppConfig.PREF_PREFER_IPV6))
         } catch (e: Exception) {
             Log.d(ANG_PACKAGE, e.toString())
         }


### PR DESCRIPTION
Simplified the call to `runLoop` by removing the redundant `== true` comparison. Since `decodeSettingsBool` returns a non-nullable Boolean, direct usage improves readability.