### PR TITLE
Adjust DNS routing

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -623,17 +623,16 @@ object V2rayConfigManager {
 
             // DNS routing
             v2rayConfig.routing.rules.add(
-                0, RulesBean(
-                    outboundTag = AppConfig.TAG_PROXY,
-                    inboundTag = arrayListOf(AppConfig.TAG_DNS),
+                RulesBean(
+                    outboundTag = AppConfig.TAG_DIRECT,
+                    inboundTag = arrayListOf(AppConfig.TAG_DOMESTIC_DNS),
                     domain = null
                 )
             )
-
             v2rayConfig.routing.rules.add(
-                0, RulesBean(
-                    outboundTag = AppConfig.TAG_DIRECT,
-                    inboundTag = arrayListOf(AppConfig.TAG_DOMESTIC_DNS),
+                RulesBean(
+                    outboundTag = AppConfig.TAG_PROXY,
+                    inboundTag = arrayListOf(AppConfig.TAG_DNS),
                     domain = null
                 )
             )


### PR DESCRIPTION
调整 DNS routing，将其作为保底机制，避免有用户 remote dns 中填入本地搭建的 DNS ，无法使用