### PR TITLE
Auto-update feature: bug fix and improvement with very few changes

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -188,6 +188,11 @@
         </service>
 
         <service
+            android:name="androidx.work.multiprocess.RemoteWorkManagerService"
+            android:exported="false"
+            android:process=":bg" />
+
+        <service
             android:name=".service.V2RayProxyOnlyService"
             android:exported="false"
             android:foregroundServiceType="specialUse"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -46,6 +46,7 @@ object AppConfig {
     const val SUBSCRIPTION_AUTO_UPDATE = "pref_auto_update_subscription"
     const val SUBSCRIPTION_AUTO_UPDATE_INTERVAL = "pref_auto_update_interval"
     const val SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL = "1440" // Default is 24 hours
+    const val PREF_LAST_SUBSCRIPTION_UPDATE_ATTEMPT = "pref_last_subscription_update_attempt"
     const val SUBSCRIPTION_UPDATE_TASK_NAME = "subscription_updater"
     const val PREF_SPEED_ENABLED = "pref_speed_enabled"
     const val PREF_CONFIRM_REMOVE = "pref_confirm_remove"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.handler
 
 import com.tencent.mmkv.MMKV
+import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.DEFAULT_SUBSCRIPTION_ID
 import com.v2ray.ang.AppConfig.PREF_IS_BOOTED
 import com.v2ray.ang.AppConfig.PREF_ROUTING_RULESET
@@ -714,6 +715,14 @@ object MmkvManager {
     fun decodeWebDavConfig(): WebDavConfig? {
         val json = mainStorage.decodeString(KEY_WEBDAV_CONFIG) ?: return null
         return JsonUtil.fromJson(json, WebDavConfig::class.java)
+    }
+
+    fun decodeLastSubscriptionUpdateAttempt(): Long {
+        return settingsStorage.decodeLong(AppConfig.PREF_LAST_SUBSCRIPTION_UPDATE_ATTEMPT, -1)
+    }
+
+    fun encodeLastSubscriptionUpdateAttempt(value: Long) {
+        settingsStorage.encode(AppConfig.PREF_LAST_SUBSCRIPTION_UPDATE_ATTEMPT, value)
     }
 
     //endregion

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -10,8 +10,15 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.v2ray.ang.AppConfig
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequest
+import androidx.work.multiprocess.RemoteWorkManager
+import com.v2ray.ang.AngApplication
 import com.v2ray.ang.R
+import com.v2ray.ang.extension.toLongEx
 import com.v2ray.ang.util.LogUtil
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
 object SubscriptionUpdater {
 
@@ -35,6 +42,7 @@ object SubscriptionUpdater {
         @SuppressLint("MissingPermission")
         override suspend fun doWork(): Result {
             LogUtil.i(AppConfig.TAG, "subscription automatic update starting")
+            MmkvManager.encodeLastSubscriptionUpdateAttempt(System.currentTimeMillis())
 
             val subs = MmkvManager.decodeSubscriptions().filter { it.subscription.autoUpdate }
 
@@ -58,6 +66,41 @@ object SubscriptionUpdater {
             }
             notificationManager.cancel(3)
             return Result.success()
+        }
+    }
+
+    fun configureUpdateTask(interval: Long) {
+        val rw = RemoteWorkManager.getInstance(AngApplication.application)
+        val lastAttempt = MmkvManager.decodeLastSubscriptionUpdateAttempt()
+        val intervalMillis = interval * 60 * 1000
+        val now = System.currentTimeMillis()
+        val delayMillis = if (lastAttempt <= 0L) 0L else max(0L, lastAttempt + intervalMillis - now)
+
+        rw.enqueueUniquePeriodicWork(
+            AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            PeriodicWorkRequest.Builder(
+                UpdateTask::class.java,
+                interval,
+                TimeUnit.MINUTES
+            )
+                .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
+                .build()
+        )
+    }
+
+    fun cancelUpdateTask() {
+        val rw = RemoteWorkManager.getInstance(AngApplication.application)
+        rw.cancelUniqueWork(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
+    }
+
+    fun scheduleIfNeeded() {
+        if (MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE)) {
+            val interval = MmkvManager.decodeSettingsString(
+                AppConfig.SUBSCRIPTION_AUTO_UPDATE_INTERVAL,
+                AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL
+            )?.toLongEx() ?: AppConfig.SUBSCRIPTION_DEFAULT_UPDATE_INTERVAL.toLong()
+            configureUpdateTask(interval)
         }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -7,11 +7,13 @@ import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkerParameters
 import com.v2ray.ang.AppConfig
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.PeriodicWorkRequest
 import androidx.work.multiprocess.RemoteWorkManager
 import com.v2ray.ang.AngApplication
 import com.v2ray.ang.R
@@ -76,6 +78,10 @@ object SubscriptionUpdater {
         val now = System.currentTimeMillis()
         val delayMillis = if (lastAttempt <= 0L) 0L else max(0L, lastAttempt + intervalMillis - now)
 
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
         rw.enqueueUniquePeriodicWork(
             AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME,
             ExistingPeriodicWorkPolicy.UPDATE,
@@ -85,6 +91,7 @@ object SubscriptionUpdater {
                 TimeUnit.MINUTES
             )
                 .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
+                .setConstraints(constraints)
                 .build()
         )
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -62,7 +62,7 @@ object SubscriptionUpdater {
                     notificationManager.createNotificationChannel(channel)
                 }
                 notificationManager.notify(3, notification.build())
-                LogUtil.i(AppConfig.TAG, "subscription automatic update: ---${subItem.remarks}")
+                LogUtil.i(AppConfig.TAG, "subscription automatic update: ---${subItem.remarks} (${sub.guid})")
                 AngConfigManager.updateConfigViaSub(sub)
                 notification.setContentText("Updating ${subItem.remarks}")
             }
@@ -81,6 +81,8 @@ object SubscriptionUpdater {
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
+
+        LogUtil.i(AppConfig.TAG, "Next auto-update scheduled in $delayMillis ms (interval: $interval min)")
 
         rw.enqueueUniquePeriodicWork(
             AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME,
@@ -102,6 +104,7 @@ object SubscriptionUpdater {
     }
 
     fun scheduleIfNeeded() {
+        LogUtil.d(AppConfig.TAG, "Auto-update schedule requested")
         if (MmkvManager.decodeSettingsBool(AppConfig.SUBSCRIPTION_AUTO_UPDATE)) {
             val interval = MmkvManager.decodeSettingsString(
                 AppConfig.SUBSCRIPTION_AUTO_UPDATE_INTERVAL,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/receiver/BootReceiver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/receiver/BootReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.handler.V2RayServiceManager
 import com.v2ray.ang.util.LogUtil
 
@@ -37,5 +38,7 @@ class BootReceiver : BroadcastReceiver() {
 
         LogUtil.i(AppConfig.TAG, "BootReceiver: Starting V2Ray service")
         V2RayServiceManager.startVService(context)
+
+        SubscriptionUpdater.scheduleIfNeeded()
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -31,6 +31,7 @@ import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.handler.V2RayServiceManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
@@ -99,6 +100,8 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
         setupGroupTab()
         setupViewModel()
         mainViewModel.reloadServerList()
+
+        SubscriptionUpdater.scheduleIfNeeded()
 
         checkAndRequestPermission(PermissionType.POST_NOTIFICATIONS) {
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -101,16 +101,18 @@ class SettingsActivity : BaseActivity() {
                 autoUpdateCheck?.isChecked = value
                 autoUpdateInterval?.isEnabled = value
                 autoUpdateInterval?.text?.toLongEx()?.let {
-                    if (newValue) configureUpdateTask(it) else cancelUpdateTask()
+                    if (newValue) SubscriptionUpdater.configureUpdateTask(it) else SubscriptionUpdater.cancelUpdateTask()
                 }
                 true
             }
 
-            autoUpdateInterval?.setOnPreferenceChangeListener { _, newValue ->
-                val interval = (newValue as? String)?.toLongEx()
+            autoUpdateInterval?.setOnPreferenceChangeListener { p, newValue ->
+                val intervalStr = newValue as? String
+                val interval = intervalStr?.toLongEx()
                 if (interval != null && autoUpdateCheck?.isChecked == true) {
-                    configureUpdateTask(interval)
+                    SubscriptionUpdater.configureUpdateTask(interval)
                 }
+                p.summary = intervalStr.orEmpty()
                 true
             }
 
@@ -241,29 +243,6 @@ class SettingsActivity : BaseActivity() {
             fakeDns?.isEnabled = enabled
 //            localDnsPort?.isEnabled = enabled
             vpnDns?.isEnabled = !enabled
-        }
-
-        private fun configureUpdateTask(interval: Long) {
-            val rw = RemoteWorkManager.getInstance(AngApplication.application)
-            rw.cancelUniqueWork(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
-            rw.enqueueUniquePeriodicWork(
-                AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME,
-                ExistingPeriodicWorkPolicy.UPDATE,
-                PeriodicWorkRequest.Builder(
-                    SubscriptionUpdater.UpdateTask::class.java,
-                    interval,
-                    TimeUnit.MINUTES
-                )
-                    .apply {
-                        setInitialDelay(interval, TimeUnit.MINUTES)
-                    }
-                    .build()
-            )
-        }
-
-        private fun cancelUpdateTask() {
-            val rw = RemoteWorkManager.getInstance(AngApplication.application)
-            rw.cancelUniqueWork(AppConfig.SUBSCRIPTION_UPDATE_TASK_NAME)
         }
 
         private fun updateMux(enabled: Boolean) {


### PR DESCRIPTION
- After the recent commit of 2dust a new bug was introduced where when you type a new value in "auto-update interval" the new value is not displayed immediately, only after you reopen settings. Fix this
- Fix AndroidManifest.xml to allow multiprocess
- Reschedule tasks when app reopens or device boots to avoid a situation where the auto-update task was killed by battery saver and never restarted. To achieve smart rescheduling remember last auto-update time attempt
- This also fixes auto-update for users who update v2rayNG from an older version: auto-update process will be rescheduled when they open a new version for the first time

This PR is focused on bug fix and is intended to replace a previous PR which focused on complete redesign of auto-update system