### PR TITLE
Remove unnecessary Boolean comparisons in conditional checks

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/handler/MmkvManager.kt
@@ -336,7 +336,7 @@ object MmkvManager {
     }
 
     fun decodeSettingsBool(key: String): Boolean {
-        return settingsStorage.decodeBool(key)
+        return settingsStorage.decodeBool(key,false)
     }
 
     fun decodeSettingsBool(key: String, defaultValue: Boolean): Boolean {


### PR DESCRIPTION
Simplified conditional checks by removing unnecessary `== true` comparisons. The `decodeSettingsBool` function returns a non-nullable Boolean with a default value, so direct usage improves readability and keeps the code concise.