### PR TITLE
use different version for abis

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -60,7 +60,7 @@ android {
     applicationVariants.all {
         val variant = this
         val versionCodes =
-            mapOf("armeabi-v7a" to 8, "arm64-v8a" to 7, "x86" to 6, "x86_64" to 5, "universal" to 4)
+            mapOf("arm64-v8a" to 1, "armeabi-v7a" to 2, "x86_64" to 3, "x86" to 4, "universal" to 0)
 
         variant.outputs
             .map { it as com.android.build.gradle.internal.api.ApkVariantOutputImpl }
@@ -73,7 +73,7 @@ android {
                 output.outputFileName = "v2rayNG_${variant.versionName}_${abi}.apk"
                 if (versionCodes.containsKey(abi)) {
                     output.versionCodeOverride =
-                        (1000000 * versionCodes[abi]!!).plus(variant.versionCode)
+                        (100 * variant.versionCode + versionCodes[abi]!!).plus(5000000)
                 } else {
                     return@forEach
                 }

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -60,7 +60,7 @@ android {
     applicationVariants.all {
         val variant = this
         val versionCodes =
-            mapOf("armeabi-v7a" to 4, "arm64-v8a" to 4, "x86" to 4, "x86_64" to 4, "universal" to 4)
+            mapOf("armeabi-v7a" to 8, "arm64-v8a" to 7, "x86" to 6, "x86_64" to 5, "universal" to 4)
 
         variant.outputs
             .map { it as com.android.build.gradle.internal.api.ApkVariantOutputImpl }


### PR DESCRIPTION
Hi, have a look at this: https://developer.android.com/build/configure-apk-splits#configure-APK-versions

Google recommends different version codes for different ABIs, and the current way seems to be incompatible with F-Droid.

I ~~set it as starting from 4~~ added a plus 5000000  to avoid inconvenience for users.