### PR TITLE
Improves intelligent selection toast and DNS routing

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -91,8 +91,8 @@ object AppConfig {
     const val TAG_DIRECT = "direct"
     const val TAG_BLOCKED = "block"
     const val TAG_FRAGMENT = "fragment"
-    const val TAG_DNS = "dns_module"
-    const val TAG_DOMESTIC_DNS = "domestic_dns"
+    const val TAG_DNS = "dns-module"
+    const val TAG_DOMESTIC_DNS = "domestic-dns"
 
     /** Network-related constants. */
     const val UPLINK = "uplink"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -91,6 +91,8 @@ object AppConfig {
     const val TAG_DIRECT = "direct"
     const val TAG_BLOCKED = "block"
     const val TAG_FRAGMENT = "fragment"
+    const val TAG_DNS = "dns_module"
+    const val TAG_DOMESTIC_DNS = "domestic_dns"
 
     /** Network-related constants. */
     const val UPLINK = "uplink"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -490,6 +490,7 @@ data class V2rayConfig(
             var expectIPs: List<String>? = null,
             val clientIp: String? = null,
             val skipFallback: Boolean? = null,
+            val tag: String? = null,
         )
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -574,18 +574,8 @@ object V2rayConfigManager {
                         address = domesticDns.first(),
                         domains = directDomain,
                         expectIPs = if (isCnRoutingMode) geoipCn else null,
-                        skipFallback = true
-                    )
-                )
-            }
-
-            if (Utils.isPureIpAddress(domesticDns.first())) {
-                v2rayConfig.routing.rules.add(
-                    0, RulesBean(
-                        outboundTag = AppConfig.TAG_DIRECT,
-                        port = "53",
-                        ip = arrayListOf(domesticDns.first()),
-                        domain = null
+                        skipFallback = true,
+                        tag = AppConfig.TAG_DOMESTIC_DNS
                     )
                 )
             }
@@ -626,20 +616,26 @@ object V2rayConfigManager {
             // DNS dns
             v2rayConfig.dns = V2rayConfig.DnsBean(
                 servers = servers,
-                hosts = hosts
+                hosts = hosts,
+                tag = AppConfig.TAG_DNS
             )
 
             // DNS routing
-            if (Utils.isPureIpAddress(remoteDns.first())) {
-                v2rayConfig.routing.rules.add(
-                    0, RulesBean(
-                        outboundTag = AppConfig.TAG_PROXY,
-                        port = "53",
-                        ip = arrayListOf(remoteDns.first()),
-                        domain = null
-                    )
+            v2rayConfig.routing.rules.add(
+                0, RulesBean(
+                    outboundTag = AppConfig.TAG_PROXY,
+                    inboundTag = arrayListOf(AppConfig.TAG_DNS),
+                    domain = null
                 )
-            }
+            )
+
+            v2rayConfig.routing.rules.add(
+                0, RulesBean(
+                    outboundTag = AppConfig.TAG_DIRECT,
+                    inboundTag = arrayListOf(AppConfig.TAG_DOMESTIC_DNS),
+                    domain = null
+                )
+            )
         } catch (e: Exception) {
             Log.e(AppConfig.TAG, "Failed to configure DNS", e)
             return false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -386,6 +386,9 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
         }
 
         R.id.intelligent_selection_all -> {
+            if (MmkvManager.decodeSettingsString(AppConfig.PREF_OUTBOUND_DOMAIN_RESOLVE_METHOD, "1") != "0") {
+                toast(getString(R.string.pre_resolving_domain))
+            }
             mainViewModel.createIntelligentSelectionAll()
             true
         }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -377,5 +377,6 @@
         <item>Least Ping</item>
         <item>Least Load</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -382,5 +382,6 @@
         <item>Least Ping</item>
         <item>Least Load</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -392,5 +392,6 @@
         <item>کم ترین پینگ</item>
         <item>کم ترین بار(لود)</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -391,5 +391,6 @@
         <item>کمترین پینگ</item>
         <item>کمترین بار(لود)</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -391,5 +391,6 @@
         <item>Наименьшая задержка</item>
         <item>Наименьшая нагрузка</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -379,5 +379,6 @@
         <item>Least Ping</item>
         <item>Least Load</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -383,5 +383,6 @@
         <item>最低延迟</item>
         <item>最稳定</item>
     </string-array>
+    <string name="pre_resolving_domain">预解析域名中…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -383,5 +383,6 @@
         <item>Least Ping</item>
         <item>Least Load</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -395,5 +395,6 @@
         <item>Least Ping</item>
         <item>Least Load</item>
     </string-array>
+    <string name="pre_resolving_domain">Pre-resolving domain…</string>
 
 </resources>


### PR DESCRIPTION
1. `智能选择`配置预解析域名前弹出 toast ，避免直接没有提示卡死 https://github.com/2dust/v2rayNG/issues/4830#issuecomment-3178549139
2. 改进 DNS routing，修复当第一个节点不可用时`智能选择`无法使用，并使其不依赖路由设置的`绕过中国DNS` https://github.com/XTLS/Xray-core/pull/4515