### PR TITLE
Add bundle build type with extractNativeLibs=false

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -46,6 +46,13 @@ android {
                 "proguard-rules.pro"
             )
         }
+
+        // extractNativeLibs (useLegacyPackaging) set to false
+        // run `bundlePlaystoreStore` task to generate Play Store bundle
+        register("store") {
+            initWith(getByName("release"))
+            matchingFallbacks.add("release")
+        }
     }
 
     flavorDimensions.add("distribution")
@@ -131,6 +138,12 @@ android {
         }
     }
 
+}
+
+androidComponents {
+    onVariants(selector().withBuildType("store")) { variant ->
+        variant.packaging.jniLibs.useLegacyPackaging = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Resolves #4308

Run `gradlew bundlePlaystoreStore` to generate bundle with `extractNativeLibs=false`.

Reference: https://stackoverflow.com/questions/72017448/how-to-specify-different-signingconfigs-for-assemble-and-bundle

@2dust 