### PR TITLE
Fix: Stop service when app is removed from recents (Locked state)

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayProxyOnlyService.kt
@@ -39,6 +39,15 @@ class V2RayProxyOnlyService : Service(), ServiceControl {
     }
 
     /**
+     * Called when the user removes the app from the recent tasks list.
+     * @param rootIntent The original root Intent.
+     */
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        stopService()
+    }
+
+    /**
      * Gets the service instance.
      * @return The service instance.
      */

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -89,6 +89,11 @@ class V2RayVpnService : VpnService(), ServiceControl {
         NotificationManager.cancelNotification()
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        stopV2Ray()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         setupVpnService()
         startService()


### PR DESCRIPTION
Fixes an issue where the notification persists after swiping away the app, specifically when the app is 'Locked' in the Android task switcher.

Implements onTaskRemoved in V2RayVpnService and V2RayProxyOnlyService to ensure services effectively stop.