### PR TITLE
Fix XHTTP option processing

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -230,7 +230,7 @@ data class V2rayConfig(
                 var path: String? = null,
                 var host: String? = null,
                 var mode: String? = null,
-                var extra: Any? = null,
+                var downloadSettings: Any? = null,
             )
 
             data class HttpSettingsBean(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -1190,7 +1190,7 @@ object V2rayConfigManager {
                 sni = host
                 xhttpSetting.path = path ?: "/"
                 xhttpSetting.mode = xhttpMode
-                xhttpSetting.extra = JsonUtil.parseString(xhttpExtra)
+                xhttpSetting.downloadSettings = JsonUtil.parseString(xhttpExtra)
                 streamSettings.xhttpSettings = xhttpSetting
             }
 


### PR DESCRIPTION
~~XHTTP expects a `streamSettings.xhttpSettings.downloadSettings` object (with fields `address`, `port`, `realitySettings`, etc) that is mistakenly named `extra` instead of `downloadSettings`, which causes these settings to be ignored and have no effect.~~

~~This makes it impossible to achieve uplink and downlink separation.
You might want to additionally rename other parts of code accordingly, this is the least amount of change that fixed the problem for me.~~

~~P.S. this is my first time contributing to a FOSS project, yay! I hope you accept my fix :3~~