### PR TITLE
fix a throws error

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -509,9 +509,10 @@ object V2rayConfigManager {
                 //hev-socks5-tunnel dns routing
                 v2rayConfig.routing.rules.add(
                     0, RulesBean(
-                        type = "field",
+                        inboundTag = arrayListOf("socks"),
+                        outboundTag = "dns-out",
                         port = "53",
-                        outboundTag = "dns-out"
+                        type = "field"
                     )
                 )
             }


### PR DESCRIPTION
还是需要使用inboundTag = arrayListOf("socks"),否则hev-socks5-tunnel使用本地dns模式日志会抛出大量错误[Error] app/dns udp:1.1.1.1:53 cannot find the pending request。