### PR TITLE
Return null in IP test if http port is 0

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
@@ -1,6 +1,5 @@
 package com.v2ray.ang.handler
 
-import android.content.Context
 import android.os.SystemClock
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
@@ -90,6 +89,7 @@ object SpeedtestManager {
         val proxyUsername = SettingsManager.getSocksUsername()
         val proxyPassword = SettingsManager.getSocksPassword()
         val httpPort = SettingsManager.getHttpPort()
+        if (httpPort == 0) return null
         val content = HttpUtil.getUrlContent(url, 5000, httpPort, proxyUsername, proxyPassword) ?: return null
         val ipInfo = JsonUtil.fromJson(content, IPAPIInfo::class.java) ?: return null
 


### PR DESCRIPTION
The new version of getUrlContent uses direct connection whenever httpPort is 0. In this case getRemoteIPInfo returns nonsense result (domestic IP). Fix this by returning null and therefore avoiding confusion.

With httpPort set to 0 and UID -1 -> block rule the VPN connection is so much protected that it's almost impossible even for v2rayNG to use it. To make a proper fix, we would need to proxy the v2rayNG app itself, but then we probably have to run xray core in a separate process. Something to look at in the future