### PR TITLE
Updated the WorkManager configuration to replace `BuildConfig.APPLICA…

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
@@ -7,6 +7,7 @@ import androidx.multidex.MultiDexApplication
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.tencent.mmkv.MMKV
+import com.v2ray.ang.AppConfig.ANG_PACKAGE
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.util.Utils
 
@@ -22,7 +23,7 @@ class AngApplication : MultiDexApplication() {
     }
 
     private val workManagerConfiguration: Configuration = Configuration.Builder()
-        .setDefaultProcessName("${BuildConfig.APPLICATION_ID}:bg")
+        .setDefaultProcessName("${ANG_PACKAGE}:bg")
         .build()
 
     override fun onCreate() {


### PR DESCRIPTION
BuildConfig.APPLICATION_ID` with `ANG_PACKAGE` for setting the default process name. This ensures consistent configuration handling in background processes.

Changes:
- Modified `setDefaultProcessName` to use `ANG_PACKAGE` instead of `BuildConfig.APPLICATION_ID`.

This resolves inconsistencies in process naming conventions and aligns with project requirements.