### PR TITLE
Update V2rayConfig.kt

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -23,8 +23,8 @@ data class V2rayConfig(
 ) {
 
     data class LogBean(
-        val access: String,
-        val error: String,
+        val access: String? = null,
+        val error: String? = null,
         var loglevel: String? = null,
         val dnsLog: Boolean? = null
     )


### PR DESCRIPTION
Make `access` and `error` in `LogBean` nullable in `LogBean` class as nullable type

you didn't provided any of this properties in the `v2ray_config.json` file in the log section so they will be null after decoded to `V2rayConfig` class using `gson` library!.

in kotlin data class because you didn't make these properties nullable kotlin generates hash-code for not-nullable string and it will crash with `NullPointerException` if you use `hashcode` method of the data class (which is used  in HashMap)

```kt
// to reproduce it
val v2rayConfig = JsonUtil.fromJson(raw, V2rayConfig::class.java)
v2rayConfig.hashcode() // crash!!!
```