### PR TITLE
Improve accessibility: mark decorative icons across remaining layouts

### DIFF
--- a/V2rayNG/app/src/main/res/layout/activity_bypass_list.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_bypass_list.xml
@@ -85,6 +85,7 @@
                         <ImageView
                             android:layout_width="@dimen/image_size_dp24"
                             android:layout_height="@dimen/image_size_dp24"
+                            android:importantForAccessibility="no"
                             app:srcCompat="@drawable/ic_about_24dp" />
 
                     </LinearLayout>

--- a/V2rayNG/app/src/main/res/layout/activity_check_update.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_check_update.xml
@@ -22,6 +22,7 @@
             <ImageView
                 android:layout_width="@dimen/image_size_dp24"
                 android:layout_height="@dimen/image_size_dp24"
+                android:importantForAccessibility="no"
                 app:srcCompat="@drawable/ic_source_code_24dp" />
 
             <androidx.appcompat.widget.SwitchCompat
@@ -50,6 +51,7 @@
             <ImageView
                 android:layout_width="@dimen/image_size_dp24"
                 android:layout_height="@dimen/image_size_dp24"
+                android:importantForAccessibility="no"
                 app:srcCompat="@drawable/ic_check_update_24dp" />
 
             <TextView

--- a/V2rayNG/app/src/main/res/layout/item_qrcode.xml
+++ b/V2rayNG/app/src/main/res/layout/item_qrcode.xml
@@ -11,6 +11,7 @@
         android:id="@+id/iv_qcode"
         android:layout_width="336dp"
         android:layout_height="336dp"
+        android:contentDescription="@string/title_qr_code"
         android:scaleType="fitXY"
         app:srcCompat="@drawable/ic_fab_check" />
 </LinearLayout>

--- a/V2rayNG/app/src/main/res/layout/item_recycler_routing_setting.xml
+++ b/V2rayNG/app/src/main/res/layout/item_recycler_routing_setting.xml
@@ -43,6 +43,7 @@
                     android:layout_height="@dimen/padding_spacing_dp16"
                     android:layout_gravity="center"
                     android:layout_marginStart="@dimen/padding_spacing_dp16"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/ic_lock_24dp" />
 
             </LinearLayout>
@@ -87,6 +88,7 @@
                 <ImageView
                     android:layout_width="@dimen/image_size_dp24"
                     android:layout_height="@dimen/image_size_dp24"
+                    android:importantForAccessibility="no"
                     app:srcCompat="@drawable/ic_edit_24dp" />
             </LinearLayout>
 

--- a/V2rayNG/app/src/main/res/layout/item_recycler_sub_setting.xml
+++ b/V2rayNG/app/src/main/res/layout/item_recycler_sub_setting.xml
@@ -67,6 +67,7 @@
                         <ImageView
                             android:layout_width="wrap_content"
                             android:layout_height="@dimen/image_size_dp24"
+                            android:importantForAccessibility="no"
                             app:srcCompat="@drawable/ic_share_24dp" />
 
                     </LinearLayout>
@@ -85,6 +86,7 @@
                         <ImageView
                             android:layout_width="@dimen/image_size_dp24"
                             android:layout_height="@dimen/image_size_dp24"
+                            android:importantForAccessibility="no"
                             app:srcCompat="@drawable/ic_edit_24dp" />
 
                     </LinearLayout>
@@ -103,6 +105,7 @@
                         <ImageView
                             android:layout_width="@dimen/image_size_dp24"
                             android:layout_height="@dimen/image_size_dp24"
+                            android:importantForAccessibility="no"
                             app:srcCompat="@drawable/ic_delete_24dp" />
 
                     </LinearLayout>

--- a/V2rayNG/app/src/main/res/layout/item_recycler_user_asset.xml
+++ b/V2rayNG/app/src/main/res/layout/item_recycler_user_asset.xml
@@ -64,6 +64,7 @@
             <ImageView
                 android:layout_width="@dimen/image_size_dp24"
                 android:layout_height="@dimen/image_size_dp24"
+                android:importantForAccessibility="no"
                 app:srcCompat="@drawable/ic_edit_24dp" />
         </LinearLayout>
 
@@ -79,6 +80,7 @@
             <ImageView
                 android:layout_width="@dimen/image_size_dp24"
                 android:layout_height="@dimen/image_size_dp24"
+                android:importantForAccessibility="no"
                 app:srcCompat="@drawable/ic_delete_24dp" />
         </LinearLayout>
     </LinearLayout>

--- a/V2rayNG/app/src/main/res/layout/widget_switch.xml
+++ b/V2rayNG/app/src/main/res/layout/widget_switch.xml
@@ -18,6 +18,7 @@
             android:id="@+id/image_switch"
             android:layout_width="45dp"
             android:layout_height="45dp"
+            android:importantForAccessibility="no"
             android:padding="@dimen/padding_spacing_dp16"
             app:srcCompat="@drawable/ic_stat_name" />
     </LinearLayout>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="summary_pref_tg_group">Join Telegram Group</string>
     <string name="toast_tg_app_not_found">Telegram app not found</string>
     <string name="title_privacy_policy">Privacy policy</string>
+    <string name="title_qr_code">QR code</string>
     <string name="title_about">About</string>
     <string name="title_source_code">Source code</string>
     <string name="title_oss_license">Open Source licenses</string>


### PR DESCRIPTION
                                                                                                                                              
  ## Summary

  - Add `android:importantForAccessibility="no"` to 11 decorative ImageViews across 6 layout files
  - Add `android:contentDescription` to QR code ImageView for screen reader support

  ## Changes

  | File | Icons | Change |
  |------|-------|--------|
  | `activity_check_update.xml` | source code, check update | `importantForAccessibility="no"` |
  | `activity_bypass_list.xml` | info | `importantForAccessibility="no"` |
  | `item_recycler_routing_setting.xml` | edit, lock | `importantForAccessibility="no"` |
  | `item_recycler_sub_setting.xml` | share, edit, delete | `importantForAccessibility="no"` |
  | `item_recycler_user_asset.xml` | edit, delete | `importantForAccessibility="no"` |
  | `widget_switch.xml` | app logo | `importantForAccessibility="no"` |
  | `item_qrcode.xml` | QR code | `contentDescription="@string/title_qr_code"` |

  ## Why?

  These icons are decorative — they sit next to text labels or inside clickable containers that already describe the action. Without this fix, screen readers (TalkBack)
  announce redundant or meaningless descriptions for each icon.

  - Decorative icons → `importantForAccessibility="no"` (skip in screen reader)
  - QR code image → `contentDescription` (meaningful, standalone content)

  ## Test plan

  - [x] Verify with TalkBack that decorative icons are skipped
  - [x] Verify QR code image is announced as "QR code"
  - [x] No visual changes to UI
