### PR TITLE
Get profile desc from server.address for vless

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -344,7 +344,7 @@ data class V2rayConfig(
             if (protocol.equals(EConfigType.VMESS.name, true)
                 || protocol.equals(EConfigType.VLESS.name, true)
             ) {
-                return settings?.vnext?.first()?.address
+                return settings?.vnext?.firstOrNull()?.address ?: settings?.address as String?
             } else if (protocol.equals(EConfigType.SHADOWSOCKS.name, true)
                 || protocol.equals(EConfigType.SOCKS.name, true)
                 || protocol.equals(EConfigType.HTTP.name, true)
@@ -365,7 +365,7 @@ data class V2rayConfig(
             if (protocol.equals(EConfigType.VMESS.name, true)
                 || protocol.equals(EConfigType.VLESS.name, true)
             ) {
-                return settings?.vnext?.first()?.port
+                return settings?.vnext?.firstOrNull()?.port ?: settings?.port
             } else if (protocol.equals(EConfigType.SHADOWSOCKS.name, true)
                 || protocol.equals(EConfigType.SOCKS.name, true)
                 || protocol.equals(EConfigType.HTTP.name, true)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/CustomFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/CustomFmt.kt
@@ -20,7 +20,7 @@ object CustomFmt : FmtBase() {
 
         config.remarks = fullConfig?.remarks ?: System.currentTimeMillis().toString()
         config.server = outbound?.getServerAddress()
-        config.serverPort = outbound?.getServerPort().toString()
+        config.serverPort = outbound?.getServerPort()?.toString()
 
         return config
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -620,17 +620,15 @@ object AngConfigManager {
      */
     fun generateDescription(profile: ProfileItem): String {
         // Hide xxx:xxx:***/xxx.xxx.xxx.***
-        val server = profile.server
+        val server = profile.server ?: return "—"
         val port = profile.serverPort
-        if (server.isNullOrBlank() && port.isNullOrBlank()) return ""
 
-        val addrPart = server?.let {
-            if (it.contains(":"))
-                it.split(":").take(2).joinToString(":", postfix = ":***")
-            else
-                it.split('.').dropLast(1).joinToString(".", postfix = ".***")
-        } ?: ""
+        val addrPart = if (server.contains(":")) {
+            server.split(":").take(2).joinToString(":", postfix = ":***")
+        } else {
+            server.split('.').dropLast(1).joinToString(".", postfix = ".***")
+        }
 
-        return "$addrPart : ${port ?: ""}"
+        return addrPart + (port?.takeIf { it.isNotBlank() }?.let { " : $it" } ?: "")
     }
 }


### PR DESCRIPTION
For VLESS, the server address and port configuration can be specified without vnext (https://github.com/XTLS/Xray-examples/pull/250). This breaks the profile description, as shown in the screenshot.

```
{
  "outbounds": [
    {
      "protocol": "vless",
      "settings": {
        "address": "...",
        "port": ...
      }
    }
  ]
}
```

<img width="495" height="242" alt="image" src="https://github.com/user-attachments/assets/85cc9f1e-3240-4882-9bb3-52ffbc8fb421" />
