### PR TITLE
Cloudflare DNS Hosts

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -168,7 +168,9 @@ object AppConfig {
     // Android Private DNS constants
     const val DNS_DNSPOD_DOMAIN = "dot.pub"
     const val DNS_ALIDNS_DOMAIN = "dns.alidns.com"
-    const val DNS_CLOUDFLARE_DOMAIN = "one.one.one.one"
+    const val DNS_CLOUDFLARE_ONE_DOMAIN = "one.one.one.one"
+    const val DNS_CLOUDFLARE_DNS_COM_DOMAIN = "dns.cloudflare.com"
+    const val DNS_CLOUDFLARE_DNS_DOMAIN = "cloudflare-dns.com"
     const val DNS_GOOGLE_DOMAIN = "dns.google"
     const val DNS_QUAD9_DOMAIN = "dns.quad9.net"
     const val DNS_YANDEX_DOMAIN = "common.dot.dns.yandex.net"
@@ -182,7 +184,9 @@ object AppConfig {
     const val HEADER_TYPE_HTTP = "http"
 
     val DNS_ALIDNS_ADDRESSES = arrayListOf("223.5.5.5", "223.6.6.6", "2400:3200::1", "2400:3200:baba::1")
-    val DNS_CLOUDFLARE_ADDRESSES = arrayListOf("1.1.1.1", "1.0.0.1", "2606:4700:4700::1111", "2606:4700:4700::1001")
+    val DNS_CLOUDFLARE_ONE_ADDRESSES = arrayListOf("1.1.1.1", "1.0.0.1", "2606:4700:4700::1111", "2606:4700:4700::1001")
+    val DNS_CLOUDFLARE_DNS_COM_ADDRESSES = arrayListOf("104.16.132.229", "104.16.133.229", "2606:4700::6810:84e5", "2606:4700::6810:85e5")
+    val DNS_CLOUDFLARE_DNS_ADDRESSES = arrayListOf("104.16.248.249", "104.16.249.249", "2606:4700::6810:f8f9", "2606:4700::6810:f9f9")
     val DNS_DNSPOD_ADDRESSES = arrayListOf("1.12.12.12", "120.53.53.53")
     val DNS_GOOGLE_ADDRESSES = arrayListOf("8.8.8.8", "8.8.4.4", "2001:4860:4860::8888", "2001:4860:4860::8844")
     val DNS_QUAD9_ADDRESSES = arrayListOf("9.9.9.9", "149.112.112.112", "2620:fe::fe", "2620:fe::9")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -16,7 +16,6 @@ import com.v2ray.ang.dto.V2rayConfig.OutboundBean.StreamSettingsBean
 import com.v2ray.ang.dto.V2rayConfig.RoutingBean.RulesBean
 import com.v2ray.ang.extension.isNotNullEmpty
 import com.v2ray.ang.fmt.HttpFmt
-import com.v2ray.ang.fmt.Hysteria2Fmt
 import com.v2ray.ang.fmt.ShadowsocksFmt
 import com.v2ray.ang.fmt.SocksFmt
 import com.v2ray.ang.fmt.TrojanFmt
@@ -479,6 +478,25 @@ object V2rayConfigManager {
                 )
             }
 
+            //block dns
+            val blkDomain = getUserRule2Domain(AppConfig.TAG_BLOCKED)
+            if (blkDomain.isNotEmpty()) {
+                hosts.putAll(blkDomain.map { it to AppConfig.LOOPBACK })
+            }
+
+            // hardcode googleapi rule to fix play store problems
+            hosts[AppConfig.GOOGLEAPIS_CN_DOMAIN] = AppConfig.GOOGLEAPIS_COM_DOMAIN
+
+            // hardcode popular Android Private DNS rule to fix localhost DNS problem
+            hosts[AppConfig.DNS_ALIDNS_DOMAIN] = AppConfig.DNS_ALIDNS_ADDRESSES
+            hosts[AppConfig.DNS_CLOUDFLARE_ONE_DOMAIN] = AppConfig.DNS_CLOUDFLARE_ONE_ADDRESSES
+            hosts[AppConfig.DNS_CLOUDFLARE_DNS_COM_DOMAIN] = AppConfig.DNS_CLOUDFLARE_DNS_COM_ADDRESSES
+            hosts[AppConfig.DNS_CLOUDFLARE_DNS_DOMAIN] = AppConfig.DNS_CLOUDFLARE_DNS_ADDRESSES
+            hosts[AppConfig.DNS_DNSPOD_DOMAIN] = AppConfig.DNS_DNSPOD_ADDRESSES
+            hosts[AppConfig.DNS_GOOGLE_DOMAIN] = AppConfig.DNS_GOOGLE_ADDRESSES
+            hosts[AppConfig.DNS_QUAD9_DOMAIN] = AppConfig.DNS_QUAD9_ADDRESSES
+            hosts[AppConfig.DNS_YANDEX_DOMAIN] = AppConfig.DNS_YANDEX_ADDRESSES
+
             //User DNS hosts
             try {
                 val userHosts = MmkvManager.decodeSettingsString(AppConfig.PREF_DNS_HOSTS)
@@ -492,24 +510,6 @@ object V2rayConfigManager {
             } catch (e: Exception) {
                 Log.e(AppConfig.TAG, "Failed to configure user DNS hosts", e)
             }
-
-            //block dns
-            val blkDomain = getUserRule2Domain(AppConfig.TAG_BLOCKED)
-            if (blkDomain.isNotEmpty()) {
-                hosts.putAll(blkDomain.map { it to AppConfig.LOOPBACK })
-            }
-
-            // hardcode googleapi rule to fix play store problems
-            hosts[AppConfig.GOOGLEAPIS_CN_DOMAIN] = AppConfig.GOOGLEAPIS_COM_DOMAIN
-
-            // hardcode popular Android Private DNS rule to fix localhost DNS problem
-            hosts[AppConfig.DNS_ALIDNS_DOMAIN] = AppConfig.DNS_ALIDNS_ADDRESSES
-            hosts[AppConfig.DNS_CLOUDFLARE_DOMAIN] = AppConfig.DNS_CLOUDFLARE_ADDRESSES
-            hosts[AppConfig.DNS_DNSPOD_DOMAIN] = AppConfig.DNS_DNSPOD_ADDRESSES
-            hosts[AppConfig.DNS_GOOGLE_DOMAIN] = AppConfig.DNS_GOOGLE_ADDRESSES
-            hosts[AppConfig.DNS_QUAD9_DOMAIN] = AppConfig.DNS_QUAD9_ADDRESSES
-            hosts[AppConfig.DNS_YANDEX_DOMAIN] = AppConfig.DNS_YANDEX_ADDRESSES
-
 
             // DNS dns
             v2rayConfig.dns = V2rayConfig.DnsBean(


### PR DESCRIPTION
1. userHosts 可覆盖预置 hosts 列表
2. 调用系统解析 `dns.cloudflare.com` 和 `cloudflare-dns.com` 到 hosts (#4660) ，当 userHosts 已有 `dns.cloudflare.com` 和 `cloudflare-dns.com` 时跳过

`dns.cloudflare.com` 和 `cloudflare-dns.com` 似乎近两年解析结果没变过，一直是
```
"cloudflare-dns.com": [
  "104.16.249.249",
  "104.16.248.249",
  "2606:4700::6810:f8f9",
  "2606:4700::6810:f9f9"
],
"dns.cloudflare.com": [
  "104.16.132.229",
  "104.16.133.229",
  "2606:4700::6810:84e5",
  "2606:4700::6810:85e5"
]
```
但是没找到官方说过 `dns.cloudflare.com` 和 `cloudflare-dns.com` 的解析结果不会变，所以我认为实时解析好一点

可能会影响启动速度，介意的话可以写死到 AppConfig 里