### PR TITLE
 Add unit tests for ShadowsocksFmt protocol formatter

### DIFF
--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -1,0 +1,288 @@
+package com.v2ray.ang.fmt
+
+import android.util.Base64
+import android.util.Log
+import com.v2ray.ang.dto.EConfigType
+import com.v2ray.ang.dto.ProfileItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.After
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.mockStatic
+import java.util.Base64 as JavaBase64
+
+/**
+ * Unit tests for ShadowsocksFmt class.
+ *
+ * Tests cover:
+ * - Parsing SIP002 format URLs (modern format)
+ * - Parsing legacy format URLs
+ * - Converting ProfileItem to URI
+ * - Various encryption methods
+ */
+class ShadowsocksFmtTest {
+
+    private lateinit var mockBase64: MockedStatic<Base64>
+    private lateinit var mockLog: MockedStatic<Log>
+
+    @Before
+    fun setUp() {
+        mockLog = mockStatic(Log::class.java, Mockito.RETURNS_DEFAULTS)
+
+        mockBase64 = mockStatic(Base64::class.java)
+        // Mock decode
+        mockBase64.`when`<ByteArray> {
+            Base64.decode(Mockito.anyString(), Mockito.anyInt())
+        }.thenAnswer { invocation ->
+            val input = invocation.arguments[0] as String
+            try {
+                JavaBase64.getDecoder().decode(input)
+            } catch (e: Exception) {
+                try {
+                    JavaBase64.getUrlDecoder().decode(input)
+                } catch (e2: Exception) {
+                    ByteArray(0)
+                }
+            }
+        }
+        // Mock encode
+        mockBase64.`when`<String> {
+            Base64.encodeToString(Mockito.any(ByteArray::class.java), Mockito.anyInt())
+        }.thenAnswer { invocation ->
+            val input = invocation.arguments[0] as ByteArray
+            JavaBase64.getEncoder().withoutPadding().encodeToString(input)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockLog.close()
+        mockBase64.close()
+    }
+
+    // ==================== SIP002 Format Tests ====================
+
+    @Test
+    fun `parseSip002 valid URL with base64 encoded userinfo`() {
+        val methodPassword = "aes-256-gcm:my-secret-password"
+        val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+        val ssUrl = "ss://${base64UserInfo}@example.com:8388#Test%20Server"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("Test Server", result?.remarks)
+        assertEquals("example.com", result?.server)
+        assertEquals("8388", result?.serverPort)
+        assertEquals("aes-256-gcm", result?.method)
+        assertEquals("my-secret-password", result?.password)
+    }
+
+    @Test
+    fun `parseSip002 valid URL with plain text userinfo`() {
+        val ssUrl = "ss://aes-256-gcm:mypassword@example.com:8388#Plain%20Server"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("Plain Server", result?.remarks)
+        assertEquals("aes-256-gcm", result?.method)
+        assertEquals("mypassword", result?.password)
+    }
+
+    @Test
+    fun `parseSip002 with chacha20 encryption`() {
+        val methodPassword = "chacha20-ietf-poly1305:secret123"
+        val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+        val ssUrl = "ss://${base64UserInfo}@ss.example.com:443#ChaCha20"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("chacha20-ietf-poly1305", result?.method)
+    }
+
+    @Test
+    fun `parseSip002 returns null for empty host`() {
+        val methodPassword = "aes-256-gcm:password"
+        val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+        val ssUrl = "ss://${base64UserInfo}@:8388#No%20Host"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseSip002 returns null for invalid port`() {
+        val methodPassword = "aes-256-gcm:password"
+        val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+        val ssUrl = "ss://${base64UserInfo}@example.com:-1#Invalid%20Port"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNull(result)
+    }
+
+    // ==================== Legacy Format Tests ====================
+
+    @Test
+    fun `parseLegacy valid URL`() {
+        val legacyContent = "aes-256-gcm:password123@legacy.example.com:8388"
+        val base64Encoded = JavaBase64.getEncoder().encodeToString(legacyContent.toByteArray())
+        val ssUrl = "ss://${base64Encoded}#Legacy%20Server"
+
+        val result = ShadowsocksFmt.parseLegacy(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("Legacy Server", result?.remarks)
+        assertEquals("legacy.example.com", result?.server)
+        assertEquals("8388", result?.serverPort)
+        assertEquals("aes-256-gcm", result?.method)
+        assertEquals("password123", result?.password)
+    }
+
+    @Test
+    fun `parseLegacy with partially encoded URL`() {
+        val methodPassword = "chacha20-ietf-poly1305:my-pass"
+        val base64Part = JavaBase64.getEncoder().encodeToString(methodPassword.toByteArray())
+        val ssUrl = "ss://${base64Part}@partial.example.com:443#Partial%20Encoded"
+
+        val result = ShadowsocksFmt.parseLegacy(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("Partial Encoded", result?.remarks)
+        assertEquals("partial.example.com", result?.server)
+        assertEquals("chacha20-ietf-poly1305", result?.method)
+    }
+
+    @Test
+    fun `parseLegacy returns null for invalid format`() {
+        val invalidContent = "not-a-valid-format"
+        val base64Encoded = JavaBase64.getEncoder().encodeToString(invalidContent.toByteArray())
+        val ssUrl = "ss://${base64Encoded}#Invalid"
+
+        val result = ShadowsocksFmt.parseLegacy(ssUrl)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseLegacy handles password with colon`() {
+        val legacyContent = "aes-256-gcm:pass:word:with:colons@example.com:8388"
+        val base64Encoded = JavaBase64.getEncoder().encodeToString(legacyContent.toByteArray())
+        val ssUrl = "ss://${base64Encoded}#Colon%20Password"
+
+        val result = ShadowsocksFmt.parseLegacy(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("pass:word:with:colons", result?.password)
+    }
+
+    // ==================== toUri Tests ====================
+
+    @Test
+    fun `toUri creates valid SIP002 URL`() {
+        val config = ProfileItem.create(EConfigType.SHADOWSOCKS).apply {
+            remarks = "Test Server"
+            server = "example.com"
+            serverPort = "8388"
+            method = "aes-256-gcm"
+            password = "my-secret-password"
+        }
+
+        val uri = ShadowsocksFmt.toUri(config)
+
+        assertTrue(uri.contains("@example.com:8388"))
+        assertTrue(uri.contains("#Test%20Server"))
+
+        // Verify the base64 part
+        val base64Part = uri.substringBefore("@")
+        val decoded = String(JavaBase64.getDecoder().decode(base64Part))
+        assertEquals("aes-256-gcm:my-secret-password", decoded)
+    }
+
+    @Test
+    fun `toUri handles IPv6 address`() {
+        val config = ProfileItem.create(EConfigType.SHADOWSOCKS).apply {
+            remarks = "IPv6 Server"
+            server = "2001:db8::1"
+            serverPort = "8388"
+            method = "aes-256-gcm"
+            password = "password"
+        }
+
+        val uri = ShadowsocksFmt.toUri(config)
+
+        assertTrue(uri.contains("[2001:db8::1]:8388"))
+    }
+
+    // ==================== Round-trip Tests ====================
+
+    @Test
+    fun `parse and toUri round-trip preserves data`() {
+        val methodPassword = "chacha20-ietf-poly1305:round-trip-password"
+        val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+        val originalUrl = "ss://${base64UserInfo}@roundtrip.example.com:443#Round%20Trip%20Test"
+
+        val parsed = ShadowsocksFmt.parse(originalUrl)
+        assertNotNull(parsed)
+
+        val regeneratedUri = ShadowsocksFmt.toUri(parsed!!)
+        val reparsed = ShadowsocksFmt.parse("ss://$regeneratedUri")
+        assertNotNull(reparsed)
+
+        assertEquals(parsed.remarks, reparsed?.remarks)
+        assertEquals(parsed.server, reparsed?.server)
+        assertEquals(parsed.serverPort, reparsed?.serverPort)
+        assertEquals(parsed.method, reparsed?.method)
+        assertEquals(parsed.password, reparsed?.password)
+    }
+
+    // ==================== Edge Cases ====================
+
+    @Test
+    fun `parse handles empty remarks gracefully`() {
+        val methodPassword = "aes-256-gcm:password"
+        val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+        val ssUrl = "ss://${base64UserInfo}@example.com:8388#"
+
+        val result = ShadowsocksFmt.parse(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("none", result?.remarks)
+    }
+
+    @Test
+    fun `parseSip002 handles different encryption methods`() {
+        val methods = listOf("aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305")
+
+        for (method in methods) {
+            val methodPassword = "$method:testpass"
+            val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
+            val ssUrl = "ss://${base64UserInfo}@example.com:8388#$method"
+
+            val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+            assertNotNull("Failed for method: $method", result)
+            assertEquals(method, result?.method)
+        }
+    }
+
+    @Test
+    fun `parseLegacy converts method to lowercase`() {
+        val legacyContent = "AES-256-GCM:password@example.com:8388"
+        val base64Encoded = JavaBase64.getEncoder().encodeToString(legacyContent.toByteArray())
+        val ssUrl = "ss://${base64Encoded}#Uppercase%20Method"
+
+        val result = ShadowsocksFmt.parseLegacy(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("aes-256-gcm", result?.method)
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -314,6 +314,13 @@ class ShadowsocksFmtTest {
         assertNotNull(parsed)
 
         val regeneratedUri = ShadowsocksFmt.toUri(parsed!!)
+
+        // Verify toUri returns without scheme, so we need to prepend it
+        assertFalse(
+            "toUri should return URI without scheme",
+            regeneratedUri.startsWith(SS_SCHEME)
+        )
+
         val reparsed = ShadowsocksFmt.parse("$SS_SCHEME$regeneratedUri")
         assertNotNull(reparsed)
 

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -51,12 +51,27 @@ class ShadowsocksFmtTest {
                 }
             }
         }
-        // Mock encode
+        // Mock encode with proper flag handling
         mockBase64.`when`<String> {
             Base64.encodeToString(Mockito.any(ByteArray::class.java), Mockito.anyInt())
         }.thenAnswer { invocation ->
             val input = invocation.arguments[0] as ByteArray
-            JavaBase64.getEncoder().withoutPadding().encodeToString(input)
+            val flags = invocation.arguments[1] as Int
+
+            val isUrlSafe = (flags and Base64.URL_SAFE) != 0
+            val noPadding = (flags and Base64.NO_PADDING) != 0
+
+            var encoder = if (isUrlSafe) {
+                JavaBase64.getUrlEncoder()
+            } else {
+                JavaBase64.getEncoder()
+            }
+
+            if (noPadding) {
+                encoder = encoder.withoutPadding()
+            }
+
+            encoder.encodeToString(input)
         }
     }
 

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.mockito.MockedStatic
 import org.mockito.Mockito
 import org.mockito.Mockito.mockStatic
+import java.net.URLDecoder
 import java.util.Base64 as JavaBase64
 
 /**
@@ -201,9 +202,10 @@ class ShadowsocksFmtTest {
         assertTrue(uri.contains("@example.com:8388"))
         assertTrue(uri.contains("#Test%20Server"))
 
-        // Verify the base64 part
+        // Verify the base64 part (URL decode first, then Base64 decode)
         val base64Part = uri.substringBefore("@")
-        val decoded = String(JavaBase64.getDecoder().decode(base64Part))
+        val urlDecoded = URLDecoder.decode(base64Part, Charsets.UTF_8.name())
+        val decoded = String(JavaBase64.getDecoder().decode(urlDecoded))
         assertEquals("aes-256-gcm:my-secret-password", decoded)
     }
 

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -69,7 +69,7 @@ class ShadowsocksFmtTest {
     // ==================== SIP002 Format Tests ====================
 
     @Test
-    fun `parseSip002 valid URL with base64 encoded userinfo`() {
+    fun test_parseSip002_validUrlWithBase64EncodedUserinfo() {
         val methodPassword = "aes-256-gcm:my-secret-password"
         val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
         val ssUrl = "ss://${base64UserInfo}@example.com:8388#Test%20Server"
@@ -85,7 +85,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseSip002 valid URL with plain text userinfo`() {
+    fun test_parseSip002_validUrlWithPlainTextUserinfo() {
         val ssUrl = "ss://aes-256-gcm:mypassword@example.com:8388#Plain%20Server"
 
         val result = ShadowsocksFmt.parseSip002(ssUrl)
@@ -97,7 +97,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseSip002 with chacha20 encryption`() {
+    fun test_parseSip002_withChacha20Encryption() {
         val methodPassword = "chacha20-ietf-poly1305:secret123"
         val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
         val ssUrl = "ss://${base64UserInfo}@ss.example.com:443#ChaCha20"
@@ -109,7 +109,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseSip002 returns null for empty host`() {
+    fun test_parseSip002_returnsNullForEmptyHost() {
         val methodPassword = "aes-256-gcm:password"
         val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
         val ssUrl = "ss://${base64UserInfo}@:8388#No%20Host"
@@ -120,7 +120,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseSip002 returns null for invalid port`() {
+    fun test_parseSip002_returnsNullForInvalidPort() {
         val methodPassword = "aes-256-gcm:password"
         val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
         val ssUrl = "ss://${base64UserInfo}@example.com:-1#Invalid%20Port"
@@ -133,7 +133,7 @@ class ShadowsocksFmtTest {
     // ==================== Legacy Format Tests ====================
 
     @Test
-    fun `parseLegacy valid URL`() {
+    fun test_parseLegacy_validUrl() {
         val legacyContent = "aes-256-gcm:password123@legacy.example.com:8388"
         val base64Encoded = JavaBase64.getEncoder().encodeToString(legacyContent.toByteArray())
         val ssUrl = "ss://${base64Encoded}#Legacy%20Server"
@@ -149,7 +149,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseLegacy with partially encoded URL`() {
+    fun test_parseLegacy_withPartiallyEncodedUrl() {
         val methodPassword = "chacha20-ietf-poly1305:my-pass"
         val base64Part = JavaBase64.getEncoder().encodeToString(methodPassword.toByteArray())
         val ssUrl = "ss://${base64Part}@partial.example.com:443#Partial%20Encoded"
@@ -163,7 +163,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseLegacy returns null for invalid format`() {
+    fun test_parseLegacy_returnsNullForInvalidFormat() {
         val invalidContent = "not-a-valid-format"
         val base64Encoded = JavaBase64.getEncoder().encodeToString(invalidContent.toByteArray())
         val ssUrl = "ss://${base64Encoded}#Invalid"
@@ -174,7 +174,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseLegacy handles password with colon`() {
+    fun test_parseLegacy_handlesPasswordWithColon() {
         val legacyContent = "aes-256-gcm:pass:word:with:colons@example.com:8388"
         val base64Encoded = JavaBase64.getEncoder().encodeToString(legacyContent.toByteArray())
         val ssUrl = "ss://${base64Encoded}#Colon%20Password"
@@ -188,7 +188,7 @@ class ShadowsocksFmtTest {
     // ==================== toUri Tests ====================
 
     @Test
-    fun `toUri creates valid SIP002 URL`() {
+    fun test_toUri_createsValidSip002Url() {
         val config = ProfileItem.create(EConfigType.SHADOWSOCKS).apply {
             remarks = "Test Server"
             server = "example.com"
@@ -210,7 +210,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `toUri handles IPv6 address`() {
+    fun test_toUri_handlesIpv6Address() {
         val config = ProfileItem.create(EConfigType.SHADOWSOCKS).apply {
             remarks = "IPv6 Server"
             server = "2001:db8::1"
@@ -227,7 +227,7 @@ class ShadowsocksFmtTest {
     // ==================== Round-trip Tests ====================
 
     @Test
-    fun `parse and toUri round-trip preserves data`() {
+    fun test_parseAndToUri_roundTripPreservesData() {
         val methodPassword = "chacha20-ietf-poly1305:round-trip-password"
         val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
         val originalUrl = "ss://${base64UserInfo}@roundtrip.example.com:443#Round%20Trip%20Test"
@@ -249,7 +249,7 @@ class ShadowsocksFmtTest {
     // ==================== Edge Cases ====================
 
     @Test
-    fun `parse handles empty remarks gracefully`() {
+    fun test_parse_handlesEmptyRemarksGracefully() {
         val methodPassword = "aes-256-gcm:password"
         val base64UserInfo = JavaBase64.getUrlEncoder().withoutPadding().encodeToString(methodPassword.toByteArray())
         val ssUrl = "ss://${base64UserInfo}@example.com:8388#"
@@ -261,7 +261,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseSip002 handles different encryption methods`() {
+    fun test_parseSip002_handlesDifferentEncryptionMethods() {
         val methods = listOf("aes-128-gcm", "aes-256-gcm", "chacha20-ietf-poly1305")
 
         for (method in methods) {
@@ -277,7 +277,7 @@ class ShadowsocksFmtTest {
     }
 
     @Test
-    fun `parseLegacy converts method to lowercase`() {
+    fun test_parseLegacy_convertsMethodToLowercase() {
         val legacyContent = "AES-256-GCM:password@example.com:8388"
         val base64Encoded = JavaBase64.getEncoder().encodeToString(legacyContent.toByteArray())
         val ssUrl = "ss://${base64Encoded}#Uppercase%20Method"

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.v2ray.ang.dto.EConfigType
 import com.v2ray.ang.dto.ProfileItem
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -268,6 +269,9 @@ class ShadowsocksFmtTest {
         }
 
         val uri = ShadowsocksFmt.toUri(config)
+
+        // Verify URI does not include scheme (toUri returns without ss:// prefix)
+        assertFalse("toUri should not include scheme prefix", uri.startsWith(SS_SCHEME))
 
         assertTrue(uri.contains("@example.com:8388"))
         assertTrue(uri.contains("#Test%20Server"))


### PR DESCRIPTION
  - Add comprehensive test coverage for Shadowsocks URL parsing
  - Test SIP002 format (modern) with base64 encoded userinfo
  - Test legacy format with full base64 encoding
  - Test URI generation and round-trip consistency
  - Cover edge cases: IPv6 addresses, empty remarks, various encryption methods
  - Mock Android Base64 and Log classes for unit test execution