### PR TITLE
Add Smart Connect and background server testing

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -44,6 +44,13 @@ object AppConfig {
     const val SUBSCRIPTION_AUTO_UPDATE_INTERVAL = "pref_auto_update_interval"
     const val SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL = "1440" // Default is 24 hours
     const val SUBSCRIPTION_UPDATE_TASK_NAME = "subscription_updater"
+
+    /** Auto server testing preferences. */
+    const val PREF_AUTO_SERVER_TEST_ENABLED = "pref_auto_server_test_enabled"
+    const val PREF_AUTO_SERVER_TEST_INTERVAL = "pref_auto_server_test_interval"
+    const val PREF_AUTO_SERVER_SWITCH_ENABLED = "pref_auto_server_switch_enabled"
+    const val AUTO_SERVER_TEST_TASK_NAME = "auto_server_tester"
+    const val DEFAULT_AUTO_TEST_INTERVAL = "60"
     const val PREF_SPEED_ENABLED = "pref_speed_enabled"
     const val PREF_CONFIRM_REMOVE = "pref_confirm_remove"
     const val PREF_START_SCAN_IMMEDIATE = "pref_start_scan_immediate"
@@ -161,6 +168,8 @@ object AppConfig {
     const val RAY_NG_CHANNEL_NAME = "v2rayNG Background Service"
     const val SUBSCRIPTION_UPDATE_CHANNEL = "subscription_update_channel"
     const val SUBSCRIPTION_UPDATE_CHANNEL_NAME = "Subscription Update Service"
+    const val AUTO_SWITCH_CHANNEL = "auto_switch_channel"
+    const val AUTO_SWITCH_CHANNEL_NAME = "Auto Server Switch"
 
     /** Protocols Scheme **/
     const val VMESS = "vmess://"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/ServerAffiliationInfo.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/ServerAffiliationInfo.kt
@@ -1,6 +1,10 @@
 package com.v2ray.ang.dto
 
-data class ServerAffiliationInfo(var testDelayMillis: Long = 0L) {
+data class ServerAffiliationInfo(
+    var testDelayMillis: Long = 0L,
+    var lastTestTime: Long = 0L,
+    var testSource: String = ""
+) {
     fun getTestDelayString(): String {
         if (testDelayMillis == 0L) {
             return ""

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/BackgroundServerTester.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/BackgroundServerTester.kt
@@ -1,0 +1,285 @@
+package com.v2ray.ang.handler
+
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkerParameters
+import androidx.work.multiprocess.RemoteWorkManager
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
+
+/**
+ * Handles periodic server testing and automatic server switching.
+ * Uses WorkManager for reliable background execution.
+ */
+object BackgroundServerTester {
+
+    private const val NOTIFICATION_ID = 4
+    private const val SWITCH_THRESHOLD = 0.8 // Switch if new server is 20% faster
+
+    data class TestResult(
+        val guid: String,
+        val remarks: String,
+        val delay: Long
+    )
+
+    /**
+     * WorkManager task for background server testing and auto-switching.
+     */
+    class TestAndSwitchTask(context: Context, params: WorkerParameters) :
+        CoroutineWorker(context, params) {
+
+        private val notificationManager = NotificationManagerCompat.from(applicationContext)
+
+        @SuppressLint("MissingPermission")
+        override suspend fun doWork(): Result {
+            Log.i(AppConfig.TAG, "Background server testing starting")
+
+            createNotificationChannel()
+
+            val subscriptionId = MmkvManager.decodeSettingsString(AppConfig.CACHE_SUBSCRIPTION_ID, "") ?: ""
+            val servers = MmkvManager.getServersBySubscriptionId(subscriptionId)
+            if (servers.isEmpty()) {
+                Log.i(AppConfig.TAG, "No servers to test")
+                return Result.success()
+            }
+
+            showNotification(applicationContext.getString(R.string.smart_connect_testing))
+
+            val bestResult = testServers(applicationContext, servers, "background")
+                .filter { it.delay > 0 }
+                .minByOrNull { it.delay }
+
+            if (bestResult != null) {
+                Log.i(AppConfig.TAG, "Best server: ${bestResult.remarks} (${bestResult.delay}ms)")
+                handleAutoSwitch(bestResult)
+            } else {
+                Log.w(AppConfig.TAG, "No working servers found")
+            }
+
+            cancelNotification()
+            return Result.success()
+        }
+
+        private fun createNotificationChannel() {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(
+                    AppConfig.AUTO_SWITCH_CHANNEL,
+                    AppConfig.AUTO_SWITCH_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_LOW
+                )
+                notificationManager.createNotificationChannel(channel)
+            }
+        }
+
+        private fun buildNotification(): NotificationCompat.Builder {
+            return NotificationCompat.Builder(applicationContext, AppConfig.AUTO_SWITCH_CHANNEL)
+                .setWhen(0)
+                .setTicker("Testing")
+                .setContentTitle(applicationContext.getString(R.string.title_auto_server_test))
+                .setSmallIcon(R.drawable.ic_stat_name)
+                .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+        }
+
+        @SuppressLint("MissingPermission")
+        private fun showNotification(text: String) {
+            try {
+                notificationManager.notify(NOTIFICATION_ID, buildNotification().setContentText(text).build())
+            } catch (e: Exception) {
+                Log.w(AppConfig.TAG, "Failed to show notification", e)
+            }
+        }
+
+        private fun cancelNotification() {
+            try {
+                notificationManager.cancel(NOTIFICATION_ID)
+            } catch (e: Exception) {
+                Log.w(AppConfig.TAG, "Failed to cancel notification", e)
+            }
+        }
+
+        @SuppressLint("MissingPermission")
+        private fun handleAutoSwitch(bestResult: TestResult) {
+            val autoSwitchEnabled = MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SERVER_SWITCH_ENABLED, true)
+            val currentServer = MmkvManager.getSelectServer()
+
+            if (!autoSwitchEnabled || !V2RayServiceManager.isRunning() || bestResult.guid == currentServer) {
+                return
+            }
+
+            val currentDelay = MmkvManager.decodeServerAffiliationInfo(currentServer ?: "")?.testDelayMillis ?: Long.MAX_VALUE
+            val shouldSwitch = currentDelay <= 0 || bestResult.delay < currentDelay * SWITCH_THRESHOLD
+
+            if (!shouldSwitch) {
+                Log.i(AppConfig.TAG, "Current server is good enough, not switching")
+                return
+            }
+
+            val switched = V2RayServiceManager.switchServer(applicationContext, bestResult.guid)
+            if (switched) {
+                showNotification(
+                    applicationContext.getString(
+                        R.string.notification_server_switched,
+                        bestResult.remarks,
+                        bestResult.delay
+                    )
+                )
+                Log.i(AppConfig.TAG, "Switched to ${bestResult.remarks}")
+            }
+        }
+    }
+
+    /**
+     * Tests all servers and returns results.
+     *
+     * @param context The application context.
+     * @param serverGuids The list of server GUIDs to test.
+     * @param testSource The source of the test (manual, background, post-sub).
+     * @return A list of test results.
+     */
+    suspend fun testServers(
+        context: Context,
+        serverGuids: List<String>,
+        testSource: String = "manual"
+    ): List<TestResult> = coroutineScope {
+        val testUrl = SettingsManager.getDelayTestUrl()
+
+        // Use limited parallelism to be battery-efficient
+        val parallelism = Runtime.getRuntime().availableProcessors().coerceAtMost(4)
+
+        serverGuids.chunked(parallelism).flatMap { chunk ->
+            chunk.map { guid ->
+                async(Dispatchers.IO) {
+                    testSingleServer(context, guid, testUrl, testSource)
+                }
+            }.awaitAll()
+        }.filterNotNull()
+    }
+
+    /**
+     * Tests a single server and returns the result.
+     */
+    private suspend fun testSingleServer(
+        context: Context,
+        guid: String,
+        testUrl: String,
+        testSource: String
+    ): TestResult? = withContext(Dispatchers.IO) {
+        try {
+            val config = MmkvManager.decodeServerConfig(guid) ?: return@withContext null
+            val remarks = config.remarks ?: guid
+
+            // Get the speedtest config
+            val result = V2rayConfigManager.getV2rayConfig4Speedtest(context, guid)
+            if (!result.status) {
+                MmkvManager.encodeServerTestDelayMillis(guid, -1L, testSource)
+                return@withContext TestResult(guid, remarks, -1L)
+            }
+
+            // Measure delay using native library
+            val delay = V2RayNativeManager.measureOutboundDelay(result.content, testUrl)
+            MmkvManager.encodeServerTestDelayMillis(guid, delay, testSource)
+
+            TestResult(guid, remarks, delay)
+        } catch (e: Exception) {
+            Log.e(AppConfig.TAG, "Failed to test server $guid", e)
+            MmkvManager.encodeServerTestDelayMillis(guid, -1L, testSource)
+            null
+        }
+    }
+
+    /**
+     * Tests servers and returns the best one (for Smart Connect).
+     *
+     * @param context The application context.
+     * @param subscriptionId The subscription ID (empty for all).
+     * @return The best server result, or null if none found.
+     */
+    suspend fun testAndFindBest(context: Context, subscriptionId: String): TestResult? {
+        val servers = MmkvManager.getServersBySubscriptionId(subscriptionId)
+        if (servers.isEmpty()) return null
+
+        val results = testServers(context, servers, "smart_connect")
+        return results.filter { it.delay > 0 }.minByOrNull { it.delay }
+    }
+
+    /**
+     * Schedules periodic server testing.
+     *
+     * @param context The application context.
+     * @param intervalMinutes The interval in minutes.
+     */
+    fun schedulePeriodicTest(context: Context, intervalMinutes: Long) {
+        val rw = RemoteWorkManager.getInstance(context)
+        rw.cancelUniqueWork(AppConfig.AUTO_SERVER_TEST_TASK_NAME)
+
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+
+        rw.enqueueUniquePeriodicWork(
+            AppConfig.AUTO_SERVER_TEST_TASK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            PeriodicWorkRequest.Builder(
+                TestAndSwitchTask::class.java,
+                intervalMinutes,
+                TimeUnit.MINUTES
+            )
+                .setConstraints(constraints)
+                .setInitialDelay(intervalMinutes, TimeUnit.MINUTES)
+                .build()
+        )
+        Log.i(AppConfig.TAG, "Scheduled background server testing every $intervalMinutes minutes")
+    }
+
+    /**
+     * Cancels periodic server testing.
+     *
+     * @param context The application context.
+     */
+    fun cancelPeriodicTest(context: Context) {
+        val rw = RemoteWorkManager.getInstance(context)
+        rw.cancelUniqueWork(AppConfig.AUTO_SERVER_TEST_TASK_NAME)
+        Log.i(AppConfig.TAG, "Cancelled background server testing")
+    }
+
+    /**
+     * Triggers an immediate test (e.g., after subscription update).
+     *
+     * @param context The application context.
+     * @param subscriptionId The subscription ID to test.
+     */
+    fun triggerImmediateTest(context: Context, subscriptionId: String) {
+        val rw = RemoteWorkManager.getInstance(context)
+
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        rw.enqueue(
+            OneTimeWorkRequest.Builder(TestAndSwitchTask::class.java)
+                .setConstraints(constraints)
+                .build()
+        )
+        Log.i(AppConfig.TAG, "Triggered immediate server test for subscription: $subscriptionId")
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -55,6 +55,11 @@ object SubscriptionUpdater {
                 Log.i(AppConfig.TAG, "subscription automatic update: ---${subItem.remarks}")
                 AngConfigManager.updateConfigViaSub(Pair(sub.first, subItem))
                 notification.setContentText("Updating ${subItem.remarks}")
+
+                // Trigger immediate server test after subscription update if enabled
+                if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SERVER_TEST_ENABLED)) {
+                    BackgroundServerTester.triggerImmediateTest(applicationContext, sub.first)
+                }
             }
             notificationManager.cancel(3)
             return Result.success()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
@@ -73,6 +73,21 @@ object V2RayServiceManager {
     }
 
     /**
+     * Switches to a different server while VPN is running.
+     * @param context The context from which the server is switched.
+     * @param newGuid The GUID of the new server to switch to.
+     * @return True if the switch was initiated, false otherwise.
+     */
+    fun switchServer(context: Context, newGuid: String): Boolean {
+        if (!isRunning()) return false
+        if (MmkvManager.getSelectServer() == newGuid) return false
+
+        MmkvManager.setSelectServer(newGuid)
+        MessageUtil.sendMsg2Service(context, AppConfig.MSG_STATE_RESTART, "")
+        return true
+    }
+
+    /**
      * Checks if the V2Ray service is running.
      * @return True if the service is running, false otherwise.
      */

--- a/V2rayNG/app/src/main/res/drawable/ic_auto_awesome_24dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_auto_awesome_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,9l-1.25,-2.75L15,5l2.75,-1.25L19,1l1.25,2.75L23,5l-2.75,1.25L19,9zM19,15l-1.25,2.75L15,19l2.75,1.25L19,23l1.25,-2.75L23,19l-2.75,-1.25L19,15zM11.5,9.5L9,4L6.5,9.5L1,12l5.5,2.5L9,20l2.5,-5.5L17,12L11.5,9.5z"/>
+</vector>

--- a/V2rayNG/app/src/main/res/layout/activity_main.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_main.xml
@@ -95,6 +95,22 @@
                     android:layout_gravity="bottom|end"
                     android:layout_marginEnd="@dimen/padding_spacing_dp16">
 
+                    <!-- Smart Connect Mini FAB -->
+                    <com.google.android.material.floatingactionbutton.FloatingActionButton
+                        android:id="@+id/fab_smart_connect"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="bottom|end"
+                        android:layout_marginBottom="@dimen/view_height_dp100"
+                        android:clickable="true"
+                        android:contentDescription="@string/smart_connect"
+                        android:focusable="true"
+                        android:src="@drawable/ic_auto_awesome_24dp"
+                        app:backgroundTint="@color/color_fab_smart"
+                        app:fabSize="mini"
+                        app:tint="@color/colorWhite" />
+
+                    <!-- Main Connect FAB -->
                     <com.google.android.material.floatingactionbutton.FloatingActionButton
                         android:id="@+id/fab"
                         android:layout_width="wrap_content"

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -222,4 +222,18 @@
         <item>full</item>
     </string-array>
 
+    <!-- Auto test interval entries -->
+    <string-array name="auto_test_interval_entries">
+        <item>30 minutes</item>
+        <item>1 hour</item>
+        <item>2 hours</item>
+        <item>4 hours</item>
+    </string-array>
+    <string-array name="auto_test_interval_values" translatable="false">
+        <item>30</item>
+        <item>60</item>
+        <item>120</item>
+        <item>240</item>
+    </string-array>
+
 </resources>

--- a/V2rayNG/app/src/main/res/values/colors.xml
+++ b/V2rayNG/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="colorWhite">#FFFFFF</color>
     <color name="color_fab_active">#f97910</color>
     <color name="color_fab_inactive">#9C9C9C</color>
+    <color name="color_fab_smart">#FF9800</color>
     <color name="divider_color_light">#E0E0E0</color>
     <color name="colorIndicator">@color/md_theme_primary</color>
 

--- a/V2rayNG/app/src/main/res/values/dimens.xml
+++ b/V2rayNG/app/src/main/res/values/dimens.xml
@@ -7,5 +7,6 @@
     <dimen name="view_height_dp36">36dp</dimen>
     <dimen name="view_height_dp48">48dp</dimen>
     <dimen name="view_height_dp64">64dp</dimen>
+    <dimen name="view_height_dp100">100dp</dimen>
     <dimen name="view_height_dp160">160dp</dimen>
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -254,6 +254,21 @@
     <string name="summary_pref_auto_update_subscription">Update your subscriptions automatically at set intervals in the background. Depending on the device, this feature may not always work</string>
     <string name="title_pref_auto_update_interval">Auto Update Interval (Minutes, Min value 15)</string>
 
+    <!-- Auto Server Testing Settings -->
+    <string name="title_auto_server_test">Automatic Server Testing</string>
+    <string name="title_pref_auto_server_test">Enable background testing</string>
+    <string name="summary_pref_auto_server_test">Periodically test servers in current subscription</string>
+    <string name="title_pref_auto_test_interval">Test interval</string>
+    <string name="title_pref_auto_switch">Auto-switch to best server</string>
+    <string name="summary_pref_auto_switch">Automatically switch when VPN is running</string>
+    <string name="notification_server_switched">Switched to %1$s (%2$dms)</string>
+
+    <!-- Smart Connect Button -->
+    <string name="smart_connect">Smart Connect</string>
+    <string name="smart_connect_testing">Finding best server…</string>
+    <string name="smart_connect_success">Connected to %1$s (%2$dms)</string>
+    <string name="smart_connect_no_servers">No working servers found</string>
+
     <string name="title_core_loglevel">Log Level</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
     <string name="title_mode">Mode</string>

--- a/V2rayNG/app/src/main/res/xml/pref_settings.xml
+++ b/V2rayNG/app/src/main/res/xml/pref_settings.xml
@@ -254,6 +254,27 @@
             android:title="@string/title_pref_auto_update_interval" />
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:title="@string/title_auto_server_test"
+        app:initialExpandedChildrenCount="0">
+        <CheckBoxPreference
+            android:key="pref_auto_server_test_enabled"
+            android:summary="@string/summary_pref_auto_server_test"
+            android:title="@string/title_pref_auto_server_test" />
+        <ListPreference
+            android:defaultValue="60"
+            android:entries="@array/auto_test_interval_entries"
+            android:entryValues="@array/auto_test_interval_values"
+            android:key="pref_auto_server_test_interval"
+            android:summary="%s"
+            android:title="@string/title_pref_auto_test_interval" />
+        <CheckBoxPreference
+            android:key="pref_auto_server_switch_enabled"
+            android:defaultValue="true"
+            android:summary="@string/summary_pref_auto_switch"
+            android:title="@string/title_pref_auto_switch" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/title_advanced">
 
         <CheckBoxPreference


### PR DESCRIPTION
## Summary

- **Smart Connect Button**: Orange mini FAB (⚡) above main FAB for one-tap best server connection
- **Background Server Testing**: Periodic testing via WorkManager with configurable intervals (30min, 1hr, 2hr, 4hr)
- **Auto-Switch**: Automatically switches to significantly faster servers (>20% improvement) when VPN is running
- **Post-Subscription Testing**: Triggers testing after subscription updates when enabled
- **Test Metadata Tracking**: Records test timestamp and source (manual, background, smart_connect, post-sub)

## Changes

### New Files
- `BackgroundServerTester.kt` - WorkManager-based background worker for periodic testing and auto-switching
- `ic_auto_awesome_24dp.xml` - Material icon for Smart Connect button

### Modified Files
- `AppConfig.kt` - Added constants for auto-testing preferences and notification channel
- `ServerAffiliationInfo.kt` - Extended with `lastTestTime` and `testSource` fields
- `MmkvManager.kt` - Added `getServersBySubscriptionId()` and `findBestServer()` helpers
- `V2RayServiceManager.kt` - Added `switchServer()` for hot-switching while VPN runs
- `MainActivity.kt` - Added Smart Connect button handler
- `SettingsActivity.kt` - Added preference handlers for auto-test settings
- `SubscriptionUpdater.kt` - Triggers immediate test after subscription updates
- Layout/resource files for UI elements and strings

## Test plan

- [ ] Tap Smart Connect button → tests all servers → connects to fastest
- [ ] Enable background testing in Settings → verify WorkManager schedules task
- [ ] Set test interval → verify schedule updates
- [ ] Enable auto-switch → verify server switches when better one found (while VPN running)
- [ ] Update subscription → verify immediate test triggers (if enabled)
- [ ] Test with no servers → shows "No working servers found" toast
- [ ] Test with all servers failing → keeps current connection

🤖 Generated with [Claude Code](https://claude.ai/code)