### PR TITLE
real delay test

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -101,8 +101,8 @@ object AppConfig {
     const val APP_PRIVACY_POLICY = "$GITHUB_RAW_URL/2dust/v2rayNG/master/CR.md"
     const val APP_PROMOTION_URL = "aHR0cHM6Ly85LjIzNDQ1Ni54eXovYWJjLmh0bWw="
     const val TG_CHANNEL_URL = "https://t.me/github_2dust"
-    const val DELAY_TEST_URL = "https://www.gstatic.com/generate_204"
-    const val DELAY_TEST_URL2 = "https://www.google.com/generate_204"
+    const val DELAY_TEST_URL = "http://www.gstatic.com/generate_204"
+    const val DELAY_TEST_URL2 = "http://www.google.com/generate_204"
     const val IP_API_Url = "https://api.ip.sb/geoip"
 
     /** DNS server addresses. */


### PR DESCRIPTION
Please make the delay test real. https has no correlation with ping and will mislead the user.