### PR TITLE
Fix blinking QSTile when QS panel is opening

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/QSTileService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/QSTileService.kt
@@ -25,14 +25,13 @@ class QSTileService : TileService() {
      * @param state The state to set.
      */
     fun setState(state: Int) {
+        qsTile?.icon = Icon.createWithResource(applicationContext, R.drawable.ic_stat_name)
         if (state == Tile.STATE_INACTIVE) {
             qsTile?.state = Tile.STATE_INACTIVE
             qsTile?.label = getString(R.string.app_name)
-            qsTile?.icon = Icon.createWithResource(applicationContext, R.drawable.ic_stat_name)
         } else if (state == Tile.STATE_ACTIVE) {
             qsTile?.state = Tile.STATE_ACTIVE
             qsTile?.label = V2RayServiceManager.getRunningServerName()
-            qsTile?.icon = Icon.createWithResource(applicationContext, R.drawable.ic_stat_name)
         }
 
         qsTile?.updateTile()
@@ -45,7 +44,11 @@ class QSTileService : TileService() {
     override fun onStartListening() {
         super.onStartListening()
 
-        setState(Tile.STATE_INACTIVE)
+        if (V2RayServiceManager.isRunning()) {
+            setState(Tile.STATE_ACTIVE)
+        } else {
+            setState(Tile.STATE_INACTIVE)
+        }
         mMsgReceive = ReceiveMessageHandler(this)
         val mFilter = IntentFilter(AppConfig.BROADCAST_ACTION_ACTIVITY)
         ContextCompat.registerReceiver(applicationContext, mMsgReceive, mFilter, Utils.receiverFlags())


### PR DESCRIPTION
I fixed the blinking of the QS tile when opening the quick settings panel. Now, when the panel is opened, the service's state is checked. If it's running, the tile is not forcibly disabled but is displayed in an active state.