### PR TITLE
disable bypass lan in vpn code.

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -116,24 +116,9 @@ object SettingsManager {
         MmkvManager.encodeRoutingRulesets(rulesetList)
     }
 
-    fun routingRulesetsBypassLan(): Boolean {
-        val guid = MmkvManager.getSelectServer() ?: return false
-        val config = MmkvManager.decodeServerConfig(guid) ?: return false
-        if (config.configType == EConfigType.CUSTOM) {
-            val raw = MmkvManager.decodeServerRaw(guid) ?: return false
-            val v2rayConfig = JsonUtil.fromJson(raw, V2rayConfig::class.java)
-            val exist = v2rayConfig.routing.rules.filter { it.outboundTag == TAG_DIRECT }?.any {
-                it.domain?.contains(GEOSITE_PRIVATE) == true || it.ip?.contains(GEOIP_PRIVATE) == true
-            }
-            return exist == true
-        }
-
-        val rulesetItems = MmkvManager.decodeRoutingRulesets()
-        val exist = rulesetItems?.filter { it.enabled && it.outboundTag == TAG_DIRECT }?.any {
-            it.domain?.contains(GEOSITE_PRIVATE) == true || it.ip?.contains(GEOIP_PRIVATE) == true
-        }
-        return exist == true
-        }
+    fun routingRulesetsBypassLan(): Boolean {        
+        return false
+    }
 
     fun swapRoutingRuleset(fromPosition: Int, toPosition: Int) {
         val rulesetList = MmkvManager.decodeRoutingRulesets()


### PR DESCRIPTION
xray-core can bypass private IPs and no need to bypass private IPs in vpn-code.

and just because geoip/geosite:private rule exist (and route to direct) is not a valid reason to bypass lan in vpn-code and **all other rules must be considered** .(if these rules exist xray-core bypass lan IPs by itself and no need to bypass lan in vpn code)

in addition **routing rules is for xray-core only** and should not used for vpn-code.
problems such as:
cannot block specific private ip.
cannot block specific port of private ips.
and ....
will occur if bypass all lan ips in vpn code.

and in the last if the bypass lan in vpn code is necessary(why?) you can put simple checkbox for it.
