### PR TITLE
fix crash while compiling tun2socks

### DIFF
--- a/compile-hev-socks5-tunnel.sh
+++ b/compile-hev-socks5-tunnel.sh
@@ -15,6 +15,7 @@ clear_tmp () {
   rm -rf $TMPDIR
 }
 trap 'echo -e "Aborted, error $? in command: $BASH_COMMAND"; trap ERR; clear_tmp; exit 1' ERR INT
+: <<'COMMENT'
 install -m644 $__dir/tun2socks.mk $TMPDIR/
 pushd $TMPDIR
 ln -s $__dir/badvpn badvpn
@@ -30,8 +31,8 @@ $NDK_HOME/ndk-build \
 cp -r $TMPDIR/libs $__dir/
 popd
 rm -rf $TMPDIR
+COMMENT
 
-: <<'COMMENT'
 #build hev-socks5-tunnel
 HEVTUN_TMP=$(mktemp -d)
 trap 'rm -rf "$HEVTUN_TMP"' EXIT
@@ -57,4 +58,3 @@ cp -r "$HEVTUN_TMP/libs/"* "$__dir/libs/"
 popd
 
 rm -rf "$HEVTUN_TMP"
-COMMENT


### PR DESCRIPTION
在Mac book pro上执行: ./compile-tun2socks.sh, 会出现如下错误：Users/name/Library/Android/sdk/ndk/29.0.14206865/build/ndk-build: line 181: 60256 Segmentation fault: 11 "$GNUMAKE" -O -f "$PROGDIR/core/build-local.mk" 
Aborted, error 139 in command: "$NDK_HOME/ndk-build" NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=jni/Android.mk "APP_ABI=armeabi-v7a arm64-v8a x86 x86_64" APP_PLATFORM=android-21 NDK_LIBS_OUT="$HEVTUN_TMP/libs" NDK_OUT="$HEVTUN_TMP/obj" "APP_CFLAGS=-O3 -DPKGNAME=com/v2ray/ang/service" "APP_LDFLAGS=-Wl,--build-id=none -Wl,--hash-style=gnu"

解决办法： 将编译 tun2socks和 hev-socks5-tunnel 分拆成两个脚本即可解决。