### PR TITLE
Apply in-app locale to Application context

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
@@ -1,12 +1,14 @@
 package com.v2ray.ang
 
 import android.content.Context
+import android.content.res.Configuration as AndroidConfiguration
 import androidx.multidex.MultiDexApplication
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig.ANG_PACKAGE
 import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.util.MyContextWrapper
 
 class AngApplication : MultiDexApplication() {
     companion object {
@@ -14,12 +16,26 @@ class AngApplication : MultiDexApplication() {
     }
 
     /**
-     * Attaches the base context to the application.
+     * Attaches the base context, wrapped with the user-selected locale.
      * @param base The base context.
      */
     override fun attachBaseContext(base: Context?) {
-        super.attachBaseContext(base)
+        if (base == null) {
+            super.attachBaseContext(base)
+            return
+        }
+        // MMKV must be initialized before SettingsManager.getLocale() is called.
+        MMKV.initialize(base)
+        super.attachBaseContext(MyContextWrapper.wrap(base, SettingsManager.getLocale()))
         application = this
+    }
+
+    /**
+     * Re-apply the user-selected locale when the system configuration changes.
+     */
+    override fun onConfigurationChanged(newConfig: AndroidConfiguration) {
+        super.onConfigurationChanged(newConfig)
+        MyContextWrapper.wrap(this, SettingsManager.getLocale())
     }
 
     private val workManagerConfiguration: Configuration = Configuration.Builder()


### PR DESCRIPTION
### Problem
After switching the in-app language (e.g. to English), some toasts and notification texts still appear in the system language. Example: starting the service shows "启动服务成功" instead of "Start Services Success".

### Root cause
`BaseActivity` and the VPN/ProxyOnly services already wrap their base context with the user-selected locale via `MyContextWrapper`, but `AngApplication.attachBaseContext` does not. Strings fetched through the application context — e.g. `getApplication<AngApplication>().toastSuccess(...)` in `MainViewModel` — therefore fall back to the system locale.

### Fix
Wrap the application base context with the user-selected locale in `AngApplication.attachBaseContext`, and re-apply it on `onConfigurationChanged`. `MMKV.initialize` is moved earlier because `SettingsManager.getLocale()` reads from MMKV; the existing `MMKV.initialize` call in `onCreate` is idempotent and left untouched.

### Test
- Set in-app language to English, restart, start the service → toast shows "Start Services Success".
- Set language back to "Auto" → behavior unchanged (follows system).