### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         submodules: 'recursive'
         fetch-depth: '0'
@@ -78,7 +78,7 @@ jobs:
         out-file-path: V2rayNG/app/libs/
 
     - name: Setup Java
-      uses: actions/setup-java@v4.7.0
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '21'
@@ -99,21 +99,21 @@ jobs:
         ./gradlew assembleRelease -Pandroid.injected.signing.store.file=${{ steps.android_keystore.outputs.filePath }} -Pandroid.injected.signing.store.password=${{ secrets.APP_KEYSTORE_PASSWORD }} -Pandroid.injected.signing.key.alias=${{ secrets.APP_KEYSTORE_ALIAS }} -Pandroid.injected.signing.key.password=${{ secrets.APP_KEY_PASSWORD }}
     
     - name: Upload arm64-v8a APK
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v6
       if: ${{  success() }}
       with:
         name: arm64-v8a
         path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/*/release/*arm64-v8a*.apk
 
     - name: Upload armeabi-v7a APK
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v6
       if: ${{  success() }}
       with:
         name: armeabi-v7a
         path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/*/release/*armeabi-v7a*.apk
 
     - name: Upload x86 APK
-      uses: actions/upload-artifact@v4.6.2
+      uses: actions/upload-artifact@v6
       if: ${{  success() }}
       with:
         name: x86-apk

--- a/.github/workflows/fastlane.yml
+++ b/.github/workflows/fastlane.yml
@@ -11,6 +11,6 @@ jobs:
   go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate Fastlane Supply Metadata
         uses: ashutoshgngwr/validate-fastlane-supply-metadata@v2.1.0


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-java` from `v4.7.0` to `v5` in `.github/workflows/build.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/build.yml`
- Updated `actions/upload-artifact` from `v4.6.2` to `v6` in `.github/workflows/build.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/fastlane.yml`
