### PR TITLE
Require SOCKS auth and rotate local credentials per service start

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -42,12 +42,18 @@ data class V2rayConfig(
 
         data class InSettingsBean(
             var auth: String? = null,
+            var accounts: List<SocksUsersBean>? = null,
             var udp: Boolean? = null,
             var userLevel: Int? = null,
             var name: String? = null,
             @SerializedName("MTU")
             var mtu: Int? = null
-        )
+        ) {
+            data class SocksUsersBean(
+                var user: String = "",
+                var pass: String = ""
+            )
+        }
 
         data class SniffingBean(
             var enabled: Boolean,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -34,6 +34,11 @@ import java.util.Collections
 import java.util.Locale
 
 object SettingsManager {
+    @Volatile
+    private var localSocksAuthUser: String? = null
+
+    @Volatile
+    private var localSocksAuthPass: String? = null
 
     fun initApp(context: Context) {
         ensureDefaultSettings()
@@ -282,6 +287,44 @@ object SettingsManager {
      */
     fun getHttpPort(): Int {
         return getSocksPort() + if (Utils.isXray()) 0 else 1
+    }
+
+    /**
+     * Rotates local SOCKS credentials in-memory for a new service run.
+     */
+    @Synchronized
+    fun rotateLocalSocksAuth() {
+        val userSeed = (Utils.getUuid() + Utils.getUuid()).ifEmpty {
+            System.currentTimeMillis().toString(16) + System.nanoTime().toString(16)
+        }
+        val passSeed = (Utils.getUuid() + Utils.getUuid()).ifEmpty {
+            (System.currentTimeMillis().toString(16) + System.nanoTime().toString(16))
+        }
+        localSocksAuthUser = userSeed.take(12)
+        localSocksAuthPass = passSeed.take(24)
+    }
+
+    /**
+     * Returns the local SOCKS username for the current service run.
+     */
+    fun getLocalSocksAuthUser(): String {
+        ensureLocalSocksAuth()
+        return localSocksAuthUser.orEmpty()
+    }
+
+    /**
+     * Returns the local SOCKS password for the current service run.
+     */
+    fun getLocalSocksAuthPass(): String {
+        ensureLocalSocksAuth()
+        return localSocksAuthPass.orEmpty()
+    }
+
+    @Synchronized
+    private fun ensureLocalSocksAuth() {
+        if (localSocksAuthUser.isNullOrBlank() || localSocksAuthPass.isNullOrBlank()) {
+            rotateLocalSocksAuth()
+        }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -5,6 +5,7 @@ import android.content.res.AssetManager
 import android.text.TextUtils
 import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
+import com.google.gson.JsonObject
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.ANG_PACKAGE
 import com.v2ray.ang.AppConfig.DEFAULT_SUBSCRIPTION_ID
@@ -34,6 +35,9 @@ import java.util.Collections
 import java.util.Locale
 
 object SettingsManager {
+    @Volatile
+    private var localSocksAuthEnabled: Boolean = true
+
     @Volatile
     private var localSocksAuthUser: String? = null
 
@@ -290,6 +294,19 @@ object SettingsManager {
     }
 
     /**
+     * Applies local SOCKS auth from custom JSON.
+     * Returns true when custom config provides usable password auth credentials for local SOCKS.
+     */
+    @Synchronized
+    fun applyCustomLocalSocksAuth(rawConfig: String?): Boolean {
+        val customAuth = resolveCustomLocalSocksAuth(rawConfig)
+        localSocksAuthEnabled = customAuth.enabled
+        localSocksAuthUser = customAuth.user
+        localSocksAuthPass = customAuth.pass
+        return customAuth.validForHevTun
+    }
+
+    /**
      * Rotates local SOCKS credentials in-memory for a new service run.
      */
     @Synchronized
@@ -300,15 +317,35 @@ object SettingsManager {
         val passSeed = (Utils.getUuid() + Utils.getUuid()).ifEmpty {
             (System.currentTimeMillis().toString(16) + System.nanoTime().toString(16))
         }
+        localSocksAuthEnabled = true
         localSocksAuthUser = userSeed.take(12)
         localSocksAuthPass = passSeed.take(24)
+    }
+
+    /**
+     * Returns true when the current local SOCKS runtime expects username/password auth.
+     */
+    fun isLocalSocksAuthEnabled(): Boolean {
+        return localSocksAuthEnabled
+    }
+
+    /**
+     * Ensures generated credentials exist for app-managed configs.
+     */
+    @Synchronized
+    fun ensureManagedLocalSocksAuth() {
+        if (!localSocksAuthEnabled || localSocksAuthUser == null || localSocksAuthPass == null) {
+            rotateLocalSocksAuth()
+        }
     }
 
     /**
      * Returns the local SOCKS username for the current service run.
      */
     fun getLocalSocksAuthUser(): String {
-        ensureLocalSocksAuth()
+        if (!localSocksAuthEnabled) {
+            return ""
+        }
         return localSocksAuthUser.orEmpty()
     }
 
@@ -316,14 +353,132 @@ object SettingsManager {
      * Returns the local SOCKS password for the current service run.
      */
     fun getLocalSocksAuthPass(): String {
-        ensureLocalSocksAuth()
+        if (!localSocksAuthEnabled) {
+            return ""
+        }
         return localSocksAuthPass.orEmpty()
     }
 
-    @Synchronized
-    private fun ensureLocalSocksAuth() {
-        if (localSocksAuthUser.isNullOrBlank() || localSocksAuthPass.isNullOrBlank()) {
-            rotateLocalSocksAuth()
+    private data class LocalSocksAuth(
+        val enabled: Boolean,
+        val user: String? = null,
+        val pass: String? = null,
+        val validForHevTun: Boolean = true
+    )
+
+    private fun resolveCustomLocalSocksAuth(rawConfig: String?): LocalSocksAuth {
+        val json = JsonUtil.parseString(rawConfig)
+        val inbounds = if (json?.has("inbounds") == true && json.get("inbounds")?.isJsonArray == true) {
+            json.getAsJsonArray("inbounds")
+        } else {
+            null
+        }
+        if (inbounds == null) {
+            Log.w(AppConfig.TAG, "Custom config has no inbounds array")
+            return LocalSocksAuth(enabled = false, validForHevTun = false)
+        }
+
+        val targetPort = getSocksPort()
+        var foundSocksInboundOnTargetPort = false
+        var foundPasswordAuthOnTargetPort = false
+        var foundAccountObjectOnTargetPort = false
+
+        for (element in inbounds) {
+            if (!element.isJsonObject) continue
+            val inbound = element.asJsonObject
+            if (!getJsonString(inbound, "protocol").equals("socks", ignoreCase = true)) {
+                continue
+            }
+            val inboundPort = getJsonInt(inbound, "port")
+            if (inboundPort != null && inboundPort != targetPort) {
+                continue
+            }
+            foundSocksInboundOnTargetPort = true
+
+            val settings = if (inbound.has("settings") && inbound.get("settings")?.isJsonObject == true) {
+                inbound.getAsJsonObject("settings")
+            } else {
+                null
+            }
+            val auth = getJsonString(settings, "auth")
+            if (!auth.equals("password", ignoreCase = true)) {
+                continue
+            }
+            foundPasswordAuthOnTargetPort = true
+
+            val accounts = if (settings?.has("accounts") == true && settings.get("accounts")?.isJsonArray == true) {
+                settings.getAsJsonArray("accounts")
+            } else {
+                null
+            }
+            if (accounts == null) {
+                continue
+            }
+
+            for (account in accounts) {
+                if (!account.isJsonObject) continue
+                foundAccountObjectOnTargetPort = true
+                val accountObject = account.asJsonObject
+                val user = getJsonString(accountObject, "user").orEmpty().trim()
+                val pass = getJsonString(accountObject, "pass").orEmpty().trim()
+                if (user.isBlank() || pass.isBlank()) {
+                    continue
+                }
+                return LocalSocksAuth(
+                    enabled = true,
+                    user = user,
+                    pass = pass,
+                    validForHevTun = true
+                )
+            }
+        }
+
+        if (!foundSocksInboundOnTargetPort) {
+            Log.w(AppConfig.TAG, "Custom config has no socks inbound on local port $targetPort")
+        } else if (!foundPasswordAuthOnTargetPort) {
+            Log.w(AppConfig.TAG, "Custom socks inbound on port $targetPort must use password auth")
+        } else if (!foundAccountObjectOnTargetPort) {
+            Log.w(AppConfig.TAG, "Custom socks inbound on port $targetPort must include at least one account")
+        } else {
+            Log.w(
+                AppConfig.TAG,
+                "Custom socks inbound on port $targetPort must include non-empty user and pass"
+            )
+        }
+        return LocalSocksAuth(enabled = false, validForHevTun = false)
+    }
+
+    private fun getJsonString(jsonObject: JsonObject?, name: String): String? {
+        if (jsonObject == null || !jsonObject.has(name)) {
+            return null
+        }
+        val element = jsonObject.get(name)
+        if (element == null || element.isJsonNull) {
+            return null
+        }
+        return try {
+            element.asString
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun getJsonInt(jsonObject: JsonObject?, name: String): Int? {
+        if (jsonObject == null || !jsonObject.has(name)) {
+            return null
+        }
+        val element = jsonObject.get(name)
+        if (element == null || element.isJsonNull) {
+            return null
+        }
+        return try {
+            if (element.isJsonPrimitive && element.asJsonPrimitive.isNumber) {
+                element.asInt
+            } else {
+                element.asString.toIntOrNull()
+            }
+        } catch (_: Exception) {
+            null
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
@@ -121,6 +121,9 @@ object V2RayServiceManager {
 //        val result = V2rayConfigUtil.getV2rayConfig(context, guid)
 //        if (!result.status) return
 
+        // Rotate local SOCKS credentials for every fresh service start.
+        SettingsManager.rotateLocalSocksAuth()
+
         if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING)) {
             context.toast(R.string.toast_warning_pref_proxysharing_short)
         } else {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
@@ -121,8 +121,24 @@ object V2RayServiceManager {
 //        val result = V2rayConfigUtil.getV2rayConfig(context, guid)
 //        if (!result.status) return
 
-        // Rotate local SOCKS credentials for every fresh service start.
-        SettingsManager.rotateLocalSocksAuth()
+        val isVpnMode = SettingsManager.isVpnMode()
+        val requireStrictCustomSocksAuth = isVpnMode && SettingsManager.isUsingHevTun()
+
+        if (config.configType == EConfigType.CUSTOM) {
+            val validCustomSocksAuth = SettingsManager.applyCustomLocalSocksAuth(MmkvManager.decodeServerRaw(guid))
+            if (!validCustomSocksAuth) {
+                if (requireStrictCustomSocksAuth) {
+                    context.toast(R.string.toast_config_file_invalid)
+                    Log.e(AppConfig.TAG, "StartCore-Manager: Custom config has invalid SOCKS auth credentials for HEV TUN")
+                    return
+                } else {
+                    Log.w(AppConfig.TAG, "StartCore-Manager: Custom config has invalid SOCKS auth credentials; continue (non-HEV or non-VPN mode)")
+                }
+            }
+        } else {
+            // Rotate local SOCKS credentials for every fresh service start.
+            SettingsManager.rotateLocalSocksAuth()
+        }
 
         if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING)) {
             context.toast(R.string.toast_warning_pref_proxysharing_short)
@@ -130,7 +146,6 @@ object V2RayServiceManager {
             context.toast(R.string.toast_services_start)
         }
 
-        val isVpnMode = SettingsManager.isVpnMode()
         val intent = if (isVpnMode) {
             Log.i(AppConfig.TAG, "StartCore-Manager: Starting VPN service")
             Intent(context.applicationContext, V2RayVpnService::class.java)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -374,11 +374,23 @@ object V2rayConfigManager {
         try {
             val socksPort = SettingsManager.getSocksPort()
             val inbound1 = v2rayConfig.inbounds[0]
+            val socksAuthUser = SettingsManager.getLocalSocksAuthUser()
+            val socksAuthPass = SettingsManager.getLocalSocksAuthPass()
 
             if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING) != true) {
                 inbound1.listen = AppConfig.LOOPBACK
             }
             inbound1.port = socksPort
+            val inboundSettings = inbound1.settings ?: V2rayConfig.InboundBean.InSettingsBean().also {
+                inbound1.settings = it
+            }
+            inboundSettings.auth = "password"
+            inboundSettings.accounts = listOf(
+                V2rayConfig.InboundBean.InSettingsBean.SocksUsersBean(
+                    user = socksAuthUser,
+                    pass = socksAuthPass
+                )
+            )
             val fakedns = MmkvManager.decodeSettingsBool(AppConfig.PREF_FAKE_DNS_ENABLED) == true
             val sniffAllTlsAndHttp =
                 MmkvManager.decodeSettingsBool(AppConfig.PREF_SNIFFING_ENABLED, true) != false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -374,6 +374,7 @@ object V2rayConfigManager {
         try {
             val socksPort = SettingsManager.getSocksPort()
             val inbound1 = v2rayConfig.inbounds[0]
+            SettingsManager.ensureManagedLocalSocksAuth()
             val socksAuthUser = SettingsManager.getLocalSocksAuthUser()
             val socksAuthPass = SettingsManager.getLocalSocksAuthPass()
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
@@ -57,6 +57,8 @@ class TProxyService(
 
     private fun buildConfig(): String {
         val socksPort = SettingsManager.getSocksPort()
+        val socksAuthUser = escapeYaml(SettingsManager.getLocalSocksAuthUser())
+        val socksAuthPass = escapeYaml(SettingsManager.getLocalSocksAuthPass())
         val vpnConfig = SettingsManager.getCurrentVpnInterfaceAddressConfig()
         return buildString {
             appendLine("tunnel:")
@@ -70,6 +72,8 @@ class TProxyService(
             appendLine("socks5:")
             appendLine("  port: ${socksPort}")
             appendLine("  address: ${AppConfig.LOOPBACK}")
+            appendLine("  username: '${socksAuthUser}'")
+            appendLine("  password: '${socksAuthPass}'")
             appendLine("  udp: 'udp'")
 
             // Read-write timeout settings
@@ -85,6 +89,10 @@ class TProxyService(
             appendLine("  udp-read-write-timeout: ${udpTimeout * 1000}")
             appendLine("  log-level: ${MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_LOGLEVEL) ?: "warn"}")
         }
+    }
+
+    private fun escapeYaml(value: String): String {
+        return value.replace("'", "''")
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
@@ -57,6 +57,7 @@ class TProxyService(
 
     private fun buildConfig(): String {
         val socksPort = SettingsManager.getSocksPort()
+        val socksAuthEnabled = SettingsManager.isLocalSocksAuthEnabled()
         val socksAuthUser = escapeYaml(SettingsManager.getLocalSocksAuthUser())
         val socksAuthPass = escapeYaml(SettingsManager.getLocalSocksAuthPass())
         val vpnConfig = SettingsManager.getCurrentVpnInterfaceAddressConfig()
@@ -72,8 +73,10 @@ class TProxyService(
             appendLine("socks5:")
             appendLine("  port: ${socksPort}")
             appendLine("  address: ${AppConfig.LOOPBACK}")
-            appendLine("  username: '${socksAuthUser}'")
-            appendLine("  password: '${socksAuthPass}'")
+            if (socksAuthEnabled) {
+                appendLine("  username: '${socksAuthUser}'")
+                appendLine("  password: '${socksAuthPass}'")
+            }
             appendLine("  udp: 'udp'")
 
             // Read-write timeout settings


### PR DESCRIPTION
## Changes
- Enforce `auth: "password"` for local SOCKS inbound.
- Add SOCKS `accounts` support to inbound config DTO.
- Generate random local SOCKS username/password in memory per service start.
- Apply the same credentials to `hev-socks5-tunnel` config (`username`/`password`).
- Rotate credentials when the service starts/restarts.

## Security impact
Previously, local SOCKS could be used without auth by other apps on the device.
Now unauthenticated access is rejected.