### PR TITLE
Change fdroid flavor applicationId

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -52,7 +52,7 @@ android {
     productFlavors {
         create("fdroid") {
             dimension = "distribution"
-            versionNameSuffix = "-fdroid"
+            applicationIdSuffix = ".fdroid"
             buildConfigField("String", "DISTRIBUTION", "\"F-Droid\"")
         }
         create("playstore") {
@@ -89,7 +89,7 @@ android {
                 .map { it as com.android.build.gradle.internal.api.ApkVariantOutputImpl }
                 .forEach { output ->
                     val abi = output.getFilter("ABI") ?: "universal"
-                    output.outputFileName = "v2rayNG_${variant.versionName}_${abi}.apk"
+                    output.outputFileName = "v2rayNG_${variant.versionName}-fdroid_${abi}.apk"
                     if (versionCodes.containsKey(abi)) {
                         output.versionCodeOverride =
                             (100 * variant.versionCode + versionCodes[abi]!!).plus(5000000)


### PR DESCRIPTION
To avoid mix installing.

@2dust linsui suggested only preserving `fdroid` flavor in GitHub Releases to avoid confusing users. I'm not sure. What do you think?