### PR TITLE
Prevent showing the location of the USA during WebRTC Leak

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -35,10 +35,10 @@ import java.lang.ref.SoftReference
 class V2RayVpnService : VpnService(), ServiceControl {
     companion object {
         private const val VPN_MTU = 1500
-        private const val PRIVATE_VLAN4_CLIENT = "26.26.26.1"
-        private const val PRIVATE_VLAN4_ROUTER = "26.26.26.2"
-        private const val PRIVATE_VLAN6_CLIENT = "da26:2626::1"
-        private const val PRIVATE_VLAN6_ROUTER = "da26:2626::2"
+        private const val PRIVATE_VLAN4_CLIENT = "10.10.10.1"
+        private const val PRIVATE_VLAN4_ROUTER = "10.10.10.2"
+        private const val PRIVATE_VLAN6_CLIENT = "fc00::10:10:10:1"
+        private const val PRIVATE_VLAN6_ROUTER = "fc00::10:10:10:2"
         private const val TUN2SOCKS = "libtun2socks.so"
     }
 


### PR DESCRIPTION
Changed tun2socks config private vlan4s and vlan6s to 10.10.10.1>10.10.10.2 and fc00::10:10:10:1>fc00::10:10:10:2 .

When visiting certain websites or using apps that could identify the real public IP, if the IP 26.26.26.1 was shown and it indicated a location in the USA, it unfortunately led to permanent account bans! . This issue is most likely resolved with this PR.