### PR TITLE
Fix wg chain proxy

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -197,7 +197,7 @@ data class V2rayConfig(
 
             data class WireGuardBean(
                 var publicKey: String = "",
-                var preSharedKey: String = "",
+                var preSharedKey: String? = null,
                 var endpoint: String = ""
             )
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/WireguardFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/WireguardFmt.kt
@@ -31,7 +31,7 @@ object WireguardFmt : FmtBase() {
         config.secretKey = uri.userInfo.orEmpty()
         config.localAddress = queryParam["address"] ?: WIREGUARD_LOCAL_ADDRESS_V4
         config.publicKey = queryParam["publickey"].orEmpty()
-        config.preSharedKey = queryParam["presharedkey"].orEmpty()
+        config.preSharedKey = queryParam["presharedkey"]?.takeIf { it.isNotEmpty() }
         config.mtu = Utils.parseInt(queryParam["mtu"] ?: AppConfig.WIREGUARD_LOCAL_MTU)
         config.reserved = queryParam["reserved"] ?: "0,0,0"
 
@@ -83,7 +83,7 @@ object WireguardFmt : FmtBase() {
         config.localAddress = interfaceParams["address"] ?: WIREGUARD_LOCAL_ADDRESS_V4
         config.mtu = Utils.parseInt(interfaceParams["mtu"] ?: AppConfig.WIREGUARD_LOCAL_MTU)
         config.publicKey = peerParams["publickey"].orEmpty()
-        config.preSharedKey = peerParams["presharedkey"].orEmpty()
+        config.preSharedKey = peerParams["presharedkey"]?.takeIf { it.isNotEmpty() }
         val endpoint = peerParams["endpoint"].orEmpty()
         val endpointParts = endpoint.split(":", limit = 2)
         if (endpointParts.size == 2) {
@@ -112,11 +112,11 @@ object WireguardFmt : FmtBase() {
             wireguard.address = (profileItem.localAddress ?: WIREGUARD_LOCAL_ADDRESS_V4).split(",")
             wireguard.peers?.firstOrNull()?.let { peer ->
                 peer.publicKey = profileItem.publicKey.orEmpty()
-                peer.preSharedKey = profileItem.preSharedKey.orEmpty()
+                peer.preSharedKey = profileItem.preSharedKey?.takeIf { it.isNotEmpty() }
                 peer.endpoint = Utils.getIpv6Address(profileItem.server) + ":${profileItem.serverPort}"
             }
             wireguard.mtu = profileItem.mtu
-            wireguard.reserved = profileItem.reserved?.split(",")?.map { it.toInt() }
+            wireguard.reserved = profileItem.reserved?.takeIf { it.isNotBlank() }?.split(",")?.filter { it.isNotBlank() }?.map { it.trim().toInt() }
         }
 
         return outboundBean

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -700,6 +700,9 @@ object V2rayConfigManager {
                     updateOutboundWithGlobalSettings(prevOutbound)
                     prevOutbound.tag = TAG_PROXY + "2"
                     v2rayConfig.outbounds.add(prevOutbound)
+                    if (outbound.streamSettings == null) {
+                        outbound.streamSettings = V2rayConfig.OutboundBean.StreamSettingsBean()
+                    }
                     outbound.streamSettings?.sockopt =
                         V2rayConfig.OutboundBean.StreamSettingsBean.SockoptBean(
                             dialerProxy = prevOutbound.tag
@@ -717,6 +720,9 @@ object V2rayConfigManager {
                     nextOutbound.tag = TAG_PROXY
                     v2rayConfig.outbounds.add(0, nextOutbound)
                     outbound.tag = TAG_PROXY + "1"
+                    if (nextOutbound.streamSettings == null) {
+                        nextOutbound.streamSettings = V2rayConfig.OutboundBean.StreamSettingsBean()
+                    }
                     nextOutbound.streamSettings?.sockopt =
                         V2rayConfig.OutboundBean.StreamSettingsBean.SockoptBean(
                             dialerProxy = outbound.tag

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -726,6 +726,10 @@ object V2rayConfigManager {
                         V2rayConfig.OutboundBean.StreamSettingsBean.SockoptBean(
                             dialerProxy = outbound.tag
                         )
+                    if (nextNode.configType == EConfigType.WIREGUARD)
+                    {
+                        domainPort = nextNode.getServerAddressAndPort()
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -30,7 +30,6 @@ import com.v2ray.ang.AppConfig.TAG_DIRECT
 import com.v2ray.ang.AppConfig.TAG_FRAGMENT
 import com.v2ray.ang.AppConfig.TAG_PROXY
 import com.v2ray.ang.AppConfig.WIREGUARD_LOCAL_ADDRESS_V4
-import com.v2ray.ang.AppConfig.WIREGUARD_LOCAL_ADDRESS_V6
 import com.v2ray.ang.dto.ConfigResult
 import com.v2ray.ang.dto.EConfigType
 import com.v2ray.ang.dto.NetworkType
@@ -561,7 +560,7 @@ object V2rayConfigManager {
 
             if (protocol.equals(EConfigType.WIREGUARD.name, true)) {
                 var localTunAddr = if (outbound.settings?.address == null) {
-                    listOf(WIREGUARD_LOCAL_ADDRESS_V4, WIREGUARD_LOCAL_ADDRESS_V6)
+                    listOf(WIREGUARD_LOCAL_ADDRESS_V4)
                 } else {
                     outbound.settings?.address as List<*>
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
@@ -18,7 +18,6 @@ import com.v2ray.ang.AppConfig.PREF_ALLOW_INSECURE
 import com.v2ray.ang.AppConfig.REALITY
 import com.v2ray.ang.AppConfig.TLS
 import com.v2ray.ang.AppConfig.WIREGUARD_LOCAL_ADDRESS_V4
-import com.v2ray.ang.AppConfig.WIREGUARD_LOCAL_ADDRESS_V6
 import com.v2ray.ang.AppConfig.WIREGUARD_LOCAL_MTU
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.EConfigType
@@ -327,7 +326,7 @@ class ServerActivity : BaseActivity() {
             et_preshared_key?.text = Utils.getEditable(config.preSharedKey.orEmpty())
             et_reserved1?.text = Utils.getEditable(config.reserved ?: "0,0,0")
             et_local_address?.text = Utils.getEditable(
-                config.localAddress ?: "$WIREGUARD_LOCAL_ADDRESS_V4,$WIREGUARD_LOCAL_ADDRESS_V6"
+                config.localAddress ?: WIREGUARD_LOCAL_ADDRESS_V4
             )
             et_local_mtu?.text = Utils.getEditable(config.mtu?.toString() ?: WIREGUARD_LOCAL_MTU)
         } else if (config.configType == EConfigType.HYSTERIA2) {
@@ -420,7 +419,7 @@ class ServerActivity : BaseActivity() {
         et_public_key?.text = null
         et_reserved1?.text = Utils.getEditable("0,0,0")
         et_local_address?.text =
-            Utils.getEditable("${WIREGUARD_LOCAL_ADDRESS_V4},${WIREGUARD_LOCAL_ADDRESS_V6}")
+            Utils.getEditable(WIREGUARD_LOCAL_ADDRESS_V4)
         et_local_mtu?.text = Utils.getEditable(WIREGUARD_LOCAL_MTU)
         return true
     }


### PR DESCRIPTION
- wireguard 的 preSharedKey 和 reserved 可空
- Wireguard 做落地节点时，因为 streamSettings 为 null，导致 nextOutbound.streamSettings?.sockopt = 设置值时失败
- 删除 wireguard ipv6 默认值，这个每次生成的ipv6都不一样，ipv4是一样的。
- 当 wireguard 做落地节点时，设置 PrepareDomain 为 wireguard 域名。