### PR TITLE
Fix connection name in Android system notification after reconnect

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
@@ -1,6 +1,5 @@
 package com.v2ray.ang.handler
 
-import android.content.Context
 import android.os.SystemClock
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
@@ -90,6 +89,7 @@ object SpeedtestManager {
         val proxyUsername = SettingsManager.getSocksUsername()
         val proxyPassword = SettingsManager.getSocksPassword()
         val httpPort = SettingsManager.getHttpPort()
+        if (httpPort == 0) return null
         val content = HttpUtil.getUrlContent(url, 5000, httpPort, proxyUsername, proxyPassword) ?: return null
         val ipInfo = JsonUtil.fromJson(content, IPAPIInfo::class.java) ?: return null
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/V2RayVpnService.kt
@@ -253,7 +253,8 @@ class V2RayVpnService : VpnService(), ServiceControl {
             }
         }
 
-        builder.setSession(V2RayServiceManager.getRunningServerName())
+        val remarks = MmkvManager.getSelectServer()?.let { MmkvManager.decodeServerConfig(it)?.remarks }
+        builder.setSession(remarks ?: "v2rayNG")
     }
 
     /**


### PR DESCRIPTION
There was some problem where after pressing on another server and reconnecting android system network name wouldn't update automatically sometimes. This PR fixes this