### PR TITLE
Add negative UID handling to process routing

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -219,6 +219,8 @@ object AppConfig {
     const val REALITY = "reality"
     const val HEADER_TYPE_HTTP = "http"
 
+    const val UNIDENTIFIED_PACKAGE = "__unknown_app__"
+
     val DNS_ALIDNS_ADDRESSES = arrayListOf("223.5.5.5", "223.6.6.6", "2400:3200::1", "2400:3200:baba::1")
     val DNS_CLOUDFLARE_ONE_ADDRESSES = arrayListOf("1.1.1.1", "1.0.0.1", "2606:4700:4700::1111", "2606:4700:4700::1001")
     val DNS_CLOUDFLARE_DNS_COM_ADDRESSES = arrayListOf("104.16.132.229", "104.16.133.229", "2606:4700::6810:84e5", "2606:4700::6810:85e5")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AppPickerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AppPickerActivity.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.ui
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -7,11 +8,13 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.widget.SearchView
 import androidx.lifecycle.lifecycleScope
+import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.databinding.ActivityAppPickerBinding
 import com.v2ray.ang.dto.AppInfo
 import com.v2ray.ang.util.AppManagerUtil
 import com.v2ray.ang.util.LogUtil
+import com.v2ray.ang.util.PackageUidResolver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -101,11 +104,15 @@ class AppPickerActivity : BaseActivity() {
         addCustomDividerToRecyclerView(binding.recyclerView, this, R.drawable.custom_divider)
     }
 
+    @SuppressLint("UseCompatLoadingForDrawables")
     private fun createSpecialItemUnidentified(): AppInfo {
-        val icon = getDrawable(android.R.drawable.ic_menu_manage) ?: getDrawable(android.R.drawable.sym_def_app_icon)!!
+        val icon = requireNotNull(
+            getDrawable(android.R.drawable.ic_menu_help)
+                ?: getDrawable(android.R.drawable.sym_def_app_icon)
+        ) { "No fallback drawable available" }
         return AppInfo(
-            appName = "Catch missing process UID (-1)",
-            packageName = "__unidentified__",
+            appName = getString(R.string.app_picker_unknown_app),
+            packageName = AppConfig.UNIDENTIFIED_PACKAGE,
             appIcon = icon,
             isSystemApp = false,
             isSelected = 0

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AppPickerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AppPickerActivity.kt
@@ -101,6 +101,17 @@ class AppPickerActivity : BaseActivity() {
         addCustomDividerToRecyclerView(binding.recyclerView, this, R.drawable.custom_divider)
     }
 
+    private fun createSpecialItemUnidentified(): AppInfo {
+        val icon = getDrawable(android.R.drawable.ic_menu_manage) ?: getDrawable(android.R.drawable.sym_def_app_icon)!!
+        return AppInfo(
+            appName = "Catch missing process UID (-1)",
+            packageName = "__unidentified__",
+            appIcon = icon,
+            isSystemApp = false,
+            isSelected = 0
+        )
+    }
+
     private fun loadApps() {
         showLoading()
 
@@ -108,7 +119,8 @@ class AppPickerActivity : BaseActivity() {
             try {
                 val apps = withContext(Dispatchers.IO) {
                     val appsList = AppManagerUtil.loadNetworkAppList(this@AppPickerActivity)
-                    sortApps(appsList)
+                    val sortedApps = sortApps(appsList)
+                    listOf(createSpecialItemUnidentified()) + sortedApps
                 }
 
                 appsAll = apps

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/PackageUidResolver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/PackageUidResolver.kt
@@ -2,11 +2,10 @@ package com.v2ray.ang.util
 
 import android.content.Context
 import android.content.pm.PackageManager
+import com.v2ray.ang.AppConfig
 import java.util.concurrent.ConcurrentHashMap
 
 object PackageUidResolver {
-
-    private const val TAG = "PackageUidResolver"
 
     // In-process cache to avoid resolving the same package UID repeatedly.
     private val packageUidCache = ConcurrentHashMap<String, String>()
@@ -33,18 +32,18 @@ object PackageUidResolver {
 
     private fun resolveUid(context: Context, packageName: String): String? {
         // Special token for connections whose UID cannot be resolved (mapped to -1)
-        if (packageName == "__unidentified__") {
+        if (packageName == AppConfig.UNIDENTIFIED_PACKAGE) {
             val uid = "-1" 
-            LogUtil.d(TAG, "Special package: $packageName -> UID: $uid")
+            LogUtil.d(AppConfig.TAG, "Special package: $packageName -> UID: $uid")
             return uid
         }
 
         return try {
             val uid = context.packageManager.getPackageUid(packageName, 0).toString()
-            LogUtil.d(TAG, "Package: $packageName -> UID: $uid")
+            LogUtil.d(AppConfig.TAG, "Package: $packageName -> UID: $uid")
             uid
         } catch (_: PackageManager.NameNotFoundException) {
-            LogUtil.w(TAG, "Package not found: $packageName")
+            LogUtil.w(AppConfig.TAG, "Package not found: $packageName")
             null
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/PackageUidResolver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/PackageUidResolver.kt
@@ -32,6 +32,13 @@ object PackageUidResolver {
     }
 
     private fun resolveUid(context: Context, packageName: String): String? {
+        // Special token for connections whose UID cannot be resolved (mapped to -1)
+        if (packageName == "__unidentified__") {
+            val uid = "-1" 
+            LogUtil.d(TAG, "Special package: $packageName -> UID: $uid")
+            return uid
+        }
+
         return try {
             val uid = context.packageManager.getPackageUid(packageName, 0).toString()
             LogUtil.d(TAG, "Package: $packageName -> UID: $uid")

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -144,6 +144,7 @@
     <string name="menu_item_import_proxy_app">Import from Clipboard</string>
     <string name="per_app_proxy_settings">Per-app settings</string>
     <string name="per_app_proxy_settings_enable">Enable per-app</string>
+    <string name="app_picker_unknown_app">Unknown app (unidentified UID)</string>
 
     <!-- Preferences -->
     <string name="title_settings">Settings</string>


### PR DESCRIPTION
Adds special item in process picker routing to handle process with negative UID (-1). Necessary to protect against malicious apps abusing SO_BINDTODEVICE which results in forced access to tun0 (linux kernel >=5.7).

This PR requires modification of libv2ray_android.go in another repo, to allow handling of negative UID.