### PR TITLE
Only list packages that have internet access permission

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/AppManagerUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/AppManagerUtil.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.util
 
+import android.Manifest
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
@@ -21,6 +22,11 @@ object AppManagerUtil {
             val apps = ArrayList<AppInfo>()
 
             for (pkg in packages) {
+                val hasInternetPermission = when (pkg.packageName) {
+                    "android" -> true
+                    else -> pkg.requestedPermissions?.contains(Manifest.permission.INTERNET) == true
+                }
+                if (!hasInternetPermission) continue
                 val applicationInfo = pkg.applicationInfo ?: continue
 
                 val appName = applicationInfo.loadLabel(packageManager).toString()


### PR DESCRIPTION
Only list packages that have internet access permission, for better readability and faster loading. This is [what NekoBox does](https://github.com/MatsuriDayo/NekoBoxForAndroid/blob/50ca7127fd5f943c3673bf1a3fbc21eaa0e4aeeb/app/src/main/java/io/nekohasekai/sagernet/utils/PackageCache.kt#L46).

If this is not expected behavior, disregard and close this pull request.