### PR TITLE
Improve auto-update

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -273,6 +273,11 @@
 
         </provider>
 
+        <service
+            android:name="androidx.work.multiprocess.RemoteWorkManagerService"
+            android:exported="false"
+            android:process=":bg" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.cache"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
@@ -7,7 +7,7 @@ data class SubscriptionItem(
     val addedTime: Long = System.currentTimeMillis(),
     var lastUpdated: Long = -1,
     var autoUpdate: Boolean = false,
-    val updateInterval: Int? = null,
+    var updateInterval: Int? = null,
     var prevProfile: String? = null,
     var nextProfile: String? = null,
     var filter: String? = null,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
@@ -6,6 +6,7 @@ data class SubscriptionItem(
     var enabled: Boolean = true,
     val addedTime: Long = System.currentTimeMillis(),
     var lastUpdated: Long = -1,
+    var lastUpdateAttempt: Long = -1,
     var autoUpdate: Boolean = false,
     var updateInterval: Int? = null,
     var prevProfile: String? = null,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -543,7 +543,7 @@ object AngConfigManager {
                 val httpPort = SettingsManager.getHttpPort()
                 HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, proxyUsername, proxyPassword) { response ->
                     response.header("Profile-Update-Interval")?.toIntOrNull()?.let { intervalHours ->
-                        it.subscription.updateInterval = intervalHours * 60
+                        it.subscription.updateInterval = Math.max(1, intervalHours) * 60
                         it.subscription.autoUpdate = true
                     }
                 }
@@ -555,7 +555,7 @@ object AngConfigManager {
                 configText = try {
                     HttpUtil.getUrlContentWithUserAgent(url, userAgent) { response ->
                         response.header("Profile-Update-Interval")?.toIntOrNull()?.let { intervalHours ->
-                            it.subscription.updateInterval = intervalHours * 60
+                            it.subscription.updateInterval = Math.max(1, intervalHours) * 60
                             it.subscription.autoUpdate = true
                         }
                     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -573,7 +573,7 @@ object AngConfigManager {
                 it.subscription.lastUpdated = System.currentTimeMillis()
                 MmkvManager.encodeSubscription(it.guid, it.subscription)
                 LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")
-                SubscriptionUpdater.scheduleTask(AngApplication.application, it.guid, force = true)
+                SubscriptionUpdater.scheduleTask(AngApplication.application, it.guid)
                 return SubscriptionUpdateResult(
                     configCount = count,
                     successCount = 1

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -522,6 +522,9 @@ object AngConfigManager {
                 return SubscriptionUpdateResult(skipCount = 1)
             }
 
+            it.subscription.lastUpdateAttempt = System.currentTimeMillis()
+            MmkvManager.encodeSubscription(it.guid, it.subscription)
+
             val url = HttpUtil.toIdnUrl(it.subscription.url)
             if (!Utils.isValidUrl(url)) {
                 return SubscriptionUpdateResult(failureCount = 1)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.handler
 import android.content.Context
 import android.graphics.Bitmap
 import android.text.TextUtils
+import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.HY2
 import com.v2ray.ang.R
@@ -537,14 +538,24 @@ object AngConfigManager {
 
             var configText = try {
                 val httpPort = SettingsManager.getHttpPort()
-                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, proxyUsername, proxyPassword)
+                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, proxyUsername, proxyPassword) { response ->
+                    response.header("Profile-Update-Interval")?.toIntOrNull()?.let { intervalHours ->
+                        it.subscription.updateInterval = intervalHours * 60
+                        it.subscription.autoUpdate = true
+                    }
+                }
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.ANG_PACKAGE, "Update subscription: proxy not ready or other error", e)
                 ""
             }
             if (configText.isEmpty()) {
                 configText = try {
-                    HttpUtil.getUrlContentWithUserAgent(url, userAgent)
+                    HttpUtil.getUrlContentWithUserAgent(url, userAgent) { response ->
+                        response.header("Profile-Update-Interval")?.toIntOrNull()?.let { intervalHours ->
+                            it.subscription.updateInterval = intervalHours * 60
+                            it.subscription.autoUpdate = true
+                        }
+                    }
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "Update subscription: Failed to get URL content with user agent", e)
                     ""
@@ -559,6 +570,7 @@ object AngConfigManager {
                 it.subscription.lastUpdated = System.currentTimeMillis()
                 MmkvManager.encodeSubscription(it.guid, it.subscription)
                 LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")
+                SubscriptionUpdater.scheduleTask(AngApplication.application, it.guid, force = true)
                 return SubscriptionUpdateResult(
                     configCount = count,
                     successCount = 1

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 
 object SubscriptionUpdater {
 
-    fun scheduleAllTasks(context: Context, force: Boolean = false) {
+    fun scheduleAllTasks(context: Context) {
         val enabled = MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE, false)
         if (!enabled) {
             cancelAllTasks(context)
@@ -26,12 +26,12 @@ object SubscriptionUpdater {
 
         MmkvManager.decodeSubscriptions().forEach { sub ->
             if (sub.subscription.autoUpdate) {
-                scheduleTask(context, sub.guid, force)
+                scheduleTask(context, sub.guid)
             }
         }
     }
 
-    fun scheduleTask(context: Context, subId: String, force: Boolean = false) {
+    fun scheduleTask(context: Context, subId: String) {
         val globalEnabled = MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE, false)
         val subItem = MmkvManager.decodeSubscription(subId)
 
@@ -56,15 +56,11 @@ object SubscriptionUpdater {
         val lastAttempt = subItem.lastUpdateAttempt
         val intervalMillis = intervalMinutes.toLong() * 60 * 1000
         
-        val initialDelayMillis = if (force) {
-            intervalMillis
+        val initialDelayMillis = if (lastAttempt <= 0) {
+            0L // Never tried before, run immediately
         } else {
-            if (lastAttempt <= 0) {
-                0L // Never tried before, run immediately
-            } else {
-                val nextExpectedRun = lastAttempt + intervalMillis
-                Math.max(0L, nextExpectedRun - currentTime)
-            }
+            val nextExpectedRun = lastAttempt + intervalMillis
+            Math.max(0L, nextExpectedRun - currentTime)
         }
 
         val constraints = Constraints.Builder()
@@ -82,13 +78,11 @@ object SubscriptionUpdater {
             .addTag(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
             .build()
 
-        // If not force, use KEEP. WorkManager will do nothing if it's already there.
-        // If force, use REPLACE. It will reset the timer using our calculated initialDelay.
-        val policy = if (force) ExistingPeriodicWorkPolicy.REPLACE else ExistingPeriodicWorkPolicy.KEEP
-
+        // Always use REPLACE to ensure our calculated initialDelay is applied.
+        // This handles app launch (smart delay), manual update (timer reset), and global toggle.
         rw.enqueueUniquePeriodicWork(
             "${AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME}_$subId",
-            policy,
+            ExistingPeriodicWorkPolicy.REPLACE,
             request
         )
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -7,13 +7,82 @@ import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.work.CoroutineWorker
-import androidx.work.WorkerParameters
+import androidx.work.*
+import androidx.work.multiprocess.RemoteWorkManager
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
+import com.v2ray.ang.dto.SubscriptionCache
+import com.v2ray.ang.extension.toLongEx
 import com.v2ray.ang.util.LogUtil
+import java.util.concurrent.TimeUnit
 
 object SubscriptionUpdater {
+
+    fun scheduleAllTasks(context: Context, force: Boolean = false) {
+        val enabled = MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE, false)
+        if (!enabled) {
+            cancelAllTasks(context)
+            return
+        }
+
+        MmkvManager.decodeSubscriptions().forEach { sub ->
+            if (sub.subscription.autoUpdate) {
+                scheduleTask(context, sub.guid, force)
+            }
+        }
+    }
+
+    fun scheduleTask(context: Context, subId: String, force: Boolean = false) {
+        val globalEnabled = MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE, false)
+        val subItem = MmkvManager.decodeSubscription(subId)
+
+        if (!globalEnabled || subItem == null || !subItem.autoUpdate) {
+            cancelTask(context, subId)
+            return
+        }
+
+        val interval = subItem.updateInterval?.toLong()
+            ?: MmkvManager.decodeSettingsString(
+                AppConfig.SUBSCRIPTION_AUTO_UPDATE_INTERVAL,
+                AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL
+            ).orEmpty().toLongEx()
+
+        if (interval <= 0) return
+
+        val rw = RemoteWorkManager.getInstance(context)
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val data = Data.Builder()
+            .putString("subId", subId)
+            .build()
+
+        val request = PeriodicWorkRequest.Builder(UpdateTask::class.java, interval, TimeUnit.MINUTES)
+            .setConstraints(constraints)
+            .setInputData(data)
+            .setInitialDelay(interval, TimeUnit.MINUTES)
+            .addTag(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
+            .build()
+
+        val policy = if (force) ExistingPeriodicWorkPolicy.REPLACE else ExistingPeriodicWorkPolicy.KEEP
+
+        rw.enqueueUniquePeriodicWork(
+            "${AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME}_$subId",
+            policy,
+            request
+        )
+    }
+
+    fun cancelAllTasks(context: Context) {
+        val rw = RemoteWorkManager.getInstance(context)
+        rw.cancelAllWorkByTag(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
+    }
+
+    fun cancelTask(context: Context, subId: String) {
+        val rw = RemoteWorkManager.getInstance(context)
+        rw.cancelUniqueWork("${AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME}_$subId")
+    }
 
     class UpdateTask(context: Context, params: WorkerParameters) :
         CoroutineWorker(context, params) {
@@ -34,9 +103,16 @@ object SubscriptionUpdater {
          */
         @SuppressLint("MissingPermission")
         override suspend fun doWork(): Result {
-            LogUtil.i(AppConfig.TAG, "subscription automatic update starting")
+            val subId = inputData.getString("subId")
+            LogUtil.i(AppConfig.TAG, "subscription automatic update starting: $subId")
 
-            val subs = MmkvManager.decodeSubscriptions().filter { it.subscription.autoUpdate }
+            val subs = if (subId.isNullOrEmpty()) {
+                MmkvManager.decodeSubscriptions().filter { it.subscription.autoUpdate }
+            } else {
+                MmkvManager.decodeSubscription(subId)?.let {
+                    listOf(SubscriptionCache(subId, it))
+                } ?: emptyList()
+            }
 
             for (sub in subs) {
                 val subItem = sub.subscription

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -12,7 +12,6 @@ import androidx.work.multiprocess.RemoteWorkManager
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.SubscriptionCache
-import com.v2ray.ang.extension.toLongEx
 import com.v2ray.ang.util.LogUtil
 import java.util.concurrent.TimeUnit
 
@@ -41,15 +40,31 @@ object SubscriptionUpdater {
             return
         }
 
-        val interval = subItem.updateInterval?.toLong()
-            ?: MmkvManager.decodeSettingsString(
-                AppConfig.SUBSCRIPTION_AUTO_UPDATE_INTERVAL,
-                AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL
-            ).orEmpty().toLongEx()
+        val intervalMinutes = subItem.updateInterval ?: MmkvManager.decodeSettingsString(
+            AppConfig.SUBSCRIPTION_AUTO_UPDATE_INTERVAL,
+            AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL
+        ).orEmpty().toIntOrNull() ?: AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL.toInt()
 
-        if (interval <= 0) return
+        if (intervalMinutes <= 0) return
 
         val rw = RemoteWorkManager.getInstance(context)
+
+        // Calculate initial delay for smart rescheduling
+        val currentTime = System.currentTimeMillis()
+        val lastAttempt = subItem.lastUpdateAttempt
+        val intervalMillis = intervalMinutes.toLong() * 60 * 1000
+        
+        val initialDelayMillis = if (force) {
+            intervalMillis
+        } else {
+            if (lastAttempt <= 0) {
+                0L // Never tried before, run immediately
+            } else {
+                val nextExpectedRun = lastAttempt + intervalMillis
+                Math.max(0L, nextExpectedRun - currentTime)
+            }
+        }
+
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
@@ -58,13 +73,15 @@ object SubscriptionUpdater {
             .putString("subId", subId)
             .build()
 
-        val request = PeriodicWorkRequest.Builder(UpdateTask::class.java, interval, TimeUnit.MINUTES)
+        val request = PeriodicWorkRequest.Builder(UpdateTask::class.java, intervalMinutes.toLong(), TimeUnit.MINUTES)
             .setConstraints(constraints)
             .setInputData(data)
-            .setInitialDelay(interval, TimeUnit.MINUTES)
+            .setInitialDelay(initialDelayMillis, TimeUnit.MILLISECONDS)
             .addTag(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
             .build()
 
+        // If not force, use KEEP. WorkManager will do nothing if it's already there.
+        // If force, use REPLACE. It will reset the timer using our calculated initialDelay.
         val policy = if (force) ExistingPeriodicWorkPolicy.REPLACE else ExistingPeriodicWorkPolicy.KEEP
 
         rw.enqueueUniquePeriodicWork(
@@ -72,6 +89,9 @@ object SubscriptionUpdater {
             policy,
             request
         )
+
+        // Cancel legacy global task if it exists
+        rw.cancelUniqueWork(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
     }
 
     fun cancelAllTasks(context: Context) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -40,12 +40,14 @@ object SubscriptionUpdater {
             return
         }
 
-        val intervalMinutes = subItem.updateInterval ?: MmkvManager.decodeSettingsString(
+        var intervalMinutes = subItem.updateInterval ?: MmkvManager.decodeSettingsString(
             AppConfig.SUBSCRIPTION_AUTO_UPDATE_INTERVAL,
             AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL
         ).orEmpty().toIntOrNull() ?: AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL.toInt()
 
-        if (intervalMinutes <= 0) return
+        if (intervalMinutes < 15) {
+            intervalMinutes = 15
+        }
 
         val rw = RemoteWorkManager.getInstance(context)
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -99,7 +99,7 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
 
         setupGroupTab()
         setupViewModel()
-        SubscriptionUpdater.scheduleAllTasks(this, force = false)
+        SubscriptionUpdater.scheduleAllTasks(this)
         mainViewModel.reloadServerList()
 
         checkAndRequestPermission(PermissionType.POST_NOTIFICATIONS) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -31,6 +31,7 @@ import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.handler.V2RayServiceManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
@@ -98,6 +99,7 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
 
         setupGroupTab()
         setupViewModel()
+        SubscriptionUpdater.scheduleAllTasks(this, force = false)
         mainViewModel.reloadServerList()
 
         checkAndRequestPermission(PermissionType.POST_NOTIFICATIONS) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -96,7 +96,7 @@ class SettingsActivity : BaseActivity() {
                 autoUpdateCheck?.isChecked = value
                 autoUpdateInterval?.isEnabled = value
                 if (value) {
-                    SubscriptionUpdater.scheduleAllTasks(AngApplication.application, force = false)
+                    SubscriptionUpdater.scheduleAllTasks(AngApplication.application)
                 } else {
                     SubscriptionUpdater.cancelAllTasks(AngApplication.application)
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -6,19 +6,14 @@ import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceFragmentCompat
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.PeriodicWorkRequest
-import androidx.work.multiprocess.RemoteWorkManager
 import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.VPN
 import com.v2ray.ang.R
-import com.v2ray.ang.extension.toLongEx
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.helper.MmkvPreferenceDataStore
 import com.v2ray.ang.util.Utils
-import java.util.concurrent.TimeUnit
 
 class SettingsActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -100,8 +95,10 @@ class SettingsActivity : BaseActivity() {
                 val value = newValue as Boolean
                 autoUpdateCheck?.isChecked = value
                 autoUpdateInterval?.isEnabled = value
-                autoUpdateInterval?.text?.toLongEx()?.let {
-                    if (newValue) configureUpdateTask(it) else cancelUpdateTask()
+                if (value) {
+                    SubscriptionUpdater.scheduleAllTasks(AngApplication.application, force = false)
+                } else {
+                    SubscriptionUpdater.cancelAllTasks(AngApplication.application)
                 }
                 true
             }
@@ -232,29 +229,6 @@ class SettingsActivity : BaseActivity() {
             fakeDns?.isEnabled = enabled
 //            localDnsPort?.isEnabled = enabled
             vpnDns?.isEnabled = !enabled
-        }
-
-        private fun configureUpdateTask(interval: Long) {
-            val rw = RemoteWorkManager.getInstance(AngApplication.application)
-            rw.cancelUniqueWork(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
-            rw.enqueueUniquePeriodicWork(
-                AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME,
-                ExistingPeriodicWorkPolicy.UPDATE,
-                PeriodicWorkRequest.Builder(
-                    SubscriptionUpdater.UpdateTask::class.java,
-                    interval,
-                    TimeUnit.MINUTES
-                )
-                    .apply {
-                        setInitialDelay(interval, TimeUnit.MINUTES)
-                    }
-                    .build()
-            )
-        }
-
-        private fun cancelUpdateTask() {
-            val rw = RemoteWorkManager.getInstance(AngApplication.application)
-            rw.cancelUniqueWork(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
         }
 
         private fun updateMux(enabled: Boolean) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -46,6 +46,15 @@ class SubEditActivity : BaseActivity() {
             binding.autoUpdateCheck.isEnabled = false
             binding.tvGlobalWarning.visibility = android.view.View.VISIBLE
         }
+
+        binding.etUpdateInterval.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) {
+                val interval = binding.etUpdateInterval.text.toString().toIntOrNull()
+                if (interval != null && interval < 15) {
+                    binding.etUpdateInterval.setText("15")
+                }
+            }
+        }
     }
 
     /**
@@ -92,7 +101,11 @@ class SubEditActivity : BaseActivity() {
         subItem.filter = binding.etFilter.text.toString()
         subItem.enabled = binding.chkEnable.isChecked
         subItem.autoUpdate = binding.autoUpdateCheck.isChecked
-        subItem.updateInterval = binding.etUpdateInterval.text.toString().toIntOrNull()
+        var interval = binding.etUpdateInterval.text.toString().toIntOrNull()
+        if (interval != null && interval < 15) {
+            interval = 15
+        }
+        subItem.updateInterval = interval
         subItem.prevProfile = binding.etPreProfile.text.toString()
         subItem.nextProfile = binding.etNextProfile.text.toString()
         subItem.allowInsecureUrl = binding.allowInsecureUrl.isChecked

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -129,7 +129,7 @@ class SubEditActivity : BaseActivity() {
         }
 
         MmkvManager.encodeSubscription(editSubId, subItem)
-        SubscriptionUpdater.scheduleTask(this, editSubId, force = true)
+        SubscriptionUpdater.scheduleTask(this, editSubId)
         toastSuccess(R.string.toast_success)
         finish()
         return true

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -15,6 +15,7 @@ import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -39,6 +40,12 @@ class SubEditActivity : BaseActivity() {
         } else {
             clearServer()
         }
+
+        val globalAutoUpdate = MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE, false)
+        if (!globalAutoUpdate) {
+            binding.autoUpdateCheck.isEnabled = false
+            binding.tvGlobalWarning.visibility = android.view.View.VISIBLE
+        }
     }
 
     /**
@@ -51,6 +58,7 @@ class SubEditActivity : BaseActivity() {
         binding.etFilter.text = Utils.getEditable(subItem.filter)
         binding.chkEnable.isChecked = subItem.enabled
         binding.autoUpdateCheck.isChecked = subItem.autoUpdate
+        binding.etUpdateInterval.text = Utils.getEditable(subItem.updateInterval?.toString() ?: "")
         binding.allowInsecureUrl.isChecked = subItem.allowInsecureUrl
         binding.etPreProfile.text = Utils.getEditable(subItem.prevProfile)
         binding.etNextProfile.text = Utils.getEditable(subItem.nextProfile)
@@ -65,6 +73,8 @@ class SubEditActivity : BaseActivity() {
         binding.etUrl.text = null
         binding.etFilter.text = null
         binding.chkEnable.isChecked = true
+        binding.autoUpdateCheck.isChecked = false
+        binding.etUpdateInterval.text = null
         binding.etPreProfile.text = null
         binding.etNextProfile.text = null
         return true
@@ -82,6 +92,7 @@ class SubEditActivity : BaseActivity() {
         subItem.filter = binding.etFilter.text.toString()
         subItem.enabled = binding.chkEnable.isChecked
         subItem.autoUpdate = binding.autoUpdateCheck.isChecked
+        subItem.updateInterval = binding.etUpdateInterval.text.toString().toIntOrNull()
         subItem.prevProfile = binding.etPreProfile.text.toString()
         subItem.nextProfile = binding.etNextProfile.text.toString()
         subItem.allowInsecureUrl = binding.allowInsecureUrl.isChecked
@@ -105,6 +116,7 @@ class SubEditActivity : BaseActivity() {
         }
 
         MmkvManager.encodeSubscription(editSubId, subItem)
+        SubscriptionUpdater.scheduleTask(this, editSubId, force = true)
         toastSuccess(R.string.toast_success)
         finish()
         return true

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -153,7 +153,8 @@ object HttpUtil {
         timeout: Int = 15000,
         httpPort: Int = 0,
         proxyUsername: String? = null,
-        proxyPassword: String? = null
+        proxyPassword: String? = null,
+        onResponse: ((okhttp3.Response) -> Unit)? = null
     ): String {
         var currentUrl = url
         var redirects = 0
@@ -191,6 +192,7 @@ object HttpUtil {
                     }
 
                     response.isSuccessful -> {
+                        onResponse?.invoke(response)
                         return response.body?.string() ?: ""
                     }
 

--- a/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
@@ -138,6 +138,22 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tv_global_warning"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sub_auto_update_global_disabled_warning"
+                    android:textColor="@color/md_theme_error"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
                 android:orientation="horizontal">
 
                 <TextView
@@ -154,6 +170,25 @@
                     android:paddingStart="@dimen/padding_spacing_dp16"
                     android:paddingEnd="@dimen/padding_spacing_dp16"
                     app:theme="@style/BrandedSwitch" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sub_setting_update_interval" />
+
+                <EditText
+                    android:id="@+id/et_update_interval"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number" />
 
             </LinearLayout>
 

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -302,7 +302,7 @@
     <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
     <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
     <string name="title_sub_update">تحديث الاشتراك (أول خطوة)</string>
-    <string name="sub_setting_update_interval">فاصل التحديث بالدقائق (اختياري، سوف يتجاوز الافتراضي)</string>
+    <string name="sub_setting_update_interval">فاصل التحديث بالدقائق (اختياري، سوف يتجاوز الافتراضي، الحد الأدنى 15)</string>
     <string name="sub_auto_update_global_disabled_warning">لاستخدام التحديث التلقائي، قم بتمكينه في الإعدادات</string>
     <string name="title_ping_all_server">Tcping لجميع الإعدادات</string>
     <string name="title_real_ping_all_server"> اختبر جميع الإعدادات (3)</string>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -268,7 +268,7 @@
 
     <string name="title_pref_auto_update_subscription">اشتراكات التحديث التلقائي</string>
     <string name="summary_pref_auto_update_subscription">قم بتحديث اشتراكاتك تلقائيًا بفترة زمنية في الخلفية. اعتمادًا على الجهاز، قد لا تعمل هذه الميزة دائمًا</string>
-    <string name="title_pref_auto_update_interval">فاصل التحديث التلقائي (بالدقائق، الحد الأدنى للقيمة 15)</string>
+    <string name="title_pref_auto_update_interval">فاصل التحديث التلقائي الافتراضي (بالدقائق، الحد الأدنى للقيمة 15)</string>
 
     <string name="title_core_loglevel">مستوى السجل</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
@@ -302,6 +302,8 @@
     <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
     <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
     <string name="title_sub_update">تحديث الاشتراك (أول خطوة)</string>
+    <string name="sub_setting_update_interval">فاصل التحديث بالدقائق (اختياري، سوف يتجاوز الافتراضي)</string>
+    <string name="sub_auto_update_global_disabled_warning">لاستخدام التحديث التلقائي، قم بتمكينه في الإعدادات</string>
     <string name="title_ping_all_server">Tcping لجميع الإعدادات</string>
     <string name="title_real_ping_all_server"> اختبر جميع الإعدادات (3)</string>
     <string name="title_user_asset_setting">Asset files</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -268,7 +268,7 @@
 
     <string name="title_pref_auto_update_subscription">স্বয়ংক্রিয় আপডেট সাবস্ক্রিপশন</string>
     <string name="summary_pref_auto_update_subscription">পটভূমিতে একটি নির্দিষ্ট সময় পর পর আপনার সাবস্ক্রিপশন স্বয়ংক্রিয়ভাবে আপডেট করুন। ডিভাইসের উপর নির্ভর করে, এই বৈশিষ্ট্যটি সবসময় কাজ নাও করতে পারে</string>
-    <string name="title_pref_auto_update_interval">অটো আপডেট ইন্টারভ্যাল (মিনিট, সর্বনিম্ন মান ১৫)</string>
+    <string name="title_pref_auto_update_interval">ডিফল্ট অটো আপডেট ইন্টারভ্যাল (মিনিট, সর্বনিম্ন মান ১৫)</string>
 
     <string name="title_core_loglevel">লগ স্তর</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
@@ -302,6 +302,8 @@
     <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
     <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
     <string name="title_sub_update">সাবস্ক্রিপশন আপডেট</string>
+    <string name="sub_setting_update_interval">মিনিটে আপডেটের ব্যবধান (ঐচ্ছিক, ডিফল্টকে ওভাররাইড করবে)</string>
+    <string name="sub_auto_update_global_disabled_warning">অটো-আপডেট ব্যবহার করতে, সেটিংসে এটি সক্ষম করুন</string>
     <string name="title_ping_all_server">সব কনফিগারেশন TCPing</string>
     <string name="title_real_ping_all_server">সব কনফিগারেশন প্রকৃত বিলম্ব</string>
     <string name="title_user_asset_setting">Asset files</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -302,7 +302,7 @@
     <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
     <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
     <string name="title_sub_update">সাবস্ক্রিপশন আপডেট</string>
-    <string name="sub_setting_update_interval">মিনিটে আপডেটের ব্যবধান (ঐচ্ছিক, ডিফল্টকে ওভাররাইড করবে)</string>
+    <string name="sub_setting_update_interval">মিনিটে আপডেটের ব্যবধান (ঐচ্ছিক, ডিফল্টকে ওভাররাইড করবে, সর্বনিম্ন ১৫)</string>
     <string name="sub_auto_update_global_disabled_warning">অটো-আপডেট ব্যবহার করতে, সেটিংসে এটি সক্ষম করুন</string>
     <string name="title_ping_all_server">সব কনফিগারেশন TCPing</string>
     <string name="title_real_ping_all_server">সব কনফিগারেশন প্রকৃত বিলম্ব</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -268,7 +268,7 @@
 
     <string name="title_pref_auto_update_subscription">ورۊ کردن خوتکار اشتراکا</string>
     <string name="summary_pref_auto_update_subscription">اشتراکا خوتۉ ن و تۉر خوتکار وا فاسله زمۊوی من پس زمینه ورۊ کۊنین. ای ویژیی من پوی دسگایل گاشڌ همیشه کار نکونه</string>
-    <string name="title_pref_auto_update_interval">فاسله ورۊ کردن خوتکار (اقلن وا 15 دؽقه بۊ)</string>
+    <string name="title_pref_auto_update_interval">فاسله ورۊ کردن خوتکار پیش‌فرض (اقلن وا 15 دؽقه بۊ)</string>
 
     <string name="title_core_loglevel">سئت گوزارشا</string>
     <string name="title_outbound_domain_resolve_method">بارت پؽش هل دامنه دری</string>
@@ -302,6 +302,8 @@
     <string name="sub_setting_next_profile">نوم موستعار پروکسی نیایی</string>
     <string name="sub_setting_pre_profile_tip">موتمعن بۊ ک نوم موستعار هڌس وو جۊرس نی</string>
     <string name="title_sub_update">ورۊ کردن اشتراک بونکۊ سکویی</string>
+    <string name="sub_setting_update_interval">فاسله ورۊ کردن د دئقه (اختیاری، پیش‌فرض نه لغو مؽ‌کنه)</string>
+    <string name="sub_auto_update_global_disabled_warning">سی استفاده د ورۊ کردن خوتکار، د تنظیمات فعالش بکن</string>
     <string name="title_ping_all_server">Tcping کانفیگا بونکۊ سکویی</string>
     <string name="title_real_ping_all_server">تئخیر واقعی کانفیگا بونکۊ سکویی</string>
     <string name="title_user_asset_setting">فایلا بونچک جوقرافیایی</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -302,7 +302,7 @@
     <string name="sub_setting_next_profile">نوم موستعار پروکسی نیایی</string>
     <string name="sub_setting_pre_profile_tip">موتمعن بۊ ک نوم موستعار هڌس وو جۊرس نی</string>
     <string name="title_sub_update">ورۊ کردن اشتراک بونکۊ سکویی</string>
-    <string name="sub_setting_update_interval">فاسله ورۊ کردن د دئقه (اختیاری، پیش‌فرض نه لغو مؽ‌کنه)</string>
+    <string name="sub_setting_update_interval">فاسله ورۊ کردن د دئقه (اختیاری، پیش‌فرض نه لغو مؽ‌کنه، اقلن 15)</string>
     <string name="sub_auto_update_global_disabled_warning">سی استفاده د ورۊ کردن خوتکار، د تنظیمات فعالش بکن</string>
     <string name="title_ping_all_server">Tcping کانفیگا بونکۊ سکویی</string>
     <string name="title_real_ping_all_server">تئخیر واقعی کانفیگا بونکۊ سکویی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -299,7 +299,7 @@
     <string name="sub_setting_next_profile">نام مستعار پروکسی بعدی</string>
     <string name="sub_setting_pre_profile_tip">لطفاً مطمئن شوید که نام مستعار وجود دارد و منحصر به فرد است</string>
     <string name="title_sub_update">به‌روزرسانی گروه فعلی اشتراک</string>
-    <string name="sub_setting_update_interval">فاصله زمانی به روز رسانی در دقیقه (اختیاری، پیش فرض را نادیده می گیرد)</string>
+    <string name="sub_setting_update_interval">فاصله زمانی به روز رسانی در دقیقه (اختیاری، پیش فرض را نادیده می گیرد، حداقل 15)</string>
     <string name="sub_auto_update_global_disabled_warning">برای استفاده از به‌روزرسانی خودکار، آن را در تنظیمات فعال کنید</string>
     <string name="title_ping_all_server">TCPING کانفیگ های گروه فعلی</string>
     <string name="title_real_ping_all_server">تاخیر واقعی کانفیگ های گروه فعلی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -266,7 +266,7 @@
 
     <string name="title_pref_auto_update_subscription">به‌ روزرسانی خودکار اشتراک ها</string>
     <string name="summary_pref_auto_update_subscription">اشتراک های خود را به طور خودکار با فاصله زمانی در پس زمینه به روز کنید. بسته به دستگاه، این ویژگی ممکن است همیشه کار نکند.</string>
-    <string name="title_pref_auto_update_interval">فاصله به‌ روزرسانی خودکار ( حداقل مقدار ، 15 دقیقه )</string>
+    <string name="title_pref_auto_update_interval">فاصله به‌ روزرسانی خودکار پیش‌فرض (حداقل مقدار، 15 دقیقه)</string>
     <string name="title_core_loglevel">سطح گزارشات</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
     <string name="title_mode">حالت</string>
@@ -299,6 +299,8 @@
     <string name="sub_setting_next_profile">نام مستعار پروکسی بعدی</string>
     <string name="sub_setting_pre_profile_tip">لطفاً مطمئن شوید که نام مستعار وجود دارد و منحصر به فرد است</string>
     <string name="title_sub_update">به‌روزرسانی گروه فعلی اشتراک</string>
+    <string name="sub_setting_update_interval">فاصله زمانی به روز رسانی در دقیقه (اختیاری، پیش فرض را نادیده می گیرد)</string>
+    <string name="sub_auto_update_global_disabled_warning">برای استفاده از به‌روزرسانی خودکار، آن را در تنظیمات فعال کنید</string>
     <string name="title_ping_all_server">TCPING کانفیگ های گروه فعلی</string>
     <string name="title_real_ping_all_server">تاخیر واقعی کانفیگ های گروه فعلی</string>
     <string name="title_user_asset_setting">فایل های منبع جغرافیایی</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -271,7 +271,7 @@
 
     <string name="title_pref_auto_update_subscription">Автоматически обновлять подписки</string>
     <string name="summary_pref_auto_update_subscription">Автоматическое обновление подписок в фоновом режиме с указанным интервалом. В зависимости от устройства эта функция может работать не всегда.</string>
-    <string name="title_pref_auto_update_interval">Интервал автообновления (минут, не менее 15)</string>
+    <string name="title_pref_auto_update_interval">Интервал автообновления по умолчанию (минут, не менее 15)</string>
 
     <string name="title_core_loglevel">Подробность ведения журнала</string>
     <string name="title_outbound_domain_resolve_method">Предопределение исходящего домена</string>
@@ -305,6 +305,8 @@
     <string name="sub_setting_next_profile">Следующий профиль прокси</string>
     <string name="sub_setting_pre_profile_tip">Профиль должен быть уникальным</string>
     <string name="title_sub_update">Обновить подписку</string>
+    <string name="sub_setting_update_interval">Интервал обновления в минутах (необязательно, переопределяет значение по умолчанию)</string>
+    <string name="sub_auto_update_global_disabled_warning">Чтобы использовать автообновление, включите его в настройках</string>
     <string name="title_ping_all_server">Проверить профили</string>
     <string name="title_real_ping_all_server">Проверить задержку профилей</string>
     <string name="title_user_asset_setting">Файлы ресурсов</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -305,7 +305,7 @@
     <string name="sub_setting_next_profile">Следующий профиль прокси</string>
     <string name="sub_setting_pre_profile_tip">Профиль должен быть уникальным</string>
     <string name="title_sub_update">Обновить подписку</string>
-    <string name="sub_setting_update_interval">Интервал обновления в минутах (необязательно, переопределяет значение по умолчанию)</string>
+    <string name="sub_setting_update_interval">Интервал обновления в минутах (необязательно, переопределяет значение по умолчанию, не менее 15)</string>
     <string name="sub_auto_update_global_disabled_warning">Чтобы использовать автообновление, включите его в настройках</string>
     <string name="title_ping_all_server">Проверить профили</string>
     <string name="title_real_ping_all_server">Проверить задержку профилей</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -302,7 +302,7 @@
     <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
     <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
     <string name="title_sub_update">Cập nhật các gói đăng ký</string>
-    <string name="sub_setting_update_interval">Khoảng thời gian cập nhật tính bằng phút (tùy chọn, sẽ ghi đè mặc định)</string>
+    <string name="sub_setting_update_interval">Khoảng thời gian cập nhật tính bằng phút (tùy chọn, sẽ ghi đè mặc định, tối thiểu 15)</string>
     <string name="sub_auto_update_global_disabled_warning">Để sử dụng cập nhật tự động, hãy bật nó trong Cài đặt</string>
     <string name="title_ping_all_server">Ping tất cả máy chủ</string>
     <string name="title_real_ping_all_server">Kiểm tra HTTP tất cả máy chủ</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -268,7 +268,7 @@
 
     <string name="title_pref_auto_update_subscription">Tự động cập nhật các gói đăng ký</string>
     <string name="summary_pref_auto_update_subscription">Tự động cập nhật các gói đăng ký của bạn ở trong nền với khoảng thời gian cố định. Tùy thiết bị, tính năng này có thể không luôn hoạt động đúng như mong đợi.</string>
-    <string name="title_pref_auto_update_interval">Thời gian cập nhật tự động (Phút, giá trị tối thiểu là 15)</string>
+    <string name="title_pref_auto_update_interval">Thời gian cập nhật tự động mặc định (Phút, giá trị tối thiểu là 15)</string>
 
     <string name="title_core_loglevel">Cấp độ nhật ký</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
@@ -302,6 +302,8 @@
     <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
     <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
     <string name="title_sub_update">Cập nhật các gói đăng ký</string>
+    <string name="sub_setting_update_interval">Khoảng thời gian cập nhật tính bằng phút (tùy chọn, sẽ ghi đè mặc định)</string>
+    <string name="sub_auto_update_global_disabled_warning">Để sử dụng cập nhật tự động, hãy bật nó trong Cài đặt</string>
     <string name="title_ping_all_server">Ping tất cả máy chủ</string>
     <string name="title_real_ping_all_server">Kiểm tra HTTP tất cả máy chủ</string>
     <string name="title_user_asset_setting">Asset files</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -300,7 +300,7 @@
     <string name="sub_setting_next_profile">落地代理配置別名</string>
     <string name="sub_setting_pre_profile_tip">请确保配置别名存在并唯一</string>
     <string name="title_sub_update">更新订阅</string>
-    <string name="sub_setting_update_interval">更新间隔分钟（可选，将覆盖默认值）</string>
+    <string name="sub_setting_update_interval">更新间隔分钟（可选，将覆盖默认值，最小值 15）</string>
     <string name="sub_auto_update_global_disabled_warning">若要使用自动更新，请在设置中启用</string>
     <string name="title_ping_all_server">测试配置 Tcping</string>
     <string name="title_real_ping_all_server">测试配置真连接</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -266,7 +266,7 @@
 
     <string name="title_pref_auto_update_subscription">自动更新订阅</string>
     <string name="summary_pref_auto_update_subscription">在后台按一定时间间隔自动更新您的订阅。受设备影响，此功能不一定总是有效</string>
-    <string name="title_pref_auto_update_interval">自动更新间隔（分钟，最小值 15）</string>
+    <string name="title_pref_auto_update_interval">默认自动更新间隔（分钟，最小值 15）</string>
 
     <string name="title_core_loglevel">日志级别</string>
     <string name="title_outbound_domain_resolve_method">Outbound 域名预解析方式</string>
@@ -300,6 +300,8 @@
     <string name="sub_setting_next_profile">落地代理配置別名</string>
     <string name="sub_setting_pre_profile_tip">请确保配置别名存在并唯一</string>
     <string name="title_sub_update">更新订阅</string>
+    <string name="sub_setting_update_interval">更新间隔分钟（可选，将覆盖默认值）</string>
+    <string name="sub_auto_update_global_disabled_warning">若要使用自动更新，请在设置中启用</string>
     <string name="title_ping_all_server">测试配置 Tcping</string>
     <string name="title_real_ping_all_server">测试配置真连接</string>
     <string name="title_user_asset_setting">资源文件</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -301,7 +301,7 @@
     <string name="sub_setting_next_profile">落地代理設定檔別名</string>
     <string name="sub_setting_pre_profile_tip">请确保設定檔别名存在并唯一</string>
     <string name="title_sub_update">更新訂閱</string>
-    <string name="sub_setting_update_interval">更新間隔分鐘（可選，將覆蓋預設值）</string>
+    <string name="sub_setting_update_interval">更新間隔分鐘（可選，將覆蓋預設值，最小值 15）</string>
     <string name="sub_auto_update_global_disabled_warning">若要使用自動更新，請在設定中啟用</string>
     <string name="title_ping_all_server">偵測設定 Tcping</string>
     <string name="title_real_ping_all_server">偵測設定真延遲</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -267,7 +267,7 @@
 
     <string name="title_pref_auto_update_subscription">自動更新訂閱</string>
     <string name="summary_pref_auto_update_subscription">在後台以一定時間間隔自動更新您的訂閱。受設備影響，此功能不一定總是有效</string>
-    <string name="title_pref_auto_update_interval">自動更新間隔（分鐘，最小值 15）</string>
+    <string name="title_pref_auto_update_interval">預設自動更新間隔（分鐘，最小值 15）</string>
 
     <string name="title_core_loglevel">記錄層級</string>
     <string name="title_outbound_domain_resolve_method">出口網域預解析方式</string>
@@ -301,6 +301,8 @@
     <string name="sub_setting_next_profile">落地代理設定檔別名</string>
     <string name="sub_setting_pre_profile_tip">请确保設定檔别名存在并唯一</string>
     <string name="title_sub_update">更新訂閱</string>
+    <string name="sub_setting_update_interval">更新間隔分鐘（可選，將覆蓋預設值）</string>
+    <string name="sub_auto_update_global_disabled_warning">若要使用自動更新，請在設定中啟用</string>
     <string name="title_ping_all_server">偵測設定 Tcping</string>
     <string name="title_real_ping_all_server">偵測設定真延遲</string>
     <string name="title_user_asset_setting">資源檔案</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -307,7 +307,7 @@
     <string name="sub_setting_next_profile">Next proxy config remarks</string>
     <string name="sub_setting_pre_profile_tip">The config remarks exist and are unique</string>
     <string name="title_sub_update">Update subscription</string>
-    <string name="sub_setting_update_interval">Update interval in minutes (optional, will override default)</string>
+    <string name="sub_setting_update_interval">Update interval in minutes (optional, override default, min 15)</string>
     <string name="sub_auto_update_global_disabled_warning">To use auto-update, enable it in Settings</string>
     <string name="title_ping_all_server">Tcping config</string>
     <string name="title_real_ping_all_server">Real delay config</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -273,7 +273,7 @@
 
     <string name="title_pref_auto_update_subscription">Automatic update subscriptions</string>
     <string name="summary_pref_auto_update_subscription">Update your subscriptions automatically at set intervals in the background. Depending on the device, this feature may not always work</string>
-    <string name="title_pref_auto_update_interval">Auto Update Interval (Minutes, Min value 15)</string>
+    <string name="title_pref_auto_update_interval">Default Auto Update Interval (Minutes, Min value 15)</string>
 
     <string name="title_core_loglevel">Log Level</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
@@ -307,6 +307,8 @@
     <string name="sub_setting_next_profile">Next proxy config remarks</string>
     <string name="sub_setting_pre_profile_tip">The config remarks exist and are unique</string>
     <string name="title_sub_update">Update subscription</string>
+    <string name="sub_setting_update_interval">Update interval in minutes (optional, will override default)</string>
+    <string name="sub_auto_update_global_disabled_warning">To use auto-update, enable it in Settings</string>
     <string name="title_ping_all_server">Tcping config</string>
     <string name="title_real_ping_all_server">Real delay config</string>
     <string name="title_user_asset_setting">Asset files</string>


### PR DESCRIPTION
Fix auto-update (something should have been specified in manifest, Gemini fixed it). Change auto-update logic - allow per-subscription update intervals and use separate tasks for separate subscriptions, respect profile-update-interval header in subs.

If global auto-update setting is turned off, no auto-updates will happen (this is default).

Fix [this](https://github.com/2dust/v2rayNG/issues/5542)