### PR TITLE
Ignore libtun2socks.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 V2rayNG/app/release/output.json
 .idea/
 .gradle/
+libtun2socks.so


### PR DESCRIPTION
Actuality it should be `*.so`. I'll build `libhysteria` in days.