### PR TITLE
Fix crash on alpn index ServerActivity

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
@@ -356,11 +356,11 @@ class ServerActivity : BaseActivity() {
             et_sni?.text = Utils.getEditable(config.sni)
             config.fingerPrint?.let {
                 val utlsIndex = Utils.arrayFind(uTlsItems, it)
-                sp_stream_fingerprint?.setSelection(utlsIndex)
+                utlsIndex.let { sp_stream_fingerprint?.setSelection(if (it >= 0) it else 0) }
             }
             config.alpn?.let {
                 val alpnIndex = Utils.arrayFind(alpns, it)
-                sp_stream_alpn?.setSelection(alpnIndex)
+                alpnIndex.let { sp_stream_alpn?.setSelection(if (it >= 0) it else 0) }
             }
             if (config.security == TLS) {
                 container_allow_insecure?.visibility = View.VISIBLE


### PR DESCRIPTION
Utils.arrayFind() in some cases return -1 and it will crash on some devices.
https://github.com/2dust/v2rayNG/blob/ddf5f220377254d1fa624d4191ac0add99fc185b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt#L550-L551


https://github.com/2dust/v2rayNG/blob/ddf5f220377254d1fa624d4191ac0add99fc185b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt#L567-L568