### PR TITLE
  Fix startLoop() call to match updated libv2ray API

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
@@ -5,7 +5,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.os.ParcelFileDescriptor
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.v2ray.ang.AppConfig
@@ -121,7 +120,7 @@ object V2RayServiceManager {
      * `registerReceiver(Context, BroadcastReceiver, IntentFilter, int)`.
      * Starts the V2Ray core service.
      */
-    fun startCoreLoop(vpnInterface: ParcelFileDescriptor?): Boolean {
+    fun startCoreLoop(): Boolean {
         if (coreController.isRunning) {
             return false
         }
@@ -145,14 +144,10 @@ object V2RayServiceManager {
         }
 
         currentConfig = config
-        var tunFd = vpnInterface?.fd ?: 0
-        if (SettingsManager.isUsingHevTun()) {
-            tunFd = 0
-        }
 
         try {
             NotificationManager.showNotification(currentConfig)
-            coreController.startLoop(result.content, tunFd)
+            coreController.startLoop(result.content)
         } catch (e: Exception) {
             Log.e(AppConfig.TAG, "Failed to start Core loop", e)
             return false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayProxyOnlyService.kt
@@ -27,7 +27,7 @@ class V2RayProxyOnlyService : Service(), ServiceControl {
      * @return The start mode.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        V2RayServiceManager.startCoreLoop(null)
+        V2RayServiceManager.startCoreLoop()
         return START_STICKY
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -107,7 +107,7 @@ class V2RayVpnService : VpnService(), ServiceControl {
             Log.e(AppConfig.TAG, "Failed to create VPN interface")
             return
         }
-        if (!V2RayServiceManager.startCoreLoop(mInterface)) {
+        if (!V2RayServiceManager.startCoreLoop()) {
             Log.e(AppConfig.TAG, "Failed to start V2Ray core loop")
             stopAllService()
             return


### PR DESCRIPTION
 ## Summary                                                                                                                                                               
  - Fix compilation error caused by updated `AndroidLibXrayLite` library (`libv2ray.aar`)           
  - `CoreController.startLoop()` signature changed from `startLoop(String, Int)` to `startLoop(String)` — the `tunFd` parameter was removed                                
  - Xray-core now handles TUN internally through its JSON config (`v2ray_config_with_tun.json`), so passing the file descriptor is no longer needed                        
                                                                                                                                                                           
  ## Changes                                                                                                                                                               
  - **V2RayServiceManager.kt**: Remove `tunFd` variable, `vpnInterface` parameter from `startCoreLoop()`, and unused `ParcelFileDescriptor` import
  - **V2RayVpnService.kt**: Update `startCoreLoop(mInterface)` → `startCoreLoop()`
  - **V2RayProxyOnlyService.kt**: Update `startCoreLoop(null)` → `startCoreLoop()`

