### PR TITLE
Xray-core default FakeIPv6 Pool should not bypass and should route

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -189,7 +189,7 @@ object AppConfig {
     val DNS_YANDEX_ADDRESSES = arrayListOf("77.88.8.8", "77.88.8.1", "2a02:6b8::feed:0ff", "2a02:6b8:0:1::feed:0ff")
 
     //minimum list https://serverfault.com/a/304791
-    val BYPASS_PRIVATE_IP_LIST = arrayListOf(
+    val ROUTED_IP_LIST = arrayListOf(
         "0.0.0.0/5",
         "8.0.0.0/7",
         "11.0.0.0/8",

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -179,6 +179,7 @@ class V2RayVpnService : VpnService(), ServiceControl {
             builder.addAddress(PRIVATE_VLAN6_CLIENT, 126)
             if (bypassLan) {
                 builder.addRoute("2000::", 3) //currently only 1/8 of total ipV6 is in use
+                builder.addRoute("fc00::", 18) //Xray-core default FakeIPv6 Pool
             } else {
                 builder.addRoute("::", 0)
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -167,7 +167,7 @@ class V2RayVpnService : VpnService(), ServiceControl {
         //builder.addDnsServer(PRIVATE_VLAN4_ROUTER)
         val bypassLan = SettingsManager.routingRulesetsBypassLan()
         if (bypassLan) {
-            AppConfig.BYPASS_PRIVATE_IP_LIST.forEach {
+            AppConfig.ROUTED_IP_LIST.forEach {
                 val addr = it.split('/')
                 builder.addRoute(addr[0], addr[1].toInt())
             }


### PR DESCRIPTION
"fc00::/18" is  Xray-core default FakeIPv6 Pool and should not bypass.

https://xtls.github.io/config/fakedns.html#fakednsobject

///

Also, the name `BYPASS_PRIVATE_IP_LIST` was chosen completely the opposite way, these are public IPs that should not bypass and should route, so its name should be `NOT_BYPASS_PUBLIC_IP_LIST` or simply `ROUTED_IP_LIST`.

///

(Xray-core default FakeIPv4 Pool routed correctly before, because "198.18.0.0/15" is in"196.0.0.0/6")