### PR TITLE
IPv6 Unreachability Fallback for TLS Configs

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -245,7 +245,14 @@ data class V2rayConfig(
                 var tproxy: String? = null,
                 var mark: Int? = null,
                 var dialerProxy: String? = null,
-                var domainStrategy: String? = null
+                var domainStrategy: String? = null,
+                var happyEyeballs: happyEyeballsBean? = null,
+                )
+            data class happyEyeballsBean(
+                var prioritizeIPv6: Boolean? = null,
+                var maxConcurrentTry: Int? = 4,
+                var tryDelayMs: Int? = 250, // ms
+                var interleave: Int? = null,
             )
 
             data class TlsSettingsBean(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -1009,8 +1009,8 @@ object V2rayConfigManager {
             val domain = item.getServerAddress()
             if (domain.isNullOrEmpty()) continue
 
-            item.ensureSockopt().domainStrategy = "UseIP"
             if (newHosts.containsKey(domain)) {
+                item.ensureSockopt().domainStrategy = "UseIP"
                 item.ensureSockopt().happyEyeballs = StreamSettingsBean.happyEyeballsBean(
                     prioritizeIPv6 = preferIpv6,
                     interleave = 2
@@ -1021,6 +1021,7 @@ object V2rayConfigManager {
             val resolvedIps = HttpUtil.resolveHostToIP(domain, preferIpv6)
             if (resolvedIps.isNullOrEmpty()) continue
 
+            item.ensureSockopt().domainStrategy = "UseIP"
             item.ensureSockopt().happyEyeballs = StreamSettingsBean.happyEyeballsBean(
                 prioritizeIPv6 = preferIpv6,
                 interleave = 2

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -1010,14 +1010,20 @@ object V2rayConfigManager {
             if (domain.isNullOrEmpty()) continue
 
             if (newHosts.containsKey(domain)) {
-                item.ensureSockopt().domainStrategy = if (preferIpv6) "UseIPv6v4" else "UseIPv4v6"
+                item.ensureSockopt().happyEyeballs = StreamSettingsBean.happyEyeballsBean(
+                    prioritizeIPv6 = preferIpv6,
+                    interleave = 2
+                )
                 continue
             }
 
             val resolvedIps = HttpUtil.resolveHostToIP(domain, preferIpv6)
             if (resolvedIps.isNullOrEmpty()) continue
 
-            item.ensureSockopt().domainStrategy = if (preferIpv6) "UseIPv6v4" else "UseIPv4v6"
+            item.ensureSockopt().happyEyeballs = StreamSettingsBean.happyEyeballsBean(
+                prioritizeIPv6 = preferIpv6,
+                interleave = 2
+            )
             newHosts[domain] = if (resolvedIps.size == 1) {
                 resolvedIps[0]
             } else {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -1009,6 +1009,7 @@ object V2rayConfigManager {
             val domain = item.getServerAddress()
             if (domain.isNullOrEmpty()) continue
 
+            item.ensureSockopt().domainStrategy = "UseIP"
             if (newHosts.containsKey(domain)) {
                 item.ensureSockopt().happyEyeballs = StreamSettingsBean.happyEyeballsBean(
                     prioritizeIPv6 = preferIpv6,


### PR DESCRIPTION
If the configuration uses TLS and prefers IPv6, but IPv6 is not reachable or ISP not supported, the connection should gracefully fall back to IPv4. To handle this reliably, the core’s built-in Happy Eyeballs function is used to automatically select the best available address family and avoid connection failures.
