### PR TITLE
Remove unnecessary Context parameter from setNightMode

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
@@ -37,7 +37,7 @@ class AngApplication : MultiDexApplication() {
 
         MMKV.initialize(this)
 
-        Utils.setNightMode(application)
+        Utils.setNightMode()
         // Initialize WorkManager with the custom configuration
         WorkManager.initialize(this, workManagerConfiguration)
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -396,7 +396,7 @@ object Utils {
     }
 
 
-    fun setNightMode(context: Context) {
+    fun setNightMode() {
         when (MmkvManager.decodeSettingsString(AppConfig.PREF_UI_MODE_NIGHT, "0")) {
             "0" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
             "1" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/SettingsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/SettingsViewModel.kt
@@ -81,7 +81,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 //            }
         }
         if (key == AppConfig.PREF_UI_MODE_NIGHT) {
-            Utils.setNightMode(getApplication())
+            Utils.setNightMode()
         }
     }
 }


### PR DESCRIPTION
Refactored the `setNightMode` function to remove the unused `Context` parameter.

Changes:
- Eliminated the `context` parameter from the `setNightMode` function.
- Adjusted function signature to align with the current implementation, which does not utilize the `Context`.

This simplifies the function interface and ensures cleaner, more maintainable code.