### PR TITLE
move Prefer_IPv6 settings

### DIFF
--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -174,7 +174,7 @@
     <string name="summary_pref_fake_dns_enabled">Local DNS returns fake IP addresses (faster, but it may not work for some apps)</string>
 
     <string name="title_pref_prefer_ipv6">Prefer IPv6</string>
-    <string name="summary_pref_prefer_ipv6">Prefer IPv6 addresses and routes</string>
+    <string name="summary_pref_prefer_ipv6">Enable IPv6 routes and Prefer IPv6 addresses</string>
 
     <string name="title_pref_remote_dns">Remote DNS (udp/tcp/https/quic)(Optional)</string>
     <string name="summary_pref_remote_dns">DNS</string>

--- a/V2rayNG/app/src/main/res/xml/pref_settings.xml
+++ b/V2rayNG/app/src/main/res/xml/pref_settings.xml
@@ -20,6 +20,11 @@
 
     <PreferenceCategory android:title="@string/title_vpn_settings">
         <CheckBoxPreference
+                android:key="pref_prefer_ipv6"
+                android:summary="@string/summary_pref_prefer_ipv6"
+                android:title="@string/title_pref_prefer_ipv6" />
+
+        <CheckBoxPreference
             android:key="pref_per_app_proxy"
             android:summary="@string/summary_pref_per_app_proxy"
             android:title="@string/title_pref_per_app_proxy" />
@@ -169,11 +174,6 @@
     <PreferenceCategory
         android:title="@string/title_advanced"
         app:initialExpandedChildrenCount="0">
-
-        <CheckBoxPreference
-            android:key="pref_prefer_ipv6"
-            android:summary="@string/summary_pref_prefer_ipv6"
-            android:title="@string/title_pref_prefer_ipv6" />
 
         <CheckBoxPreference
             android:defaultValue="false"


### PR DESCRIPTION
Prefer_IPv6 option is an important option and it should be more accessible.

also, it enable/disable IPv6 in tun, so it is related to "VPN-Settings"

as a result, I put it on "VPN-Settings".