### PR TITLE
  fix: add SOCKS5 authentication to prevent unauthorized local proxy access

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -74,6 +74,8 @@ object AppConfig {
     const val PREF_HEV_TUNNEL_RW_TIMEOUT = "pref_hev_tunnel_rw_timeout_v2"
     const val PREF_AUTO_REMOVE_INVALID_AFTER_TEST = "pref_auto_remove_invalid_after_test"
     const val PREF_AUTO_SORT_AFTER_TEST = "pref_auto_sort_after_test"
+    const val PREF_SOCKS_AUTH_USERNAME = "pref_socks_auth_username"
+    const val PREF_SOCKS_AUTH_PASSWORD = "pref_socks_auth_password"
 
     /** Cache keys. */
     const val CACHE_SUBSCRIPTION_ID = "cache_subscription_id"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -44,9 +44,15 @@ data class V2rayConfig(
             var auth: String? = null,
             var udp: Boolean? = null,
             var userLevel: Int? = null,
+            var accounts: List<InboundAccountBean>? = null,
             var name: String? = null,
             @SerializedName("MTU")
             var mtu: Int? = null
+        )
+
+        data class InboundAccountBean(
+            var user: String = "",
+            var pass: String = ""
         )
 
         data class SniffingBean(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -32,6 +32,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.Collections
 import java.util.Locale
+import java.util.UUID
 
 object SettingsManager {
 
@@ -276,12 +277,46 @@ object SettingsManager {
         return Utils.parseInt(MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_PORT), AppConfig.PORT_SOCKS.toInt())
     }
 
+    fun getSocksAuthUsername(): String =
+        MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_AUTH_USERNAME) ?: ""
+
+    fun getSocksAuthPassword(): String =
+        MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_AUTH_PASSWORD) ?: ""
+
+    @Volatile
+    private var runtimeSocksPort: Int = 0
+
+    fun getEffectiveSocksPort(): Int {
+        val port = runtimeSocksPort
+        return if (port > 0) port else getSocksPort()
+    }
+
+    fun randomizeSocksPort(): Int {
+        val random = java.security.SecureRandom()
+        repeat(10) {
+            val candidate = 49152 + random.nextInt(16384)
+            try {
+                java.net.ServerSocket(candidate, 0,
+                    java.net.InetAddress.getByName(AppConfig.LOOPBACK)).use {
+                    runtimeSocksPort = candidate
+                    return candidate
+                }
+            } catch (_: Exception) { }
+        }
+        runtimeSocksPort = getSocksPort()
+        return runtimeSocksPort
+    }
+
+    fun clearRuntimePort() {
+        runtimeSocksPort = 0
+    }
+
     /**
      * Get the HTTP port.
      * @return The HTTP port.
      */
     fun getHttpPort(): Int {
-        return getSocksPort() + if (Utils.isXray()) 0 else 1
+        return getEffectiveSocksPort() + if (Utils.isXray()) 0 else 1
     }
 
     /**
@@ -452,6 +487,22 @@ object SettingsManager {
         ensureDefaultValue(AppConfig.PREF_MUX_XUDP_CONCURRENCY, "8")
         ensureDefaultValue(AppConfig.PREF_FRAGMENT_LENGTH, "50-100")
         ensureDefaultValue(AppConfig.PREF_FRAGMENT_INTERVAL, "10-20")
+        ensureSocksAuthCredentials()
+    }
+
+    private fun ensureSocksAuthCredentials() {
+        if (MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_AUTH_USERNAME).isNullOrEmpty()) {
+            MmkvManager.encodeSettings(
+                AppConfig.PREF_SOCKS_AUTH_USERNAME,
+                UUID.randomUUID().toString().replace("-", "").take(16)
+            )
+        }
+        if (MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_AUTH_PASSWORD).isNullOrEmpty()) {
+            MmkvManager.encodeSettings(
+                AppConfig.PREF_SOCKS_AUTH_PASSWORD,
+                UUID.randomUUID().toString().replace("-", "").take(16)
+            )
+        }
     }
 
     private fun ensureDefaultValue(key: String, default: String) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2RayServiceManager.kt
@@ -229,6 +229,7 @@ object V2RayServiceManager {
      */
     fun stopCoreLoop(): Boolean {
         val service = getService() ?: return false
+        SettingsManager.clearRuntimePort()
 
         if (coreController.isRunning) {
             CoroutineScope(Dispatchers.IO).launch {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/V2rayConfigManager.kt
@@ -372,13 +372,26 @@ object V2rayConfigManager {
      */
     private fun getInbounds(v2rayConfig: V2rayConfig): Boolean {
         try {
-            val socksPort = SettingsManager.getSocksPort()
+            val socksPort = SettingsManager.getEffectiveSocksPort()
             val inbound1 = v2rayConfig.inbounds[0]
 
             if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING) != true) {
                 inbound1.listen = AppConfig.LOOPBACK
             }
             inbound1.port = socksPort
+
+            // SOCKS5 authentication to prevent unauthorized proxy access from other apps
+            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING) != true) {
+                val username = SettingsManager.getSocksAuthUsername()
+                val password = SettingsManager.getSocksAuthPassword()
+                if (username.isNotEmpty() && password.isNotEmpty()) {
+                    inbound1.settings?.auth = "password"
+                    inbound1.settings?.accounts = listOf(
+                        V2rayConfig.InboundBean.InboundAccountBean(user = username, pass = password)
+                    )
+                }
+            }
+
             val fakedns = MmkvManager.decodeSettingsBool(AppConfig.PREF_FAKE_DNS_ENABLED) == true
             val sniffAllTlsAndHttp =
                 MmkvManager.decodeSettingsBool(AppConfig.PREF_SNIFFING_ENABLED, true) != false
@@ -397,6 +410,9 @@ object V2rayConfigManager {
                 inbound2.tag = EConfigType.HTTP.name.lowercase()
                 inbound2.port = SettingsManager.getHttpPort()
                 inbound2.protocol = EConfigType.HTTP.name.lowercase()
+                // Clear SOCKS-specific auth fields from HTTP inbound clone
+                inbound2.settings?.auth = null
+                inbound2.settings?.accounts = null
                 v2rayConfig.inbounds.add(inbound2)
             }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
@@ -56,7 +56,7 @@ class TProxyService(
     }
 
     private fun buildConfig(): String {
-        val socksPort = SettingsManager.getSocksPort()
+        val socksPort = SettingsManager.getEffectiveSocksPort()
         val vpnConfig = SettingsManager.getCurrentVpnInterfaceAddressConfig()
         return buildString {
             appendLine("tunnel:")
@@ -71,6 +71,13 @@ class TProxyService(
             appendLine("  port: ${socksPort}")
             appendLine("  address: ${AppConfig.LOOPBACK}")
             appendLine("  udp: 'udp'")
+
+            val username = SettingsManager.getSocksAuthUsername()
+            val password = SettingsManager.getSocksAuthPassword()
+            if (username.isNotEmpty() && password.isNotEmpty()) {
+                appendLine("  username: '${username}'")
+                appendLine("  password: '${password}'")
+            }
 
             // Read-write timeout settings
             val timeoutSetting = MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_RW_TIMEOUT) ?: AppConfig.HEVTUN_RW_TIMEOUT

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -147,6 +147,11 @@ class V2RayVpnService : VpnService(), ServiceControl {
             return
         }
 
+        // Randomize SOCKS port before any config generation (hev-socks5-tunnel and xray-core)
+        if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING) != true) {
+            SettingsManager.randomizeSocksPort()
+        }
+
         if (configureVpnService() != true) {
             Log.e(AppConfig.TAG, "StartCore-VPN: Configuration failed")
             stopSelf()


### PR DESCRIPTION
  ## Summary
            
  The local SOCKS5 proxy runs without authentication (`"auth": "noauth"`), allowing any app on the device to connect directly to `127.0.0.1:10808` and bypass per-app split tunneling. This enables malicious
  apps (including government-mandated spyware modules) to:                                                                                                                                                       
                                                          
  - Discover the VPN server's exit IP address                                                                                                                                                                    
  - Route their own traffic through the user's VPN tunnel   
  - Bypass Android private spaces (Knox/Shelter/Island) since loopback is not isolated
                                                                                                                                                                                                                 
  ## Changes                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  1. **SOCKS5 Authentication** — Random username/password generated on first launch, injected into xray-core inbound config and passed to hev-socks5-tunnel                                                      
  2. **Port Randomization** — SOCKS5 port randomized per VPN session (49152-65535) instead of fixed 10808                                                                                                        
                                                                                                         
  Auth is automatically disabled when "Proxy Sharing" is enabled (user's explicit choice to share the proxy on LAN).                                                                                             
                                                                                                                                                                                                                 
  ## References                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - POC bypass: https://github.com/runetfreedom/per-app-split-bypass-poc
  - Advanced detector: https://github.com/cherepavel/VPN-Detector                                                                                                                                                
  - Affected clients: v2rayNG, Hiddify, V2BOX, v2RayTun, Exclave, Npv Tunnel, Neko Box, and others
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - [ ] Connect VPN, verify internet works normally                                                                                                                                                              
  - [ ] `curl --socks5 127.0.0.1:<port> http://ifconfig.me` — should be rejected (no auth)                                                                                                                       
  - [ ] `curl --socks5-basic --proxy-user <user>:<pass> --socks5 127.0.0.1:<port> http://ifconfig.me` — should work
  - [ ] Port 10808 should not be listening (randomized)                                                                                                                                                          
  - [ ] Reconnect VPN — port should change                                                                                                                                                                       
  - [ ] Enable "Proxy Sharing" — auth should be disabled for LAN access                                                                                                                                          
                                                                                                                                                                                                                 
  ## Files changed (7)                                                                                                                                                                                           
                                                                                                                                                                                                                 
  | File | Change |                                                                                                                                                                                              
  |------|--------|                                         
  | `V2rayConfig.kt` | Add `InboundAccountBean` data class and `accounts` field |
  | `AppConfig.kt` | Add auth preference constants |                             
  | `SettingsManager.kt` | Credential generation, port randomization |                                                                                                                                           
  | `V2rayConfigManager.kt` | Inject auth into SOCKS5 inbound |                                                                                                                                                  
  | `TProxyService.kt` | Pass credentials to hev-socks5-tunnel |                                                                                                                                                 
  | `V2RayVpnService.kt` | Randomize port before service start |                                                                                                                                                 
  | `V2RayServiceManager.kt` | Clear runtime port on stop |       

Tested on Android 15 (MIUI) with VLESS/xray-core.