### PR TITLE
Shadowsocks - support for query string, mux, and UoT

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -130,6 +130,7 @@ data class V2rayConfig(
                 val email: String? = null,
                 var flow: String? = null,
                 val ivCheck: Boolean? = null,
+                var uot: Boolean? = null,
                 var users: List<SocksUsersBean>? = null
             ) {
                 data class SocksUsersBean(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -7,6 +7,7 @@ import com.v2ray.ang.dto.V2rayConfig.OutboundBean
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.enums.NetworkType
 import com.v2ray.ang.extension.idnHost
+import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.V2rayConfigManager
 import com.v2ray.ang.util.Utils
 import java.net.URI
@@ -64,6 +65,13 @@ object ShadowsocksFmt : FmtBase() {
                 config.headerType = "http"
                 config.host = queryPairs["obfs-host"]
                 config.path = queryPairs["path"]
+            } else {
+                val allowInsecureDefault = try {
+                    MmkvManager.decodeSettingsBool(AppConfig.PREF_ALLOW_INSECURE, false)
+                } catch(_: IllegalStateException) {
+                    false
+                }
+                getItemFormQuery(config, queryParam, allowInsecureDefault)
             }
         }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -153,6 +153,17 @@ object ShadowsocksFmt : FmtBase() {
             server.port = profileItem.serverPort.orEmpty().toInt()
             server.password = profileItem.password
             server.method = profileItem.method
+
+            if (profileItem.method.orEmpty().startsWith("2022-blake3-")) {
+                // UDP over TCP is a feature of SagerNet implementation
+                // which is used by Xray only if the method is one of 2022's
+                // Relevant sources:
+                // https://sing-box.sagernet.org/configuration/shared/udp-over-tcp/
+                // https://github.com/SagerNet/sing-shadowsocks/blob/v0.2.8/shadowaead_2022/protocol.go#L57-L61
+                // https://github.com/XTLS/Xray-core/blob/v26.2.6/infra/conf/shadowsocks.go#L54-L56
+                // https://github.com/XTLS/Xray-core/blob/v26.2.6/proxy/shadowsocks_2022/outbound.go#L58-L60
+                server.uot = true;
+            }
         }
 
         val sni = outboundBean?.streamSettings?.let {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -120,9 +120,15 @@ object ShadowsocksFmt : FmtBase() {
      * @return the converted URI string
      */
     fun toUri(config: ProfileItem): String {
-        val pw = "${config.method}:${config.password}"
+        val isRaw = config.network.let { it.isNullOrBlank() || it == NetworkType.TCP.type }
+                && config.headerType.let { it.isNullOrBlank() || it == "none" }
+                && config.host.let { it.isNullOrBlank() }
+                && config.security.let { it.isNullOrBlank() || it == "none" }
 
-        return toUri(config, Utils.encode(pw, true), null)
+        val pw = "${config.method}:${config.password}"
+        val dicQuery = if (!isRaw) getQueryDic(config) else null
+
+        return toUri(config, Utils.encode(pw, true), dicQuery)
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -128,13 +128,8 @@ object ShadowsocksFmt : FmtBase() {
      * @return the converted URI string
      */
     fun toUri(config: ProfileItem): String {
-        val isRaw = config.network.let { it.isNullOrBlank() || it == NetworkType.TCP.type }
-                && config.headerType.let { it.isNullOrBlank() || it == "none" }
-                && config.host.let { it.isNullOrBlank() }
-                && config.security.let { it.isNullOrBlank() || it == "none" }
-
         val pw = "${config.method}:${config.password}"
-        val dicQuery = if (!isRaw) getQueryDic(config) else null
+        val dicQuery = if (!Utils.isRawShadowsocks(config)) getQueryDic(config) else null
 
         return toUri(config, Utils.encode(pw, true), dicQuery)
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -770,14 +770,15 @@ object V2rayConfigManager {
         try {
             var muxEnabled = MmkvManager.decodeSettingsBool(AppConfig.PREF_MUX_ENABLED, false)
             val protocol = outbound.protocol
-            if (protocol.equals(EConfigType.SHADOWSOCKS.name, true)
-                || protocol.equals(EConfigType.SOCKS.name, true)
+            if (protocol.equals(EConfigType.SOCKS.name, true)
                 || protocol.equals(EConfigType.HTTP.name, true)
                 || protocol.equals(EConfigType.TROJAN.name, true)
                 || protocol.equals(EConfigType.WIREGUARD.name, true)
                 || protocol.equals(EConfigType.HYSTERIA2.name, true)
                 || protocol.equals(EConfigType.HYSTERIA.name, true)
             ) {
+                muxEnabled = false
+            } else if (Utils.isRawShadowsocks(outbound)) {
                 muxEnabled = false
             } else if (outbound.streamSettings?.network == NetworkType.XHTTP.type) {
                 muxEnabled = false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -20,6 +20,7 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.LOOPBACK
 import com.v2ray.ang.BuildConfig
 import com.v2ray.ang.dto.ProfileItem
+import com.v2ray.ang.dto.V2rayConfig.OutboundBean
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.enums.NetworkType
 import java.io.IOException
@@ -616,6 +617,19 @@ object Utils {
             headerType = config.headerType,
             host = config.host,
             security = config.security
+        )
+    }
+
+    fun isRawShadowsocks(outbound: OutboundBean): Boolean {
+        if (!outbound.protocol.equals(EConfigType.SHADOWSOCKS.name, true)) {
+            return false
+        }
+        val streamSettings = outbound.streamSettings;
+        return isRawStreamSettings(
+            network =  streamSettings?.network,
+            headerType = streamSettings?.tcpSettings?.header?.type,
+            host = streamSettings?.wsSettings?.headers?.Host,
+            security = streamSettings?.security
         )
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -19,6 +19,9 @@ import androidx.core.net.toUri
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.LOOPBACK
 import com.v2ray.ang.BuildConfig
+import com.v2ray.ang.dto.ProfileItem
+import com.v2ray.ang.enums.EConfigType
+import com.v2ray.ang.enums.NetworkType
 import java.io.IOException
 import java.net.InetAddress
 import java.net.ServerSocket
@@ -602,5 +605,24 @@ object Utils {
             Log.e(AppConfig.TAG, "Failed to format timestamp", e)
             ""
         }
+    }
+
+    fun isRawShadowsocks(config: ProfileItem): Boolean {
+        if (config.configType != EConfigType.SHADOWSOCKS) {
+            return false
+        }
+        return isRawStreamSettings(
+            network = config.network,
+            headerType = config.headerType,
+            host = config.host,
+            security = config.security
+        )
+    }
+
+    private fun isRawStreamSettings(network: String?, headerType: String?, host: String?, security: String?): Boolean {
+        return (network.isNullOrBlank() || network.equals(NetworkType.TCP.type, true))
+            && (headerType.isNullOrBlank() || headerType.equals("none", true))
+            && host.isNullOrBlank()
+            && (security.isNullOrBlank() || security.equals("none", true))
     }
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -379,4 +379,20 @@ class ShadowsocksFmtTest {
         assertNotNull(result)
         assertEquals("aes-256-gcm", result?.method)
     }
+
+    // ==================== Stream settings via query string  ====================
+
+    @Test
+    fun test_queryString_toUri() {
+        val config = ProfileItem.create(EConfigType.SHADOWSOCKS)
+        assertFalse(ShadowsocksFmt.toUri(config).contains('?'))
+
+        config.network = "tcp"
+        config.headerType = "none"
+        config.security = "none"
+        assertFalse(ShadowsocksFmt.toUri(config).contains('?'))
+
+        config.network = "ws";
+        assertTrue(ShadowsocksFmt.toUri(config).contains("type=ws"))
+    }
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -395,4 +395,13 @@ class ShadowsocksFmtTest {
         config.network = "ws";
         assertTrue(ShadowsocksFmt.toUri(config).contains("type=ws"))
     }
+
+    @Test
+    fun test_queryString_parse() {
+        val uri = "ss://plain:@example.com:443?type=ws&security=tls"
+        val item = ShadowsocksFmt.parse(uri)!!
+
+        assertEquals("ws", item.network)
+        assertEquals("tls", item.security)
+    }
 }


### PR DESCRIPTION
For Shadowsocks protocol **with any stream settings configured** (non TCP transport, TLS, etc):
- Allow query string in `ShadowsocksFmt`
- Allow mux in `updateOutboundWithGlobalSettings`
- UDP over TCP flag is set to `true` if `method` is one of `2022-blake3-*` - comment in code explains why

These changes expose Xray-specific capabilities while preserving compatibility with standard / vanilla Shadowsocks configurations.