### PR TITLE
fix: remove unsafe exec() in LogcatViewModel.kt

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/LogcatViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/LogcatViewModel.kt
@@ -15,14 +15,15 @@ class LogcatViewModel : ViewModel() {
 
     fun loadLogcat() {
         try {
-            val lst = LinkedHashSet<String>()
-            lst.add("logcat")
-            lst.add("-d")
-            lst.add("-v")
-            lst.add("time")
-            lst.add("-s")
-            lst.add("GoLog,${ANG_PACKAGE},AndroidRuntime,System.err")
-            val process = Runtime.getRuntime().exec(lst.toTypedArray())
+            val allowedTags = listOf("GoLog", ANG_PACKAGE, "AndroidRuntime", "System.err")
+            val tagFilter = allowedTags.joinToString(",") { tag ->
+                require(tag.matches(Regex("[A-Za-z0-9_.:]+"))) { "Invalid logcat tag: $tag" }
+                tag
+            }
+            val cmd = listOf("logcat", "-d", "-v", "time", "-s", tagFilter)
+            val process = ProcessBuilder(cmd)
+                .redirectErrorStream(false)
+                .start()
             val allText = process.inputStream.bufferedReader().use { it.readLines() }.reversed()
 
             logsetsAll.clear()
@@ -35,10 +36,10 @@ class LogcatViewModel : ViewModel() {
 
     fun clearLogcat() {
         try {
-            val lst = LinkedHashSet<String>()
-            lst.add("logcat")
-            lst.add("-c")
-            val process = Runtime.getRuntime().exec(lst.toTypedArray())
+            val cmd = listOf("logcat", "-c")
+            val process = ProcessBuilder(cmd)
+                .redirectErrorStream(false)
+                .start()
             process.waitFor()
 
             logsetsAll.clear()


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/LogcatViewModel.kt`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/LogcatViewModel.kt:25` |

**Description**: LogcatViewModel.kt invokes Runtime.getRuntime().exec(lst.toTypedArray()) at lines 25 and 41. The 'lst' array is constructed from command arguments. If any element of 'lst' is derived from user-controlled input such as server configuration fields, routing tags, or package names imported via subscription URLs or QR codes, an attacker can inject shell metacharacters or arbitrary arguments. While Runtime.exec() with an array does not invoke a shell by default, passing attacker-controlled strings as individual array elements can still lead to argument injection or execution of unintended commands if the array construction logic incorporates external data.

## Changes
- `V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/LogcatViewModel.kt`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
