### PR TITLE
fix: send x-hwid for subscription updates

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -46,6 +46,9 @@ object AppConfig {
     const val SUBSCRIPTION_AUTO_UPDATE = "pref_auto_update_subscription"
     const val SUBSCRIPTION_AUTO_UPDATE_INTERVAL = "pref_auto_update_interval"
     const val SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL = "1440" // Default is 24 hours
+    // Remnawave HWID header (stable per install).
+    const val HWID_HEADER_NAME = "x-hwid"
+    const val PREF_FAKE_HWID = "pref_fake_hwid"
     const val SUBSCRIPTION_UPDATE_TASK_NAME = "subscription_updater"
     const val PREF_SPEED_ENABLED = "pref_speed_enabled"
     const val PREF_CONFIRM_REMOVE = "pref_confirm_remove"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
@@ -13,5 +13,7 @@ data class SubscriptionItem(
     var filter: String? = null,
     var allowInsecureUrl: Boolean = false,
     var userAgent: String? = null,
+    var enableXHwid: Boolean = false,
+    var customXHwid: String? = null,
 )
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -532,17 +532,19 @@ object AngConfigManager {
             }
             LogUtil.i(AppConfig.TAG, url)
             val userAgent = it.subscription.userAgent
+            val enableXHwid = it.subscription.enableXHwid
+            val customXHwid = it.subscription.customXHwid
 
             var configText = try {
                 val httpPort = SettingsManager.getHttpPort()
-                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort)
+                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, enableXHwid, customXHwid)
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.ANG_PACKAGE, "Update subscription: proxy not ready or other error", e)
                 ""
             }
             if (configText.isEmpty()) {
                 configText = try {
-                    HttpUtil.getUrlContentWithUserAgent(url, userAgent)
+                    HttpUtil.getUrlContentWithUserAgent(url, userAgent, enableXHwid = enableXHwid, customXHwid = customXHwid)
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "Update subscription: Failed to get URL content with user agent", e)
                     ""

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -537,14 +537,14 @@ object AngConfigManager {
 
             var configText = try {
                 val httpPort = SettingsManager.getHttpPort()
-                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, enableXHwid, customXHwid)
+                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, enableXHwid, customXHwid, it.guid)
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.ANG_PACKAGE, "Update subscription: proxy not ready or other error", e)
                 ""
             }
             if (configText.isEmpty()) {
                 configText = try {
-                    HttpUtil.getUrlContentWithUserAgent(url, userAgent, enableXHwid = enableXHwid, customXHwid = customXHwid)
+                    HttpUtil.getUrlContentWithUserAgent(url, userAgent, enableXHwid = enableXHwid, customXHwid = customXHwid, subId = it.guid)
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "Update subscription: Failed to get URL content with user agent", e)
                     ""

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -393,6 +393,9 @@ object MmkvManager {
         encodeSubsList(subsList)
 
         removeServerViaSubid(subid)
+        // Clean up per-subscription HWID
+        val hwidKey = "sub_hwid_$subid"
+        settingsStorage.remove(hwidKey)
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -86,8 +86,9 @@ class SubEditActivity : BaseActivity() {
     private fun updateXHwidInputState(enabled: Boolean) {
         binding.etCustomXHwid.isEnabled = enabled
         binding.etCustomXHwid.alpha = if (enabled) 1f else 0.6f
-        if (enabled && binding.etCustomXHwid.text.isEmpty()) {
-            binding.etCustomXHwid.setText(HttpUtil.getFakeHwid())
+        if (enabled && binding.etCustomXHwid.text.isEmpty() && editSubId.isNotEmpty()) {
+            // Generate or retrieve per-subscription HWID for existing subscriptions
+            binding.etCustomXHwid.setText(HttpUtil.getSubscriptionHwid(editSubId))
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -16,6 +16,7 @@ import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.util.Utils
+import com.v2ray.ang.util.HttpUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -85,6 +86,9 @@ class SubEditActivity : BaseActivity() {
     private fun updateXHwidInputState(enabled: Boolean) {
         binding.etCustomXHwid.isEnabled = enabled
         binding.etCustomXHwid.alpha = if (enabled) 1f else 0.6f
+        if (enabled && binding.etCustomXHwid.text.isEmpty()) {
+            binding.etCustomXHwid.setText(HttpUtil.getFakeHwid())
+        }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -48,12 +48,18 @@ class SubEditActivity : BaseActivity() {
         binding.etRemarks.text = Utils.getEditable(subItem.remarks)
         binding.etUrl.text = Utils.getEditable(subItem.url)
         binding.etUserAgent.text = Utils.getEditable(subItem.userAgent)
+        binding.etCustomXHwid.text = Utils.getEditable(subItem.customXHwid)
         binding.etFilter.text = Utils.getEditable(subItem.filter)
         binding.chkEnable.isChecked = subItem.enabled
+        binding.chkEnableXHwid.isChecked = subItem.enableXHwid
         binding.autoUpdateCheck.isChecked = subItem.autoUpdate
         binding.allowInsecureUrl.isChecked = subItem.allowInsecureUrl
         binding.etPreProfile.text = Utils.getEditable(subItem.prevProfile)
         binding.etNextProfile.text = Utils.getEditable(subItem.nextProfile)
+        updateXHwidInputState(subItem.enableXHwid)
+        binding.chkEnableXHwid.setOnCheckedChangeListener { _, isChecked ->
+            updateXHwidInputState(isChecked)
+        }
         return true
     }
 
@@ -63,11 +69,22 @@ class SubEditActivity : BaseActivity() {
     private fun clearServer(): Boolean {
         binding.etRemarks.text = null
         binding.etUrl.text = null
+        binding.etCustomXHwid.text = null
         binding.etFilter.text = null
         binding.chkEnable.isChecked = true
+        binding.chkEnableXHwid.isChecked = false
         binding.etPreProfile.text = null
         binding.etNextProfile.text = null
+        updateXHwidInputState(false)
+        binding.chkEnableXHwid.setOnCheckedChangeListener { _, isChecked ->
+            updateXHwidInputState(isChecked)
+        }
         return true
+    }
+
+    private fun updateXHwidInputState(enabled: Boolean) {
+        binding.etCustomXHwid.isEnabled = enabled
+        binding.etCustomXHwid.alpha = if (enabled) 1f else 0.6f
     }
 
     /**
@@ -79,6 +96,8 @@ class SubEditActivity : BaseActivity() {
         subItem.remarks = binding.etRemarks.text.toString()
         subItem.url = binding.etUrl.text.toString()
         subItem.userAgent = binding.etUserAgent.text.toString()
+        subItem.enableXHwid = binding.chkEnableXHwid.isChecked
+        subItem.customXHwid = binding.etCustomXHwid.text.toString().trim().ifEmpty { null }
         subItem.filter = binding.etFilter.text.toString()
         subItem.enabled = binding.chkEnable.isChecked
         subItem.autoUpdate = binding.autoUpdateCheck.isChecked

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -25,7 +25,7 @@ object HttpUtil {
 
     // Stable fake HWID for x-hwid; generated once, then reused.
     @Synchronized
-    private fun getFakeHwid(): String {
+    internal fun getFakeHwid(): String {
         cachedFakeHwid?.let { return it }
         val stored = MmkvManager.decodeSettingsString(AppConfig.PREF_FAKE_HWID)
         val hwid = stored?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString().also {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -4,6 +4,7 @@ import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.LOOPBACK
 import com.v2ray.ang.BuildConfig
+import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.util.Utils.encode
 import com.v2ray.ang.util.Utils.urlDecode
 import java.io.IOException
@@ -16,8 +17,23 @@ import java.net.MalformedURLException
 import java.net.Proxy
 import java.net.URI
 import java.net.URL
+import java.util.UUID
 
 object HttpUtil {
+
+    private var cachedFakeHwid: String? = null
+
+    // Stable fake HWID for x-hwid; generated once, then reused.
+    @Synchronized
+    private fun getFakeHwid(): String {
+        cachedFakeHwid?.let { return it }
+        val stored = MmkvManager.decodeSettingsString(AppConfig.PREF_FAKE_HWID)
+        val hwid = stored?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString().also {
+            MmkvManager.encodeSettings(AppConfig.PREF_FAKE_HWID, it)
+        }
+        cachedFakeHwid = hwid
+        return hwid
+    }
 
     /**
      * Converts the domain part of a URL string to its IDN (Punycode, ASCII Compatible Encoding) format.
@@ -110,6 +126,9 @@ object HttpUtil {
     fun getUrlContent(url: String, timeout: Int, httpPort: Int = 0): String? {
         val conn = createProxyConnection(url, httpPort, timeout, timeout) ?: return null
         try {
+            // x-hwid required by Remnawave.
+            conn.setRequestProperty(AppConfig.HWID_HEADER_NAME, getFakeHwid())
+            conn.connect()
             return conn.inputStream.bufferedReader().readText()
         } catch (_: Exception) {
         } finally {
@@ -142,6 +161,8 @@ object HttpUtil {
                 userAgent
             }
             conn.setRequestProperty("User-agent", finalUserAgent)
+            // x-hwid required by Remnawave.
+            conn.setRequestProperty(AppConfig.HWID_HEADER_NAME, getFakeHwid())
             conn.connect()
 
             val responseCode = conn.responseCode

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -113,6 +113,14 @@ object HttpUtil {
         }
     }
 
+    // Per-subscription HWID: generate once and persist
+    @Synchronized
+    fun getSubscriptionHwid(subId: String): String {
+        val stored = MmkvManager.decodeSettingsString("sub_hwid_$subId")
+        return stored?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString().also {
+            MmkvManager.encodeSettings("sub_hwid_$subId", it)
+        }
+    }
 
     /**
      * Retrieves the content of a URL as a string.
@@ -125,8 +133,7 @@ object HttpUtil {
     fun getUrlContent(url: String, timeout: Int, httpPort: Int = 0): String? {
         val conn = createProxyConnection(url, httpPort, timeout, timeout) ?: return null
         try {
-            // x-hwid required by Remnawave.
-            conn.setRequestProperty(AppConfig.HWID_HEADER_NAME, getFakeHwid())
+            // Do NOT add x-hwid by default for generic requests
             conn.connect()
             return conn.inputStream.bufferedReader().readText()
         } catch (_: Exception) {
@@ -142,6 +149,9 @@ object HttpUtil {
      * @param url The URL to fetch content from.
      * @param timeout The timeout value in milliseconds.
      * @param httpPort The HTTP port to use.
+     * @param enableXHwid Whether to include x-hwid header.
+     * @param customXHwid Custom x-hwid value (if null and enableXHwid is true, generates per-subscription or global fallback).
+     * @param subId Optional subscription ID for per-sub HWID generation.
      * @return The content of the URL as a string.
      * @throws IOException If an I/O error occurs.
      */
@@ -152,7 +162,8 @@ object HttpUtil {
         timeout: Int = 15000,
         httpPort: Int = 0,
         enableXHwid: Boolean = false,
-        customXHwid: String? = null
+        customXHwid: String? = null,
+        subId: String? = null
     ): String {
         var currentUrl = url
         var redirects = 0
@@ -168,7 +179,13 @@ object HttpUtil {
             }
             conn.setRequestProperty("User-agent", finalUserAgent)
             if (enableXHwid) {
-                val hwid = customXHwid?.trim().takeUnless { it.isNullOrEmpty() } ?: getFakeHwid()
+                val hwid = if (!customXHwid.isNullOrBlank()) {
+                    customXHwid.trim()
+                } else if (subId != null) {
+                    getSubscriptionHwid(subId)
+                } else {
+                    getFakeHwid()
+                }
                 conn.setRequestProperty(AppConfig.HWID_HEADER_NAME, hwid)
             }
             conn.connect()
@@ -280,4 +297,3 @@ object HttpUtil {
         }
     }
 }
-

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -147,7 +147,14 @@ object HttpUtil {
      * @throws IOException If an I/O error occurs.
      */
     @Throws(IOException::class)
-    fun getUrlContentWithUserAgent(url: String?, userAgent: String?,  timeout: Int = 15000, httpPort: Int = 0): String {
+    fun getUrlContentWithUserAgent(
+        url: String?,
+        userAgent: String?,
+        timeout: Int = 15000,
+        httpPort: Int = 0,
+        enableXHwid: Boolean = false,
+        customXHwid: String? = null
+    ): String {
         var currentUrl = url
         var redirects = 0
         val maxRedirects = 3
@@ -161,8 +168,10 @@ object HttpUtil {
                 userAgent
             }
             conn.setRequestProperty("User-agent", finalUserAgent)
-            // x-hwid required by Remnawave.
-            conn.setRequestProperty(AppConfig.HWID_HEADER_NAME, getFakeHwid())
+            if (enableXHwid) {
+                val hwid = customXHwid?.trim().takeUnless { it.isNullOrEmpty() } ?: getFakeHwid()
+                conn.setRequestProperty(AppConfig.HWID_HEADER_NAME, hwid)
+            }
             conn.connect()
 
             val responseCode = conn.responseCode

--- a/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
@@ -144,6 +144,48 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1.0"
+                    android:text="@string/sub_setting_enable_x_hwid" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/chk_enable_x_hwid"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="@dimen/padding_spacing_dp16"
+                    android:paddingEnd="@dimen/padding_spacing_dp16"
+                    app:theme="@style/BrandedSwitch" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sub_setting_custom_x_hwid" />
+
+                <EditText
+                    android:id="@+id/et_custom_x_hwid"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/sub_setting_custom_x_hwid_hint"
+                    android:inputType="textNoSuggestions" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.0"
                     android:text="@string/sub_auto_update" />
 
 

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -287,6 +287,9 @@
     <string name="sub_setting_remarks">Название</string>
     <string name="sub_setting_url">URL (необязательно)</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_enable_x_hwid">Включить заголовок x-hwid</string>
+    <string name="sub_setting_custom_x_hwid">Пользовательский x-hwid</string>
+    <string name="sub_setting_custom_x_hwid_hint">Оставьте пустым для сгенерированного значения</string>
     <string name="sub_setting_filter">Название фильтра</string>
     <string name="sub_setting_enable">Использовать обновление</string>
     <string name="sub_auto_update">Использовать автообновление</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -292,6 +292,9 @@
     <string name="sub_setting_remarks">remarks</string>
     <string name="sub_setting_url">Optional URL</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_enable_x_hwid">Enable x-hwid header</string>
+    <string name="sub_setting_custom_x_hwid">Custom x-hwid value</string>
+    <string name="sub_setting_custom_x_hwid_hint">Leave empty to use generated value</string>
     <string name="sub_setting_filter">Remarks regular filter</string>
     <string name="sub_setting_enable">Enable update</string>
     <string name="sub_auto_update">Enable automatic update</string>


### PR DESCRIPTION
## Summary
- send `x-hwid` with subscription update requests
- keep the value stable per install by persisting it once
- avoid per-request random IDs that can trigger false device-limit hits
## Why
Some subscription endpoints reject requests when device binding is enabled and `x-hwid` is missing.
Using a stable stub restores compatibility without adding hardware fingerprinting or changing behavior for servers that ignore the header.
## Notes
- applied only to subscription download requests
- no UI changes
- no real hardware identifiers are collected
