### PR TITLE
Follow encodeURIComponent rules strictly

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/FmtBase.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/FmtBase.kt
@@ -22,17 +22,17 @@ open class FmtBase {
         val query = if (dicQuery != null)
             "?" + dicQuery.toList().joinToString(
                 separator = "&",
-                transform = { it.first + "=" + Utils.urlEncode(it.second) })
+                transform = { it.first + "=" + Utils.encodeURIComponent(it.second) })
         else ""
 
         val url = String.format(
             "%s@%s:%s",
-            Utils.urlEncode(userInfo ?: ""),
+            Utils.encodeURIComponent(userInfo ?: ""),
             Utils.getIpv6Address(HttpUtil.toIdnDomain(config.server.orEmpty())),
             config.serverPort
         )
 
-        return "${url}${query}#${Utils.urlEncode(config.remarks)}"
+        return "${url}${query}#${Utils.encodeURIComponent(config.remarks)}"
     }
 
     /**
@@ -43,7 +43,7 @@ open class FmtBase {
      */
     fun getQueryParam(uri: URI): Map<String, String> {
         return uri.rawQuery.split("&")
-            .associate { it.split("=").let { (k, v) -> k to Utils.urlDecode(v) } }
+            .associate { it.split("=").let { (k, v) -> k to Utils.decodeURIComponent(v) } }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/Hysteria2Fmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/Hysteria2Fmt.kt
@@ -27,7 +27,7 @@ object Hysteria2Fmt : FmtBase() {
         val config = ProfileItem.create(EConfigType.HYSTERIA2)
 
         val uri = URI(Utils.fixIllegalUrl(str))
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
         config.password = uri.userInfo

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -36,7 +36,7 @@ object ShadowsocksFmt : FmtBase() {
         if (uri.port <= 0) return null
         if (uri.userInfo.isNullOrEmpty()) return null
 
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
 
@@ -83,7 +83,7 @@ object ShadowsocksFmt : FmtBase() {
         if (indexSplit > 0) {
             try {
                 config.remarks =
-                    Utils.urlDecode(result.substring(indexSplit + 1, result.length))
+                    Utils.decodeURIComponent(result.substring(indexSplit + 1, result.length))
             } catch (e: Exception) {
                 Log.e(AppConfig.TAG, "Failed to decode remarks in SS legacy URL", e)
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/SocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/SocksFmt.kt
@@ -23,7 +23,7 @@ object SocksFmt : FmtBase() {
         if (uri.idnHost.isEmpty()) return null
         if (uri.port <= 0) return null
 
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/TrojanFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/TrojanFmt.kt
@@ -23,7 +23,7 @@ object TrojanFmt : FmtBase() {
         val config = ProfileItem.create(EConfigType.TROJAN)
 
         val uri = URI(Utils.fixIllegalUrl(str))
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
         config.password = uri.userInfo

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/VlessFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/VlessFmt.kt
@@ -26,7 +26,7 @@ object VlessFmt : FmtBase() {
         if (uri.rawQuery.isNullOrEmpty()) return null
         val queryParam = getQueryParam(uri)
 
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
         config.password = uri.userInfo

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/VmessFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/VmessFmt.kt
@@ -163,7 +163,7 @@ object VmessFmt : FmtBase() {
         if (uri.rawQuery.isNullOrEmpty()) return null
         val queryParam = getQueryParam(uri)
 
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
         config.password = uri.userInfo

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/WireguardFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/WireguardFmt.kt
@@ -26,7 +26,7 @@ object WireguardFmt : FmtBase() {
         if (uri.rawQuery.isNullOrEmpty()) return null
         val queryParam = getQueryParam(uri)
 
-        config.remarks = Utils.urlDecode(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -328,9 +328,44 @@ object Utils {
      */
     fun urlEncode(url: String): String {
         return try {
-            URLEncoder.encode(url, Charsets.UTF_8.toString()).replace("+", "%20")
+            URLEncoder.encode(url, Charsets.UTF_8.toString())
         } catch (e: Exception) {
             Log.e(AppConfig.TAG, "Failed to encode URL", e)
+            url
+        }
+    }
+
+    /**
+     * Decode a "encodeURIComponent" string.
+     *
+     * @param url The "encodeURIComponent" string.
+     * @return The decoded string, or the original string if decoding fails.
+     */
+    fun decodeURIComponent(url: String): String {
+        return try {
+            // Decode strictly according to RFC 3986 / encodeURIComponent semantics.
+            // '+' is a literal plus and MUST NOT be interpreted as space.
+            // Inputs using '+' for spaces are non-conforming and rejected deliberately
+            // to avoid cross-language interoperability issues.
+            URLDecoder.decode(url.replace("+", "%2B"), Charsets.UTF_8.toString())
+        } catch (e: Exception) {
+            Log.e(AppConfig.TAG, "Failed to decode encodeURIComponent", e)
+            url
+        }
+    }
+
+    /**
+     * Encode a string to "encodeURIComponent" format.
+     * 
+     * @param url The string to encode.
+     * @return The "encodeURIComponent" encoded string, or the original string if encoding fails.
+     */
+    fun encodeURIComponent(url: String): String {
+        return try {
+            // Replace '+' with '%20' to conform to encodeURIComponent semantics.
+            URLEncoder.encode(url, Charsets.UTF_8.toString()).replace("+", "%20")
+        } catch (e: Exception) {
+            Log.e(AppConfig.TAG, "Failed to encode encodeURIComponent", e)
             url
         }
     }


### PR DESCRIPTION
对齐 v2rayN 和 v2rayNG 在 URL 编码/解码上的行为，
减少跨平台使用时的差异和用户困惑。

目前规范要求使用 encodeURIComponent 的编码规则，
即空格使用 "%20"，"+" 表示字面量加号。
但在解码阶段，v2rayNG 等实现仍然兼容将 "+" 解析为空格，
这会导致编码和解码遵循了不同的语义。

在实际使用中，这种差异会带来一些问题：
部分服务或面板会输出 "+" 表示空格，
而这些数据在非 Android / 非 Java 生态中往往无法被正确解析，
最终表现为“在某些平台可用，在另一些平台不可用”。

因此这里尝试统一编码和解码的行为，使其都严格遵循
encodeURIComponent / RFC 3986 的语义，以减少平台间差异，
也让与其他语言实现的互操作更加可预期。
