### PR TITLE
  Improve accessibility: mark decorative icons as not important for accessibility

### DIFF
--- a/V2rayNG/app/src/main/res/layout/activity_about.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_about.xml
@@ -29,6 +29,7 @@
                 <ImageView
                     android:layout_width="@dimen/image_size_dp24"
                     android:layout_height="@dimen/image_size_dp24"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/ic_source_code_24dp" />
 
                 <TextView
@@ -53,6 +54,7 @@
                 <ImageView
                     android:layout_width="@dimen/image_size_dp24"
                     android:layout_height="@dimen/image_size_dp24"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/license_24px" />
 
                 <TextView
@@ -77,6 +79,7 @@
                 <ImageView
                     android:layout_width="@dimen/image_size_dp24"
                     android:layout_height="@dimen/image_size_dp24"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/ic_feedback_24dp" />
 
                 <TextView
@@ -102,6 +105,7 @@
                 <ImageView
                     android:layout_width="@dimen/image_size_dp24"
                     android:layout_height="@dimen/image_size_dp24"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/ic_telegram_24dp" />
 
                 <TextView
@@ -126,6 +130,7 @@
                 <ImageView
                     android:layout_width="@dimen/image_size_dp24"
                     android:layout_height="@dimen/image_size_dp24"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/ic_privacy_24dp" />
 
                 <TextView


### PR DESCRIPTION
                                                                                                                                                                    
  - Add `android:importantForAccessibility="no"` to decorative ImageViews in About screen                                                                                  
  - Prevents screen readers from announcing redundant icon descriptions                                                                                                    
                                                                                                                                                                           
  ## Changes                                                                                                                                                               
                                                                                                                                                                           
  **`app/src/main/res/layout/activity_about.xml`**                                                                                                                         
  - Mark 5 decorative icons as `importantForAccessibility="no"`:                                                                                                           
    - Source code icon                                                                                                                                                     
    - License icon                                                                                                                                                         
    - Feedback icon                                                                                                                                                        
    - Telegram icon                                                                                                                                                        
    - Privacy policy icon                                                                                                                                                  
                                                                                                                                                                           
  ## Why This Approach?                                                                                                                                                    
                                                                                                                                                                           
  These icons are decorative - they appear next to text labels that already describe the action. Following [Android accessibility                                          
  guidelines](https://developer.android.com/guide/topics/ui/accessibility/apps#describe-ui-elements):                                                                      
                                                                                                                                                                           
  - ❌ Adding `contentDescription` would cause redundant announcements ("Source code icon, Source code")                                                                   
  - ✅ Using `importantForAccessibility="no"` lets screen readers skip the icon and announce only the text                                                                 
                                                                                                                                                                           
  ## Related                                                                                                                                                               
                                                                                                                                                                           
  Continues accessibility improvements from #5105 and #5110                                                                                                                
                                                                                                                                                                           
  ## Testing                                                                                                                                                               
                                                                                                                                                                           
  - [x] Verified with TalkBack - screen reader announces only text labels                                                                                                  
  - [x] No visual changes to UI                                                                                                                                            
                                                           