### PR TITLE
Correct isEmpty syntax for collection check

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/ZipUtil.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/util/ZipUtil.kt
@@ -31,7 +31,7 @@ object ZipUtil {
                     }
                 }
             }
-            if (filesToCompress.isEmpty) {
+            if (filesToCompress.isEmpty()) {
                 return false
             }
 


### PR DESCRIPTION
Fixed the syntax for checking if `filesToCompress` is empty by using `isEmpty()` instead of `isEmpty`. This ensures correct functionality when verifying if the collection has elements.