### PR TITLE
add fab longclick locate server

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -94,6 +94,10 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
         })
 
         binding.fab.setOnClickListener { handleFabAction() }
+        binding.fab.setOnLongClickListener {
+            locateSelectedServer()
+            true
+        }
         binding.layoutTest.setOnClickListener { handleLayoutTestClick() }
 
         setupGroupTab()


### PR DESCRIPTION
启动停止按钮添加长按功能，快速定位服务器配置位置。不影响启动停止。菜单栏二级太麻烦。