### PR TITLE
better export fix

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -533,8 +533,8 @@ class MainActivity : BaseActivity(), NavigationView.OnNavigationItemSelectedList
     private fun exportAll() {
         binding.pbWaiting.show()
         lifecycleScope.launch(Dispatchers.IO) {
-            val ret = mainViewModel.exportAllServer()
             launch(Dispatchers.Main) {
+                val ret = mainViewModel.exportAllServer()
                 if (ret > 0)
                     toast(getString(R.string.title_export_config_count, ret))
                 else


### PR DESCRIPTION
Make sure setClipboard is safe to call from Main. setClipboard  is called from shareNonCustomConfigsToClipboard which in turn called from exportAllServer. so exportAllServer requires Dispatchers.Main context