### PR TITLE
Switch to gradle-license-plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
       run: |
         cd ${{ github.workspace }}/V2rayNG
         chmod 755 gradlew
+        ./gradlew licenseReleaseReport
         ./gradlew assembleRelease -Pandroid.injected.signing.store.file=${{ steps.android_keystore.outputs.filePath }} -Pandroid.injected.signing.store.password=${{ secrets.APP_KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.APP_KEYSTORE_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.APP_KEY_PASSWORD }}
 
     - name: Upload arm64-v8a APK

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    id("com.google.android.gms.oss-licenses-plugin")
+    id("com.jaredsburrows.license")
 }
 
 android {
@@ -146,6 +146,4 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     testImplementation(libs.org.mockito.mockito.inline)
     testImplementation(libs.mockito.kotlin)
-    // Oss Licenses
-    implementation(libs.play.services.oss.licenses)
 }

--- a/V2rayNG/app/src/main/assets/open_source_licenses.html
+++ b/V2rayNG/app/src/main/assets/open_source_licenses.html
@@ -1,0 +1,1285 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head><meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <style>body { font-family: sans-serif; background-color: #ffffff; color: #000000; } a { color: #0000EE; } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; word-break: break-word; display: inline-block; } @media (prefers-color-scheme: dark) { body { background-color: #121212; color: #E0E0E0; } a { color: #BB86FC; } pre { background-color: #333333; color: #E0E0E0; } }</style>
+    <title>Open source licenses</title>
+  </head>
+  <body>
+    <h3>Notice for packages:</h3>
+    <ul>
+      <li><a href="#189946331">Camera Core</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="189946331"></a>
+    <pre>                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+<br>
+    <pre>BSD License
+<a href="https://chromium.googlesource.com/libyuv/libyuv/+/refs/heads/main/README.chromium">https://chromium.googlesource.com/libyuv/libyuv/+/refs/heads/main/README.chromium</a></pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#1934118923">Activity</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Activity Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android App Startup Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Arch-Common</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Arch-Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Emoji2 Compat</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Emoji2 Compat view helpers</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Multi-Dex Library</a>
+        <dl>
+          <dt>Copyright &copy; 2013 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Preferences KTX</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Resource Inspection - Annotations</a>
+        <dl>
+          <dt>Copyright &copy; 2021 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support AnimatedVectorDrawable</a>
+        <dl>
+          <dt>Copyright &copy; 2015 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support CardView v7</a>
+        <dl>
+          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support DynamicAnimation</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support ExifInterface</a>
+        <dl>
+          <dt>Copyright &copy; 2016 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Annotations</a>
+        <dl>
+          <dt>Copyright &copy; 2013 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Annotations</a>
+        <dl>
+          <dt>Copyright &copy; 2013 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Coordinator Layout</a>
+        <dl>
+          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library core utils</a>
+        <dl>
+          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Cursor Adapter</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Custom View</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Document File</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Drawer Layout</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library fragment</a>
+        <dl>
+          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Interpolators</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library loader</a>
+        <dl>
+          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Local Broadcast Manager</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Print</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library Sliding Pane Layout</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support Library View Pager</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support RecyclerView</a>
+        <dl>
+          <dt>Copyright &copy; 2014 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Support VectorDrawable</a>
+        <dl>
+          <dt>Copyright &copy; 2015 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Tracing</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Android Tracing Runtime Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">AndroidX Preference</a>
+        <dl>
+          <dt>Copyright &copy; 2015 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">androidx.customview:poolingcontainer</a>
+        <dl>
+          <dt>Copyright &copy; 2021 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Annotation</a>
+        <dl>
+          <dt>Copyright &copy; 2013 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">AppCompat</a>
+        <dl>
+          <dt>Copyright &copy; 2011 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">AppCompat Resources</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">AutoValue Annotations</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Camera Lifecycle</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Camera Video</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Camera View</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Camera2</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">collections</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Collections Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">ConstraintLayout</a>
+        <dl>
+          <dt>Copyright &copy; 2022 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">ConstraintLayout Core</a>
+        <dl>
+          <dt>Copyright &copy; 2022 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Core</a>
+        <dl>
+          <dt>Copyright &copy; 2015 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Core Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">error-prone annotations</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Experimental annotation</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">firebase-annotations</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">firebase-components</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">firebase-encoders</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">firebase-encoders-json</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">flexbox-layout</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Google</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Fragment Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Futures</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Futures Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Gson</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Guava ListenableFuture only</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">javax.inject</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">JetBrains Java Annotations</a>
+        <dl>
+          <dt>Copyright &copy; 20xx JetBrains Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Jetpack WindowManager Library</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Kotlin Android Extensions Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Kotlin Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Kotlin Stdlib</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Kotlin Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Kotlin Stdlib Jdk7</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Kotlin Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Kotlin Stdlib Jdk8</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Kotlin Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">kotlinx-coroutines-android</a>
+        <dl>
+          <dt>Copyright &copy; 20xx JetBrains Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">kotlinx-coroutines-core</a>
+        <dl>
+          <dt>Copyright &copy; 20xx JetBrains Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle LiveData</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle LiveData Core</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle Process</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle Service</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle ViewModel</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle ViewModel</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle ViewModel</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle ViewModel Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle ViewModel with SavedState</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Lifecycle-Common</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">LiveData Core Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">LiveData Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Material Components for Android</a>
+        <dl>
+          <dt>Copyright &copy; 2015 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Parcelize Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Kotlin Team</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Profile Installer</a>
+        <dl>
+          <dt>Copyright &copy; 2021 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Room Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2019 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Room-Common</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Room-Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">RxAndroid</a>
+        <dl>
+          <dt>Copyright &copy; 20xx ReactiveX</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">RxJava</a>
+        <dl>
+          <dt>Copyright &copy; 2013 David Karnok</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Saved State</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">SavedState Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">SQLite</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">SQLite Framework Integration</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">tbruyelle/RxPermissions</a>
+        <dl>
+          <dt>Copyright &copy; 2015 Thomas Bruyelle</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">ToastCompat</a>
+        <dl>
+          <dt>Copyright &copy; 20xx drakeet</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">Transition</a>
+        <dl>
+          <dt>Copyright &copy; 2016 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">transport-api</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">transport-backend-cct</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">transport-runtime</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">VersionedParcelable</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">viewbinding</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">ViewPager2</a>
+        <dl>
+          <dt>Copyright &copy; 2017 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">WorkManager Kotlin Extensions</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">WorkManager Multiprocess</a>
+        <dl>
+          <dt>Copyright &copy; 2020 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">WorkManager Runtime</a>
+        <dl>
+          <dt>Copyright &copy; 2018 The Android Open Source Project</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1934118923">ZXing Core</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="1934118923"></a>
+    <pre>                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#2134416733">MMKV</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Tencent Wechat, Inc.</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="2134416733"></a>
+    <pre>BSD 3-Clause License
+
+Copyright (c) [year], [fullname]
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#1121107629">image</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1121107629">play-services-base</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1121107629">play-services-basement</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1121107629">play-services-oss-licenses</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1121107629">play-services-tasks</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="1121107629"></a>
+    <pre>Android Software Development Kit License
+<a href="https://developer.android.com/studio/terms.html">https://developer.android.com/studio/terms.html</a></pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#-1837751947">barcode-scanning</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#-1837751947">barcode-scanning-common</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#-1837751947">common</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#-1837751947">play-services-mlkit-barcode-scanning</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#-1837751947">vision-common</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#-1837751947">vision-interfaces</a>
+        <dl>
+          <dt>Copyright &copy; 20xx The original author or authors</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="-1837751947"></a>
+    <pre>ML Kit Terms of Service
+<a href="https://developers.google.com/ml-kit/terms">https://developers.google.com/ml-kit/terms</a></pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#1258221018">editorkit</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Dmitrii Rubtsov</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1258221018">language-base</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Dmitrii Rubtsov</dt>
+          <dd></dd>
+        </dl>
+      </li>
+      <li><a href="#1258221018">language-json</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Dmitrii Rubtsov</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="1258221018"></a>
+    <pre>Apache 2.0 License
+<a href="https://github.com/massivemadness/EditorKit/blob/master/LICENSE">https://github.com/massivemadness/EditorKit/blob/master/LICENSE</a></pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#402152448">reactive-streams</a>
+        <dl>
+          <dt>Copyright &copy; 2014 Reactive Streams SIG</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="402152448"></a>
+    <pre>MIT-0
+<a href="https://spdx.org/licenses/MIT-0.html">https://spdx.org/licenses/MIT-0.html</a></pre>
+<br>
+    <hr>
+    <ul>
+      <li><a href="#1783810846">quickie-bundled</a>
+        <dl>
+          <dt>Copyright &copy; 20xx Thomas Wirth</dt>
+          <dd></dd>
+        </dl>
+      </li>
+    </ul>
+<a id="1783810846"></a>
+    <pre>MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+<br>
+    <hr>
+  </body>
+</html>

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AboutActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AboutActivity.kt
@@ -20,7 +20,6 @@ import com.v2ray.ang.util.ZipUtil
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 
 
 class AboutActivity : BaseActivity() {
@@ -90,7 +89,12 @@ class AboutActivity : BaseActivity() {
             Utils.openUri(this, AppConfig.v2rayNGIssues)
         }
         binding.layoutOssLicenses.setOnClickListener{
-            startActivity(Intent(this, OssLicensesMenuActivity::class.java))
+            val webView = android.webkit.WebView(this);
+            webView.loadUrl("file:///android_asset/open_source_licenses.html");
+            android.app.AlertDialog.Builder(this)
+                .setTitle("Open source licenses")
+                .setView(webView)
+                .setPositiveButton("OK", android.content.DialogInterface.OnClickListener { dialog, whichButton -> dialog.dismiss() }).show()
         }
 
         binding.layoutTgChannel.setOnClickListener {

--- a/V2rayNG/build.gradle.kts
+++ b/V2rayNG/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 buildscript {
     dependencies {
-        classpath(libs.oss.licenses.plugin)
+        classpath(libs.gradle.license.plugin)
     }
 }
 

--- a/V2rayNG/gradle/libs.versions.toml
+++ b/V2rayNG/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.2"
+gradleLicensePlugin = "0.9.8"
 kotlin = "2.1.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -11,8 +12,6 @@ activity = "1.9.3"
 constraintlayout = "2.2.0"
 mmkvStatic = "1.3.11"
 gson = "2.11.0"
-ossLicensesPlugin = "0.10.6"
-playServicesOssLicenses = "17.1.0"
 rxjava = "3.1.9"
 rxandroid = "3.0.2"
 rxpermissions = "0.12"
@@ -29,6 +28,7 @@ preferenceKtx = "1.2.1"
 recyclerview = "1.3.2"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+gradle-license-plugin = { module = "com.jaredsburrows:gradle-license-plugin", version.ref = "gradleLicensePlugin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -38,8 +38,6 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 mmkv-static = { module = "com.tencent:mmkv-static", version.ref = "mmkvStatic" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
-oss-licenses-plugin = { module = "com.google.android.gms:oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
-play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 rxjava = { module = "io.reactivex.rxjava3:rxjava", version.ref = "rxjava" }
 rxandroid = { module = "io.reactivex.rxjava3:rxandroid", version.ref = "rxandroid" }
 rxpermissions = { module = "com.github.tbruyelle:rxpermissions", version.ref = "rxpermissions" }


### PR DESCRIPTION
#4022 introduced a non-free dependency. Replacing it with [jaredsburrows/gradle-license-plugin](https://github.com/jaredsburrows/gradle-license-plugin).

### Before

<img src="https://github.com/user-attachments/assets/c9abb2d3-0af3-4056-85e2-3ce3710fcd3a" width="256px" />

Somehow the texts passed through the status bar on my device.

### After

<img src="https://github.com/user-attachments/assets/d0ca5589-64b5-4f70-aa7e-2436763b07d4" width="256px" />

I was thinking about patching it only in F-Droid build script. But linsui [suggested](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/16106#note_2268930300) that there could be another flavor for F-Droid, I'm now trying to

1. This, replace `gms.oss-licenses-plugin`.
2. Next patch, replace `quickie` which depends on Google's proprietary mlkit with [quickie-foss](https://github.com/T8RIN/QuickieExtended).
3. Next patch, apply #4152 only for fdroid flavor.
4. Enable Reproducible Builds on fdroidserver.

The last one is basically verifying if your released binary is the same with fdroidserver's, and it's not possible if there's any downstream patch in the build script.