### PR TITLE
fix hevtun loglevel

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
@@ -74,10 +74,7 @@ class TProxyService(
             appendLine("misc:")
             appendLine("  tcp-read-write-timeout: ${MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_RW_TIMEOUT) ?: AppConfig.HEVTUN_RW_TIMEOUT}")
             appendLine("  udp-read-write-timeout: ${MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_RW_TIMEOUT) ?: AppConfig.HEVTUN_RW_TIMEOUT}")
-            val hevTunLogLevel = MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_LOGLEVEL) ?: "none"
-            if (hevTunLogLevel != "none") {
-                appendLine("  log-level: $hevTunLogLevel")
-            }
+            appendLine("  log-level: ${MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_LOGLEVEL) ?: "warn"}")
         }
     }
 

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -119,9 +119,9 @@
     </string-array>
 
     <string-array name="hev_tunnel_loglevel" translatable="false">
-        <item>none</item>
         <item>error</item>
         <item>warn</item>
+        <item>info</item>
         <item>debug</item>
     </string-array>
 

--- a/V2rayNG/app/src/main/res/xml/pref_settings.xml
+++ b/V2rayNG/app/src/main/res/xml/pref_settings.xml
@@ -85,7 +85,7 @@
             android:title="@string/title_pref_use_hev_tunnel" />
 
         <ListPreference
-            android:defaultValue="none"
+            android:defaultValue="warn"
             android:entries="@array/hev_tunnel_loglevel"
             android:entryValues="@array/hev_tunnel_loglevel"
             android:key="pref_hev_tunnel_loglevel"


### PR DESCRIPTION
if change to debug,then change to none. It is still debug unless the app is restarted.The correct one should be to warn.[hev-config-loglevel](https://github.com/heiher/hev-socks5-tunnel/blob/main/src/hev-config.c#L308-L319)