### PR TITLE
功能提案：添加 IP 纯净度测试与排序流程（Feature proposal: Add IP purity testing and sorting workflow）

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -1,4 +1,4 @@
-package com.v2ray.ang
+﻿package com.v2ray.ang
 
 
 object AppConfig {
@@ -63,6 +63,7 @@ object AppConfig {
     const val PREF_DNS_HOSTS = "pref_dns_hosts"
     const val PREF_DELAY_TEST_URL = "pref_delay_test_url"
     const val PREF_IP_API_URL = "pref_ip_api_url"
+    const val PREF_IP_PURITY_API_URL = "pref_ip_purity_api_url"
     const val PREF_LOGLEVEL = "pref_core_loglevel"
     const val PREF_OUTBOUND_DOMAIN_RESOLVE_METHOD = "pref_outbound_domain_resolve_method"
     const val PREF_MODE = "pref_mode"
@@ -122,6 +123,7 @@ object AppConfig {
     const val DELAY_TEST_URL2 = "https://www.google.com/generate_204"
 //    const val IP_API_URL = "https://speed.cloudflare.com/meta"
     const val IP_API_URL = "https://api.ip.sb/geoip"
+    const val IP_PURITY_API_URL = "https://my.123169.xyz/v1/info"
 
     /** DNS server addresses. */
     const val DNS_PROXY = "1.1.1.1"
@@ -164,6 +166,16 @@ object AppConfig {
     const val MSG_MEASURE_CONFIG_CANCEL = 72
     const val MSG_MEASURE_CONFIG_NOTIFY = 73
     const val MSG_MEASURE_CONFIG_FINISH = 74
+    const val MSG_MEASURE_IP_PURITY = 8
+    const val MSG_MEASURE_IP_PURITY_SUCCESS = 81
+    const val MSG_MEASURE_IP_PURITY_CANCEL = 82
+    const val MSG_MEASURE_IP_PURITY_NOTIFY = 83
+    const val MSG_MEASURE_IP_PURITY_FINISH = 84
+    const val MSG_MEASURE_FAST_IP_PURITY = 9
+    const val MSG_MEASURE_FAST_IP_PURITY_SUCCESS = 91
+    const val MSG_MEASURE_FAST_IP_PURITY_CANCEL = 92
+    const val MSG_MEASURE_FAST_IP_PURITY_NOTIFY = 93
+    const val MSG_MEASURE_FAST_IP_PURITY_FINISH = 94
 
     /** Notification channel IDs and names. */
     const val RAY_NG_CHANNEL_ID = "RAY_NG_M_CH_ID"
@@ -275,3 +287,4 @@ object AppConfig {
     )
 
 }
+

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -1,4 +1,4 @@
-package com.v2ray.ang.handler
+﻿package com.v2ray.ang.handler
 
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig.DEFAULT_SUBSCRIPTION_ID
@@ -6,9 +6,11 @@ import com.v2ray.ang.AppConfig.PREF_IS_BOOTED
 import com.v2ray.ang.AppConfig.PREF_ROUTING_RULESET
 import com.v2ray.ang.dto.AssetUrlCache
 import com.v2ray.ang.dto.AssetUrlItem
+import com.v2ray.ang.dto.IpPurityResult
 import com.v2ray.ang.dto.ProfileItem
 import com.v2ray.ang.dto.RulesetItem
 import com.v2ray.ang.dto.ServerAffiliationInfo
+import com.v2ray.ang.dto.ServerTestResult
 import com.v2ray.ang.dto.SubscriptionCache
 import com.v2ray.ang.dto.SubscriptionItem
 import com.v2ray.ang.dto.WebDavConfig
@@ -265,6 +267,71 @@ object MmkvManager {
         serverAffStorage.encode(guid, JsonUtil.toJson(aff))
     }
 
+    fun encodeServerTestResult(guid: String, testResult: ServerTestResult) {
+        if (guid.isBlank()) {
+            return
+        }
+        val aff = decodeServerAffiliationInfo(guid) ?: ServerAffiliationInfo()
+        aff.testDelayMillis = testResult.delayMillis
+        aff.purityScore = testResult.ipPurityResult.purityScore
+        aff.purityEmoji = testResult.ipPurityResult.purityEmoji
+        aff.ipCategory = testResult.ipPurityResult.ipCategory
+        aff.ipOrigin = testResult.ipPurityResult.ipOrigin
+        aff.purityDisplay = testResult.ipPurityResult.purityDisplay
+        aff.purityLastError = testResult.ipPurityResult.purityLastError
+        aff.exitIp = testResult.ipPurityResult.exitIp
+        serverAffStorage.encode(guid, JsonUtil.toJson(aff))
+    }
+
+    fun encodeServerPurityResult(guid: String, purityResult: IpPurityResult) {
+        if (guid.isBlank()) {
+            return
+        }
+        val aff = decodeServerAffiliationInfo(guid) ?: ServerAffiliationInfo()
+        aff.purityScore = purityResult.purityScore
+        aff.purityEmoji = purityResult.purityEmoji
+        aff.ipCategory = purityResult.ipCategory
+        aff.ipOrigin = purityResult.ipOrigin
+        aff.purityDisplay = purityResult.purityDisplay
+        aff.purityLastError = purityResult.purityLastError
+        aff.exitIp = purityResult.exitIp
+        serverAffStorage.encode(guid, JsonUtil.toJson(aff))
+    }
+
+    fun encodeServerPurityScore(guid: String, score: Int) {
+        if (guid.isBlank()) {
+            return
+        }
+        val aff = decodeServerAffiliationInfo(guid) ?: ServerAffiliationInfo()
+        if (score < 0) {
+            aff.purityScore = ""
+            aff.purityEmoji = ""
+            aff.ipCategory = ""
+            aff.ipOrigin = ""
+            aff.purityDisplay = ""
+            aff.purityLastError = "Fast purity check failed"
+            aff.exitIp = ""
+        } else {
+            val scoreText = "$score%"
+            val emoji = when {
+                score <= 10 -> "⚪"
+                score <= 30 -> "🟢"
+                score <= 50 -> "🟡"
+                score <= 70 -> "🟠"
+                score <= 90 -> "🔴"
+                else -> "⚫"
+            }
+            aff.purityScore = scoreText
+            aff.purityEmoji = emoji
+            aff.ipCategory = ""
+            aff.ipOrigin = ""
+            aff.purityDisplay = "$emoji $scoreText 快测"
+            aff.purityLastError = ""
+            aff.exitIp = ""
+        }
+        serverAffStorage.encode(guid, JsonUtil.toJson(aff))
+    }
+
     /**
      * Clears all test delay results.
      *
@@ -274,6 +341,37 @@ object MmkvManager {
         keys?.forEach { key ->
             decodeServerAffiliationInfo(key)?.let { aff ->
                 aff.testDelayMillis = 0
+                serverAffStorage.encode(key, JsonUtil.toJson(aff))
+            }
+        }
+    }
+
+    fun clearAllRealTestResults(keys: List<String>?) {
+        keys?.forEach { key ->
+            decodeServerAffiliationInfo(key)?.let { aff ->
+                aff.testDelayMillis = 0
+                aff.purityScore = ""
+                aff.purityEmoji = ""
+                aff.ipCategory = ""
+                aff.ipOrigin = ""
+                aff.purityDisplay = ""
+                aff.purityLastError = ""
+                aff.exitIp = ""
+                serverAffStorage.encode(key, JsonUtil.toJson(aff))
+            }
+        }
+    }
+
+    fun clearAllPurityResults(keys: List<String>?) {
+        keys?.forEach { key ->
+            decodeServerAffiliationInfo(key)?.let { aff ->
+                aff.purityScore = ""
+                aff.purityEmoji = ""
+                aff.ipCategory = ""
+                aff.ipOrigin = ""
+                aff.purityDisplay = ""
+                aff.purityLastError = ""
+                aff.exitIp = ""
                 serverAffStorage.encode(key, JsonUtil.toJson(aff))
             }
         }
@@ -718,3 +816,4 @@ object MmkvManager {
 
     //endregion
 }
+

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
@@ -1,21 +1,32 @@
-package com.v2ray.ang.handler
+﻿package com.v2ray.ang.handler
 
 import android.content.Context
 import android.os.SystemClock
 import android.util.Log
+import com.google.gson.JsonObject
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.IPAPIInfo
+import com.v2ray.ang.dto.IpPurityResult
 import com.v2ray.ang.util.HttpUtil
 import com.v2ray.ang.util.JsonUtil
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.isActive
+import libv2ray.CoreCallbackHandler
+import libv2ray.CoreController
 import java.io.IOException
 import java.net.InetSocketAddress
+import java.net.ServerSocket
 import java.net.Socket
 import java.net.UnknownHostException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 
 object SpeedtestManager {
+
+    private const val TEMP_CORE_START_RETRY = 10
+    private const val TEMP_CORE_START_WAIT_MS = 100L
+    private const val TEMP_PROXY_REQUEST_RETRY = 3
+    private const val TEMP_PROXY_REQUEST_WAIT_MS = 200L
+    private const val TEMP_PROXY_REQUEST_TIMEOUT_MS = 5000
 
     private val tcpTestingSockets = ArrayList<Socket?>()
 
@@ -143,5 +154,158 @@ object SpeedtestManager {
         ).firstOrNull { !it.isNullOrBlank() }
 
         return "(${country ?: "unknown"}) ${ip ?: "unknown"}"
+    }
+
+    fun getIpPurityResult(context: Context, guid: String): IpPurityResult {
+        val failureDisplay = context.getString(R.string.connection_test_purity_failed)
+        val socksPort = findAvailablePort()
+        val httpPort = findAvailablePort(setOf(socksPort))
+        val configResult = V2rayConfigManager.getV2rayConfig4PurityTest(context, guid, socksPort, httpPort)
+        if (!configResult.status) {
+            return IpPurityResult.failure("Config unavailable", failureDisplay)
+        }
+
+        val controller = V2RayNativeManager.newCoreController(TemporaryCoreCallback())
+        try {
+            controller.startLoop(configResult.content, 0)
+            if (!waitForCore(controller)) {
+                return IpPurityResult.failure("Temporary core failed to start", failureDisplay)
+            }
+
+            repeat(TEMP_PROXY_REQUEST_RETRY) {
+                val content = HttpUtil.getUrlContent(SettingsManager.getIpPurityApiUrl(), TEMP_PROXY_REQUEST_TIMEOUT_MS, httpPort)
+                val result = parseIpPurityResult(content)
+                if (result != null) {
+                    return result
+                }
+                Thread.sleep(TEMP_PROXY_REQUEST_WAIT_MS)
+            }
+        } catch (e: Exception) {
+            Log.e(AppConfig.TAG, "Failed to check IP purity", e)
+            return IpPurityResult.failure(e.message ?: "Unknown error", failureDisplay)
+        } finally {
+            stopTemporaryCore(controller)
+        }
+
+        return IpPurityResult.failure("Empty or invalid response", failureDisplay)
+    }
+
+    fun getIpPurityScore(context: Context, guid: String): Int {
+        val result = getIpPurityResult(context, guid)
+        return result.purityScore.removeSuffix("%").toIntOrNull() ?: -1
+    }
+
+    private fun waitForCore(controller: CoreController): Boolean {
+        repeat(TEMP_CORE_START_RETRY) {
+            if (controller.isRunning) {
+                return true
+            }
+            Thread.sleep(TEMP_CORE_START_WAIT_MS)
+        }
+        return controller.isRunning
+    }
+
+    private fun stopTemporaryCore(controller: CoreController) {
+        try {
+            if (controller.isRunning) {
+                controller.stopLoop()
+            }
+        } catch (e: Exception) {
+            Log.e(AppConfig.TAG, "Failed to stop temporary core", e)
+        }
+    }
+
+    private fun parseIpPurityResult(content: String?): IpPurityResult? {
+        if (content.isNullOrBlank()) {
+            return null
+        }
+        val json = JsonUtil.parseString(content) ?: return null
+        val score = getPercentageString(json, "fraudScore") ?: return null
+        val category = when (json.getBooleanValue("isResidential")) {
+            true -> "住宅"
+            false -> "机房"
+            null -> "未知"
+        }
+        val origin = when (json.getBooleanValue("isBroadcast")) {
+            true -> "广播"
+            false -> "原生"
+            null -> "未知"
+        }
+        val emoji = getPurityEmoji(score)
+        return IpPurityResult(
+            exitIp = json.getStringValue("ip").orEmpty(),
+            purityScore = score,
+            purityEmoji = emoji,
+            ipCategory = category,
+            ipOrigin = origin,
+            purityDisplay = "$emoji $score $category|$origin"
+        )
+    }
+
+    private fun getPercentageString(json: JsonObject, key: String): String? {
+        val element = json.get(key) ?: return null
+        return try {
+            when {
+                element.isJsonNull -> null
+                element.isJsonPrimitive && element.asJsonPrimitive.isNumber -> "${element.asNumber.toInt()}%"
+                element.isJsonPrimitive && element.asJsonPrimitive.isString -> {
+                    val raw = element.asString.trim()
+                    if (raw.isEmpty()) null else if (raw.endsWith("%")) raw else "$raw%"
+                }
+                else -> null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun JsonObject.getStringValue(key: String): String? {
+        val element = get(key) ?: return null
+        return try {
+            if (element.isJsonNull) null else element.asString
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun JsonObject.getBooleanValue(key: String): Boolean? {
+        val element = get(key) ?: return null
+        return try {
+            if (element.isJsonNull) null else element.asBoolean
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun getPurityEmoji(score: String): String {
+        val value = score.removeSuffix("%").toIntOrNull() ?: return "❓"
+        return when {
+            value <= 10 -> "⚪"
+            value <= 30 -> "🟢"
+            value <= 50 -> "🟡"
+            value <= 70 -> "🟠"
+            value <= 90 -> "🔴"
+            else -> "⚫"
+        }
+    }
+
+    private fun findAvailablePort(excluded: Set<Int> = emptySet()): Int {
+        repeat(10) {
+            ServerSocket(0).use { serverSocket ->
+                val port = serverSocket.localPort
+                if (port !in excluded) {
+                    return port
+                }
+            }
+        }
+        return if (excluded.contains(18080)) 18081 else 18080
+    }
+
+    private class TemporaryCoreCallback : CoreCallbackHandler {
+        override fun startup(): Long = 0
+
+        override fun shutdown(): Long = 0
+
+        override fun onEmitStatus(l: Long, s: String?): Long = 0
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/FastIpPurityWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/FastIpPurityWorkerService.kt
@@ -2,9 +2,8 @@ package com.v2ray.ang.service
 
 import android.content.Context
 import com.v2ray.ang.AppConfig
-import com.v2ray.ang.handler.SettingsManager
-import com.v2ray.ang.handler.V2RayNativeManager
-import com.v2ray.ang.handler.V2rayConfigManager
+import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.handler.SpeedtestManager
 import com.v2ray.ang.util.MessageUtil
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
@@ -16,10 +15,7 @@ import kotlinx.coroutines.launch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
-/**
- * Worker that runs a batch of real-ping tests independently.
- */
-class RealPingWorkerService(
+class FastIpPurityWorkerService(
     private val context: Context,
     private val guids: List<String>,
     private val onFinish: (status: String) -> Unit = {}
@@ -28,8 +24,9 @@ class RealPingWorkerService(
     private var cancelled = false
     private val job = SupervisorJob()
     private val cpu = Runtime.getRuntime().availableProcessors().coerceAtLeast(1)
-    private val dispatcher = Executors.newFixedThreadPool(cpu * 4).asCoroutineDispatcher()
-    private val scope = CoroutineScope(job + dispatcher + CoroutineName("RealPingBatchWorker"))
+    private val poolSize = (cpu.coerceAtMost(4)).coerceAtLeast(2)
+    private val dispatcher = Executors.newFixedThreadPool(poolSize).asCoroutineDispatcher()
+    private val scope = CoroutineScope(job + dispatcher + CoroutineName("FastIpPurityBatchWorker"))
     private val runningCount = AtomicInteger(0)
     private val totalCount = AtomicInteger(0)
 
@@ -42,16 +39,23 @@ class RealPingWorkerService(
                     if (cancelled || !job.isActive) {
                         throw CancellationException()
                     }
-                    val result = startRealPing(guid)
+                    val delay = MmkvManager.decodeServerAffiliationInfo(guid)?.testDelayMillis
+                    val score = if (delay != null && delay < 0L) {
+                        -1
+                    } else {
+                        SpeedtestManager.getIpPurityScore(context, guid)
+                    }
                     if (cancelled || !job.isActive) {
                         throw CancellationException()
                     }
-                    MessageUtil.sendMsg2UI(context, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, Pair(guid, result))
+                    MessageUtil.sendMsg2UI(context, AppConfig.MSG_MEASURE_FAST_IP_PURITY_SUCCESS, Pair(guid, score))
+                } catch (_: CancellationException) {
+                    throw CancellationException()
                 } finally {
                     val count = totalCount.decrementAndGet()
                     val left = runningCount.decrementAndGet()
                     if (!cancelled && job.isActive) {
-                        MessageUtil.sendMsg2UI(context, AppConfig.MSG_MEASURE_CONFIG_NOTIFY, "$left / $count")
+                        MessageUtil.sendMsg2UI(context, AppConfig.MSG_MEASURE_FAST_IP_PURITY_NOTIFY, "$left / $count")
                     }
                 }
             }
@@ -80,14 +84,5 @@ class RealPingWorkerService(
         } catch (_: Throwable) {
             // ignore
         }
-    }
-
-    private fun startRealPing(guid: String): Long {
-        val retFailure = -1L
-        val configResult = V2rayConfigManager.getV2rayConfig4Speedtest(context, guid)
-        if (!configResult.status) {
-            return retFailure
-        }
-        return V2RayNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/IpPurityWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/IpPurityWorkerService.kt
@@ -1,0 +1,68 @@
+package com.v2ray.ang.service
+
+import android.content.Context
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.dto.IpPurityResult
+import com.v2ray.ang.handler.SpeedtestManager
+import com.v2ray.ang.util.MessageUtil
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.launch
+import java.util.concurrent.Executors
+
+class IpPurityWorkerService(
+    private val context: Context,
+    private val guids: List<String>,
+    private val onFinish: (status: String) -> Unit = {}
+) {
+    @Volatile
+    private var cancelled = false
+    private val job = SupervisorJob()
+    private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    private val scope = CoroutineScope(job + dispatcher + CoroutineName("IpPurityBatchWorker"))
+
+    fun start() {
+        scope.launch {
+            try {
+                val total = guids.size
+                guids.forEachIndexed { index, guid ->
+                    if (cancelled || !job.isActive) {
+                        throw CancellationException()
+                    }
+                    val result = startPurityCheck(guid)
+                    if (cancelled || !job.isActive) {
+                        throw CancellationException()
+                    }
+                    MessageUtil.sendMsg2UI(context, AppConfig.MSG_MEASURE_IP_PURITY_SUCCESS, Pair(guid, result))
+                    val remaining = (total - index - 1).coerceAtLeast(0)
+                    MessageUtil.sendMsg2UI(context, AppConfig.MSG_MEASURE_IP_PURITY_NOTIFY, "$remaining / $total")
+                }
+                onFinish("0")
+            } catch (_: CancellationException) {
+                onFinish("-1")
+            } finally {
+                close()
+            }
+        }
+    }
+
+    fun cancel() {
+        cancelled = true
+        job.cancel()
+    }
+
+    private fun startPurityCheck(guid: String): IpPurityResult {
+        return SpeedtestManager.getIpPurityResult(context, guid)
+    }
+
+    private fun close() {
+        try {
+            dispatcher.close()
+        } catch (_: Throwable) {
+            // ignore
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayTestService.kt
@@ -6,6 +6,10 @@ import android.os.IBinder
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.MSG_MEASURE_CONFIG
 import com.v2ray.ang.AppConfig.MSG_MEASURE_CONFIG_CANCEL
+import com.v2ray.ang.AppConfig.MSG_MEASURE_FAST_IP_PURITY
+import com.v2ray.ang.AppConfig.MSG_MEASURE_FAST_IP_PURITY_CANCEL
+import com.v2ray.ang.AppConfig.MSG_MEASURE_IP_PURITY
+import com.v2ray.ang.AppConfig.MSG_MEASURE_IP_PURITY_CANCEL
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.handler.MmkvManager
@@ -14,9 +18,9 @@ import com.v2ray.ang.util.MessageUtil
 import java.util.Collections
 
 class V2RayTestService : Service() {
-
-    // manage active batch workers so each batch is independent and cancellable
     private val activeWorkers = Collections.synchronizedList(mutableListOf<RealPingWorkerService>())
+    private val activePurityWorkers = Collections.synchronizedList(mutableListOf<IpPurityWorkerService>())
+    private val activeFastPurityWorkers = Collections.synchronizedList(mutableListOf<FastIpPurityWorkerService>())
 
     /**
      * Initializes the V2Ray environment.
@@ -40,10 +44,15 @@ class V2RayTestService : Service() {
      */
     override fun onDestroy() {
         super.onDestroy()
-        // cancel any active workers
         val snapshot = ArrayList(activeWorkers)
         snapshot.forEach { it.cancel() }
         activeWorkers.clear()
+        val puritySnapshot = ArrayList(activePurityWorkers)
+        puritySnapshot.forEach { it.cancel() }
+        activePurityWorkers.clear()
+        val fastPuritySnapshot = ArrayList(activeFastPurityWorkers)
+        fastPuritySnapshot.forEach { it.cancel() }
+        activeFastPurityWorkers.clear()
     }
 
     /**
@@ -68,7 +77,6 @@ class V2RayTestService : Service() {
                 if (guidsList.isNotEmpty()) {
                     lateinit var worker: RealPingWorkerService
                     worker = RealPingWorkerService(this, guidsList) { status ->
-                        // notify UI and remove the worker from active list when finished
                         MessageUtil.sendMsg2UI(this@V2RayTestService, AppConfig.MSG_MEASURE_CONFIG_FINISH, status)
                         activeWorkers.remove(worker)
                     }
@@ -78,10 +86,61 @@ class V2RayTestService : Service() {
             }
 
             MSG_MEASURE_CONFIG_CANCEL -> {
-                // cancel all running batch workers independently
                 val snapshot = ArrayList(activeWorkers)
                 snapshot.forEach { it.cancel() }
                 activeWorkers.clear()
+            }
+
+            MSG_MEASURE_IP_PURITY -> {
+                val guidsList = if (message.serverGuids.isNotEmpty()) {
+                    message.serverGuids
+                } else if (message.subscriptionId.isNotEmpty()) {
+                    MmkvManager.decodeServerList(message.subscriptionId)
+                } else {
+                    MmkvManager.decodeAllServerList()
+                }
+
+                if (guidsList.isNotEmpty()) {
+                    lateinit var worker: IpPurityWorkerService
+                    worker = IpPurityWorkerService(this, guidsList) { status ->
+                        MessageUtil.sendMsg2UI(this@V2RayTestService, AppConfig.MSG_MEASURE_IP_PURITY_FINISH, status)
+                        activePurityWorkers.remove(worker)
+                    }
+                    activePurityWorkers.add(worker)
+                    worker.start()
+                }
+            }
+
+            MSG_MEASURE_IP_PURITY_CANCEL -> {
+                val snapshot = ArrayList(activePurityWorkers)
+                snapshot.forEach { it.cancel() }
+                activePurityWorkers.clear()
+            }
+
+            MSG_MEASURE_FAST_IP_PURITY -> {
+                val guidsList = if (message.serverGuids.isNotEmpty()) {
+                    message.serverGuids
+                } else if (message.subscriptionId.isNotEmpty()) {
+                    MmkvManager.decodeServerList(message.subscriptionId)
+                } else {
+                    MmkvManager.decodeAllServerList()
+                }
+
+                if (guidsList.isNotEmpty()) {
+                    lateinit var worker: FastIpPurityWorkerService
+                    worker = FastIpPurityWorkerService(this, guidsList) { status ->
+                        MessageUtil.sendMsg2UI(this@V2RayTestService, AppConfig.MSG_MEASURE_FAST_IP_PURITY_FINISH, status)
+                        activeFastPurityWorkers.remove(worker)
+                    }
+                    activeFastPurityWorkers.add(worker)
+                    worker.start()
+                }
+            }
+
+            MSG_MEASURE_FAST_IP_PURITY_CANCEL -> {
+                val snapshot = ArrayList(activeFastPurityWorkers)
+                snapshot.forEach { it.cancel() }
+                activeFastPurityWorkers.clear()
             }
         }
         return super.onStartCommand(intent, flags, startId)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -298,15 +298,21 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
             true
         }
 
-        R.id.ping_all -> {
-            toast(getString(R.string.connection_test_testing_count, mainViewModel.serversCache.count()))
-            mainViewModel.testAllTcping()
-            true
-        }
-
         R.id.real_ping_all -> {
             toast(getString(R.string.connection_test_testing_count, mainViewModel.serversCache.count()))
             mainViewModel.testAllRealPing()
+            true
+        }
+
+        R.id.purity_ping_all -> {
+            toast(getString(R.string.connection_test_testing_count, mainViewModel.serversCache.count()))
+            mainViewModel.testAllIpPurity()
+            true
+        }
+
+        R.id.fast_purity_ping_all -> {
+            toast(getString(R.string.connection_test_testing_count, mainViewModel.serversCache.count()))
+            mainViewModel.testAllFastIpPurity()
             true
         }
 
@@ -332,6 +338,11 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
 
         R.id.sort_by_test_results -> {
             sortByTestResults()
+            true
+        }
+
+        R.id.sort_by_purity_results -> {
+            sortByPurityResults()
             true
         }
 
@@ -537,6 +548,17 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
         showLoading()
         lifecycleScope.launch(Dispatchers.IO) {
             mainViewModel.sortByTestResults()
+            launch(Dispatchers.Main) {
+                mainViewModel.reloadServerList()
+                hideLoading()
+            }
+        }
+    }
+
+    private fun sortByPurityResults() {
+        showLoading()
+        lifecycleScope.launch(Dispatchers.IO) {
+            mainViewModel.sortByPurityResults()
             launch(Dispatchers.Main) {
                 mainViewModel.reloadServerList()
                 hideLoading()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -15,6 +15,7 @@ import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.GroupMapItem
+import com.v2ray.ang.dto.IpPurityResult
 import com.v2ray.ang.dto.ServersCache
 import com.v2ray.ang.dto.SubscriptionCache
 import com.v2ray.ang.dto.SubscriptionUpdateResult
@@ -212,6 +213,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             getApplication(),
             TestServiceMessage(key = AppConfig.MSG_MEASURE_CONFIG_CANCEL)
         )
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_IP_PURITY_CANCEL)
+        )
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_FAST_IP_PURITY_CANCEL)
+        )
         MmkvManager.clearAllTestDelayResults(serversCache.map { it.guid }.toList())
         updateListAction.value = -1
 
@@ -223,6 +232,68 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 getApplication(),
                 TestServiceMessage(
                     key = AppConfig.MSG_MEASURE_CONFIG,
+                    subscriptionId = subscriptionId,
+                    serverGuids = if (keywordFilter.isNotEmpty()) serversCache.map { it.guid } else emptyList()
+                )
+            )
+        }
+    }
+
+    fun testAllIpPurity() {
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_CONFIG_CANCEL)
+        )
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_IP_PURITY_CANCEL)
+        )
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_FAST_IP_PURITY_CANCEL)
+        )
+        MmkvManager.clearAllPurityResults(serversCache.map { it.guid }.toList())
+        updateListAction.value = -1
+
+        viewModelScope.launch(Dispatchers.Default) {
+            if (serversCache.isEmpty()) {
+                return@launch
+            }
+            MessageUtil.sendMsg2TestService(
+                getApplication(),
+                TestServiceMessage(
+                    key = AppConfig.MSG_MEASURE_IP_PURITY,
+                    subscriptionId = subscriptionId,
+                    serverGuids = if (keywordFilter.isNotEmpty()) serversCache.map { it.guid } else emptyList()
+                )
+            )
+        }
+    }
+
+    fun testAllFastIpPurity() {
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_CONFIG_CANCEL)
+        )
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_IP_PURITY_CANCEL)
+        )
+        MessageUtil.sendMsg2TestService(
+            getApplication(),
+            TestServiceMessage(key = AppConfig.MSG_MEASURE_FAST_IP_PURITY_CANCEL)
+        )
+        MmkvManager.clearAllPurityResults(serversCache.map { it.guid }.toList())
+        updateListAction.value = -1
+
+        viewModelScope.launch(Dispatchers.Default) {
+            if (serversCache.isEmpty()) {
+                return@launch
+            }
+            MessageUtil.sendMsg2TestService(
+                getApplication(),
+                TestServiceMessage(
+                    key = AppConfig.MSG_MEASURE_FAST_IP_PURITY,
                     subscriptionId = subscriptionId,
                     serverGuids = if (keywordFilter.isNotEmpty()) serversCache.map { it.guid } else emptyList()
                 )
@@ -391,6 +462,35 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
 
 
+    fun sortByPurityResults() {
+        if (subscriptionId.isEmpty()) {
+            getSortableSubscriptionIds().forEach { guid ->
+                sortByPurityResultsForSub(guid)
+            }
+        } else {
+            sortByPurityResultsForSub(subscriptionId)
+        }
+    }
+
+    private fun sortByPurityResultsForSub(subId: String) {
+        data class ServerPurity(val guid: String, val purityScore: Int, val testDelayMillis: Long)
+
+        val serverListToSort = MmkvManager.decodeServerList(subId)
+        val serverPurities = serverListToSort.map { key ->
+            val aff = MmkvManager.decodeServerAffiliationInfo(key)
+            val purityScore = aff?.purityScore?.removeSuffix("%")?.toIntOrNull() ?: Int.MAX_VALUE
+            val testDelayMillis = aff?.testDelayMillis?.takeIf { it > 0L } ?: Long.MAX_VALUE
+            ServerPurity(key, purityScore, testDelayMillis)
+        }
+
+        val sortedServerList = serverPurities
+            .sortedWith(compareBy<ServerPurity> { it.purityScore }.thenBy { it.testDelayMillis })
+            .map { it.guid }
+            .toMutableList()
+
+        MmkvManager.encodeServerList(sortedServerList, subId)
+    }
+
     /**
      * Initializes assets.
      * @param assets The asset manager.
@@ -424,14 +524,26 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         return config?.subscriptionId
     }
 
-    fun onTestsFinished() {
+    private fun getSortableSubscriptionIds(): List<String> {
+        val subIds = MmkvManager.decodeSubsList().toMutableList()
+        if (!subIds.contains(AppConfig.DEFAULT_SUBSCRIPTION_ID)) {
+            subIds.add(0, AppConfig.DEFAULT_SUBSCRIPTION_ID)
+        }
+        return subIds
+    }
+
+    fun onTestsFinished(sortByPurityResults: Boolean = false) {
         viewModelScope.launch(Dispatchers.Default) {
             if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST)) {
                 removeInvalidServer()
             }
 
             if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST)) {
-                sortByTestResults()
+                if (sortByPurityResults) {
+                    sortByPurityResults()
+                } else {
+                    sortByTestResults()
+                }
             }
 
             withContext(Dispatchers.Main) {
@@ -487,7 +599,47 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         onTestsFinished()
                     }
                 }
+
+                AppConfig.MSG_MEASURE_IP_PURITY_SUCCESS -> {
+                    val resultPair = intent.serializable<Pair<String, IpPurityResult>>("content") ?: return
+                    MmkvManager.encodeServerPurityResult(resultPair.first, resultPair.second)
+                    updateListAction.value = getPosition(resultPair.first)
+                }
+
+                AppConfig.MSG_MEASURE_IP_PURITY_NOTIFY -> {
+                    val content = intent.getStringExtra("content")
+                    updateTestResultAction.value =
+                        getApplication<AngApplication>().getString(R.string.connection_runing_task_left, content)
+                }
+
+                AppConfig.MSG_MEASURE_IP_PURITY_FINISH -> {
+                    val content = intent.getStringExtra("content")
+                    if (content == "0") {
+                        onTestsFinished(sortByPurityResults = true)
+                    }
+                }
+
+                AppConfig.MSG_MEASURE_FAST_IP_PURITY_SUCCESS -> {
+                    val resultPair = intent.serializable<Pair<String, Int>>("content") ?: return
+                    MmkvManager.encodeServerPurityScore(resultPair.first, resultPair.second)
+                    updateListAction.value = getPosition(resultPair.first)
+                }
+
+                AppConfig.MSG_MEASURE_FAST_IP_PURITY_NOTIFY -> {
+                    val content = intent.getStringExtra("content")
+                    updateTestResultAction.value =
+                        getApplication<AngApplication>().getString(R.string.connection_runing_task_left, content)
+                }
+
+                AppConfig.MSG_MEASURE_FAST_IP_PURITY_FINISH -> {
+                    val content = intent.getStringExtra("content")
+                    if (content == "0") {
+                        onTestsFinished(sortByPurityResults = true)
+                    }
+                }
             }
         }
     }
 }
+
+

--- a/V2rayNG/app/src/main/res/menu/menu_main.xml
+++ b/V2rayNG/app/src/main/res/menu/menu_main.xml
@@ -87,16 +87,24 @@
         android:title="@string/title_export_all"
         app:showAsAction="never" />
     <item
-        android:id="@+id/ping_all"
-        android:title="@string/title_ping_all_server"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/real_ping_all"
         android:title="@string/title_real_ping_all_server"
         app:showAsAction="never" />
     <item
+        android:id="@+id/purity_ping_all"
+        android:title="@string/title_purity_ping_all_server"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/fast_purity_ping_all"
+        android:title="@string/title_fast_purity_ping_all_server"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/sort_by_test_results"
         android:title="@string/title_sort_by_test_results"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/sort_by_purity_results"
+        android:title="@string/title_sort_by_purity_results"
         app:showAsAction="never" />
     <item
         android:id="@+id/sub_update"

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -291,7 +291,9 @@
     <string name="sub_setting_pre_profile_tip">The config remarks exist and are unique</string>
     <string name="title_sub_update">Update subscription</string>
     <string name="title_ping_all_server">Tcping config</string>
-    <string name="title_real_ping_all_server">Real delay config</string>
+    <string name="title_real_ping_all_server">测试配置真连接</string>
+    <string name="title_purity_ping_all_server">测试配置纯净度</string>
+    <string name="title_fast_purity_ping_all_server">快速测试纯净度</string>
     <string name="title_user_asset_setting">Asset files</string>
     <string name="title_sort_by_test_results">Sorting by test results</string>
     <string name="title_filter_config">Filter config</string>
@@ -436,4 +438,8 @@
         <item>WebDAV</item>
     </string-array>
 
+    <string name="title_sort_by_purity_results">按纯净度排序</string>
+    <string name="title_pref_ip_purity_api_url">IP purity test url</string>
+    <string name="summary_pref_ip_purity_api_url">Url</string>
+    <string name="connection_test_purity_failed">IP purity check failed</string>
 </resources>


### PR DESCRIPTION
## English

### Summary

This is a feature-oriented PR for discussion and review.

I would like to propose an IP purity testing workflow for AI-oriented node selection.  
This PR is intended to show the current implementation and collect feedback on whether this feature direction fits the project.

The main additions include:

- full IP purity test
- fast IP purity test
- sort by IP purity
- separation of real delay test and purity test
- fixes for test-task cross-triggering between real delay / full purity / fast purity

### Why

For many AI-related services, connectivity alone is not enough.  
A node may pass delay or real connection tests, but still be unsuitable because the exit IP quality is poor.

Because of that, I tried to add IP purity as an extra dimension for filtering and sorting nodes.

### Included changes

- keep real delay test as a separate workflow
- add a dedicated full IP purity test entry
- add a dedicated fast IP purity test entry
- add sort by IP purity
- prevent different batch test modes from continuing to report results after cancellation
- update related menu labels

### Notes

- `libv2ray.aar` is not modified in this PR
- startup service path is not the target of this PR
- this PR only includes code and resource changes
- no APK or build artifacts are included

### Local verification

Verified locally:

- service startup still works
- real delay test works
- full IP purity test works
- fast IP purity test works
- sort by IP purity works
- switching between different batch test modes no longer causes cross-triggered result reporting

### Feedback request

I would really appreciate feedback on whether this feature direction is suitable for the mainline project.  
If the direction itself is not a fit, I also understand that it may be more appropriate to keep it as a separately maintained version.

---

## 中文

### 摘要

这是一个以功能讨论和代码评审为目的的 PR。

我想提交一个与 IP 纯净度测试相关的功能提案，用于面向 AI 使用场景的节点筛选。  
这个 PR 的主要目的是展示当前实现，并请你判断这个功能方向是否适合项目主线。

主要包括以下内容：

- 完整纯净度测试
- 快速纯净度测试
- 按纯净度排序
- 将真连接测试和纯净度测试拆分为独立流程
- 修复真连接 / 完整纯净度 / 快速纯净度之间批量测试任务串台的问题

### 为什么需要这个功能

对于很多 AI 相关服务来说，仅仅“可连接”是不够的。  
一个节点即使能够通过延迟测试或真连接测试，也可能因为出口 IP 质量较差而不适合实际使用。

因此我尝试把 IP 纯净度作为一个额外维度，用于节点筛选和排序。

### 包含的改动

- 保持真连接测试为独立流程
- 新增独立的完整纯净度测试入口
- 新增独立的快速纯净度测试入口
- 新增按纯净度排序
- 防止不同批量测试模式在取消后继续向界面回传结果
- 更新相关菜单文案

### 说明

- 这个 PR 没有修改 `libv2ray.aar`
- 这个 PR 的目标不是修改启动服务主链路
- 这个 PR 只包含代码和资源文件改动
- 不包含 APK 或构建产物

### 本地验证

已在本地验证：

- 启动服务仍然正常
- 真连接测试正常
- 完整纯净度测试正常
- 快速纯净度测试正常
- 按纯净度排序正常
- 在不同批量测试模式之间切换时，不再出现测试结果串台回传的问题

### 希望获得的反馈

我很希望先听听你对这个功能方向的看法，看看它是否适合进入项目主线。  
如果这个方向本身不适合主线，我也完全理解它更适合作为一个单独维护的版本。
