### PR TITLE
Enable sing-box runtime path and dual-core Android validation

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -161,6 +161,7 @@ dependencies {
     implementation(libs.mmkv.static)
     implementation(libs.gson)
     implementation(libs.okhttp)
+    implementation(libs.org.yaml.snakeyaml)
 
     // Reactive and Utility Libraries
     implementation(libs.kotlinx.coroutines.android)

--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -127,19 +127,16 @@
             android:name=".ui.ScSwitchActivity"
             android:excludeFromRecents="true"
             android:exported="false"
-            android:process=":RunSoLibV2RayDaemon"
             android:theme="@style/AppThemeDayNight.NoActionBar.Translucent" />
         <activity
             android:name=".ui.ScStartActivity"
             android:excludeFromRecents="true"
             android:exported="false"
-            android:process=":RunSoLibV2RayDaemon"
             android:theme="@style/AppThemeDayNight.NoActionBar.Translucent" />
         <activity
             android:name=".ui.ScStopActivity"
             android:excludeFromRecents="true"
             android:exported="false"
-            android:process=":RunSoLibV2RayDaemon"
             android:theme="@style/AppThemeDayNight.NoActionBar.Translucent" />
 
         <activity
@@ -178,7 +175,6 @@
             android:foregroundServiceType="specialUse"
             android:label="@string/app_name"
             android:permission="android.permission.BIND_VPN_SERVICE"
-            android:process=":RunSoLibV2RayDaemon"
             tools:ignore="VpnServicePolicy">
             <intent-filter>
                 <action android:name="android.net.VpnService" />
@@ -195,8 +191,7 @@
             android:name=".service.CoreProxyOnlyService"
             android:exported="false"
             android:foregroundServiceType="specialUse"
-            android:label="@string/app_name"
-            android:process=":RunSoLibV2RayDaemon">
+            android:label="@string/app_name">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="proxy" />
@@ -205,8 +200,7 @@
         <service
             android:name=".service.CoreTestService"
             android:exported="false"
-            android:foregroundServiceType="specialUse"
-            android:process=":RunSoLibV2RayDaemon">
+            android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="test" />
@@ -214,8 +208,7 @@
 
         <receiver
             android:name=".receiver.WidgetProvider"
-            android:exported="true"
-            android:process=":RunSoLibV2RayDaemon">
+            android:exported="true">
             <meta-data
                 android:name="android.appwidget.provider"
                 android:resource="@xml/app_widget_provider" />
@@ -240,8 +233,7 @@
             android:foregroundServiceType="specialUse"
             android:icon="@drawable/ic_stat_name"
             android:label="@string/app_tile_name"
-            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE"
-            android:process=":RunSoLibV2RayDaemon">
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
@@ -262,7 +254,6 @@
         <receiver
             android:name=".receiver.TaskerReceiver"
             android:exported="true"
-            android:process=":RunSoLibV2RayDaemon"
             tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.twofortyfouram.locale.intent.action.FIRE_SETTING" />

--- a/V2rayNG/app/src/main/assets/sing-box/README.txt
+++ b/V2rayNG/app/src/main/assets/sing-box/README.txt
@@ -1,0 +1,11 @@
+Place per-ABI sing-box binaries in this assets tree:
+
+- arm64-v8a/sing-box
+- armeabi-v7a/sing-box
+- x86_64/sing-box
+- x86/sing-box
+
+The current test entry resolves only explicitly marked CUSTOM profiles:
+
+- profile remark prefix: [sing-box]
+- runtime config source: raw custom JSON

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -147,6 +147,8 @@ object AppConfig {
     /** Ports and addresses for various services. */
     const val PORT_LOCAL_DNS = "10853"
     const val PORT_SOCKS = "10808"
+    const val HEV_MAP_DNS_NETWORK = "100.64.0.0"
+    const val HEV_MAP_DNS_NETMASK = "255.192.0.0"
     const val WIREGUARD_LOCAL_ADDRESS_V4 = "172.16.0.2/32"
     const val WIREGUARD_LOCAL_ADDRESS_V6 = "2606:4700:110:8f81:d551:a0:532e:a2b3/128"
     const val WIREGUARD_LOCAL_MTU = "1420"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/contracts/ServiceControl.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/contracts/ServiceControl.kt
@@ -20,6 +20,11 @@ interface ServiceControl {
     fun stopService()
 
     /**
+     * Returns whether the underlying Android service is currently active.
+     */
+    fun isServiceRunning(): Boolean
+
+    /**
      * Protects the VPN socket.
      * @param socket The socket to protect.
      * @return True if the socket is protected, false otherwise.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -3,7 +3,10 @@ package com.v2ray.ang.core
 import android.content.Context
 import android.text.TextUtils
 import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import com.v2ray.ang.AppConfig
+import com.v2ray.ang.core.engine.CoreSelector
+import com.v2ray.ang.core.engine.CoreType
 import com.v2ray.ang.dto.ConfigResult
 import com.v2ray.ang.dto.CoreConfigContext
 import com.v2ray.ang.dto.ProfileItem
@@ -91,12 +94,17 @@ object CoreConfigManager {
     private fun getV2rayCustomConfig(configContext: CoreConfigContext): ConfigResult {
         val context = configContext.context
         val raw = MmkvManager.decodeServerRaw(configContext.guid) ?: return ConfigResult(false)
-        val result = ConfigResult(true, configContext.guid, raw)
+        val normalizedRaw = if (CoreSelector.resolve(configContext.selectedProfile) == CoreType.SING_BOX) {
+            normalizeSingBoxCustomConfig(raw)
+        } else {
+            raw
+        }
+        val result = ConfigResult(true, configContext.guid, normalizedRaw)
         if (!needTun()) {
             return result
         }
 
-        val json = JsonUtil.parseString(raw)?.takeIf { it.isJsonObject }?.asJsonObject ?: return result
+        val json = JsonUtil.parseString(normalizedRaw)?.takeIf { it.isJsonObject }?.asJsonObject ?: return result
 
         // Check whether package names need to be replaced with UIDs
         if (SettingsManager.canUseProcessRouting()) {
@@ -136,6 +144,185 @@ object CoreConfigManager {
         }
 
         return JsonUtil.toJsonPretty(json)?.let { ConfigResult(true, configContext.guid, it) } ?: result
+    }
+
+    fun normalizeSingBoxCustomConfig(raw: String): String {
+        val root = JsonUtil.parseString(raw)?.takeIf { it.isJsonObject }?.asJsonObject ?: return raw
+        val outboundDomain = findSingBoxOutboundDomain(root)
+        ensureSingBoxDnsBootstrap(root, outboundDomain)
+        resolveSingBoxOutboundDomains(root)
+        return JsonUtil.toJsonPretty(root) ?: raw
+    }
+
+    private fun findSingBoxOutboundDomain(root: JsonObject): String? {
+        val outbounds = root.getAsJsonArray("outbounds") ?: return null
+        outbounds.forEach { element ->
+            val outbound = element.takeIf { it.isJsonObject }?.asJsonObject ?: return@forEach
+            val tag = outbound.get("tag")?.takeIf { it.isJsonPrimitive }?.asString
+            if (tag == AppConfig.TAG_DIRECT) return@forEach
+
+            val server = outbound.get("server")?.takeIf { it.isJsonPrimitive }?.asString ?: return@forEach
+            if (!Utils.isPureIpAddress(server)) {
+                return server
+            }
+        }
+        return null
+    }
+
+    private fun ensureSingBoxDnsBootstrap(root: JsonObject, outboundDomain: String?) {
+        val directDnsDomains = listOf(
+            "alidns.com",
+            "doh.pub",
+            "dot.pub",
+            "onedns.net",
+            "dns.alidns.com",
+        )
+
+        val dnsServers = JsonArray().apply {
+            add(
+                JsonObject().apply {
+                    addProperty("type", "hosts")
+                    addProperty("tag", "hosts_dns")
+                    add(
+                        "predefined",
+                        JsonObject().apply {
+                            add("cloudflare-dns.com", JsonArray().apply {
+                                add("104.16.249.249")
+                                add("104.16.248.249")
+                            })
+                            add("one.one.one.one", JsonArray().apply {
+                                add("1.1.1.1")
+                                add("1.0.0.1")
+                            })
+                            add("dns.google", JsonArray().apply {
+                                add("8.8.8.8")
+                                add("8.8.4.4")
+                            })
+                            add("dns.alidns.com", JsonArray().apply {
+                                add("223.5.5.5")
+                                add("223.6.6.6")
+                            })
+                        }
+                    )
+                }
+            )
+            add(
+                JsonObject().apply {
+                    addProperty("type", "udp")
+                    addProperty("tag", "direct_dns")
+                    addProperty("server", AppConfig.DNS_DIRECT)
+                }
+            )
+            add(
+                JsonObject().apply {
+                    addProperty("type", "https")
+                    addProperty("tag", "remote_dns")
+                    addProperty("server", "cloudflare-dns.com")
+                    addProperty("path", "/dns-query")
+                    addProperty("domain_resolver", "hosts_dns")
+                    addProperty("detour", AppConfig.TAG_PROXY)
+                }
+            )
+        }
+
+        val dnsRules = JsonArray().apply {
+            if (!outboundDomain.isNullOrBlank()) {
+                add(
+                    JsonObject().apply {
+                        addProperty("action", "route")
+                        addProperty("server", "direct_dns")
+                        add("domain", JsonArray().apply { add(outboundDomain) })
+                    }
+                )
+            }
+            add(
+                JsonObject().apply {
+                    addProperty("action", "route")
+                    addProperty("server", "direct_dns")
+                    add("domain_suffix", JsonArray().apply {
+                        directDnsDomains.forEach { add(it) }
+                    })
+                }
+            )
+        }
+
+        root.add(
+            "dns",
+            JsonObject().apply {
+                add("servers", dnsServers)
+                add("rules", dnsRules)
+                addProperty("final", "remote_dns")
+                addProperty("independent_cache", true)
+                addProperty("strategy", "prefer_ipv4")
+            }
+        )
+
+        val route = root.getAsJsonObject("route") ?: JsonObject().also { root.add("route", it) }
+        route.add(
+            "default_domain_resolver",
+            JsonObject().apply {
+                addProperty("server", "direct_dns")
+                addProperty("strategy", "prefer_ipv4")
+            }
+        )
+        route.add(
+            "rules",
+            JsonArray().apply {
+                add(
+                    JsonObject().apply {
+                        addProperty("action", "sniff")
+                    }
+                )
+                add(
+                    JsonObject().apply {
+                        add("protocol", JsonArray().apply { add("dns") })
+                        addProperty("action", "hijack-dns")
+                    }
+                )
+                add(
+                    JsonObject().apply {
+                        addProperty("ip_is_private", true)
+                        addProperty("action", "route")
+                        addProperty("outbound", AppConfig.TAG_DIRECT)
+                    }
+                )
+                add(
+                    JsonObject().apply {
+                        add("domain_suffix", JsonArray().apply {
+                            directDnsDomains.forEach { add(it) }
+                        })
+                        addProperty("action", "route")
+                        addProperty("outbound", AppConfig.TAG_DIRECT)
+                    }
+                )
+            }
+        )
+        if (!route.has("final")) {
+            route.addProperty("final", AppConfig.TAG_PROXY)
+        }
+    }
+
+    private fun resolveSingBoxOutboundDomains(root: JsonObject) {
+        val outbounds = root.getAsJsonArray("outbounds") ?: return
+        val preferIpv6 = MmkvManager.decodeSettingsBool(AppConfig.PREF_PREFER_IPV6) == true
+
+        outbounds.forEach { element ->
+            val outbound = element.takeIf { it.isJsonObject }?.asJsonObject ?: return@forEach
+            val serverElement = outbound.get("server") ?: return@forEach
+            if (!serverElement.isJsonPrimitive || !serverElement.asJsonPrimitive.isString) return@forEach
+
+            val server = serverElement.asString
+            if (server.isBlank() || Utils.isPureIpAddress(server)) return@forEach
+
+            val resolvedIps = HttpUtil.resolveHostToIP(server, preferIpv6)
+            if (resolvedIps.isNullOrEmpty()) {
+                LogUtil.w(AppConfig.TAG, "Failed to pre-resolve sing-box outbound host: $server")
+                return@forEach
+            }
+
+            outbound.addProperty("server", resolvedIps.first())
+            LogUtil.i(AppConfig.TAG, "Pre-resolved sing-box outbound host $server -> ${resolvedIps.first()}")
+        }
     }
 
     /** Builds full config for policy-group mode. */

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -12,6 +12,12 @@ import android.system.OsConstants
 import androidx.core.content.ContextCompat
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
+import com.v2ray.ang.core.engine.AppProcessFinder
+import com.v2ray.ang.core.engine.CoreEngine
+import com.v2ray.ang.core.engine.CoreEngineFactory
+import com.v2ray.ang.core.engine.CoreEventHandler
+import com.v2ray.ang.core.engine.CoreSelector
+import com.v2ray.ang.core.engine.CoreType
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.dto.ProfileItem
 import com.v2ray.ang.enums.EConfigType
@@ -28,15 +34,13 @@ import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import libv2ray.CoreCallbackHandler
-import libv2ray.CoreController
-import libv2ray.ProcessFinder
 import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
 
 object CoreServiceManager {
 
-    private val coreController: CoreController = CoreNativeManager.newCoreController(CoreCallback())
+    private val coreEventHandler = CoreCallback()
+    private var coreEngine: CoreEngine = CoreEngineFactory.create(CoreType.XRAY, coreEventHandler)
     private val mMsgReceive = ReceiveMessageHandler()
     private var currentConfig: ProfileItem? = null
     private var processFinder: XrayProcessFinder? = null
@@ -45,10 +49,10 @@ object CoreServiceManager {
         set(value) {
             field = value
             val service = value?.get()?.getService()
-            CoreNativeManager.initCoreEnv(service)
+            coreEngine.initCoreEnv(service)
             if (service != null && processFinder == null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 processFinder = XrayProcessFinder(service)
-                coreController.registerProcessFinder(processFinder)
+                coreEngine.registerProcessFinder(processFinder!!)
             }
         }
 
@@ -94,7 +98,8 @@ object CoreServiceManager {
      * Checks if the V2Ray service is running.
      * @return True if the service is running, false otherwise.
      */
-    fun isRunning() = coreController.isRunning
+    fun isRunning() = coreEngine.isRunning
+
 
     /**
      * Gets the name of the currently running server.
@@ -108,7 +113,7 @@ object CoreServiceManager {
      * @param context The context from which the service is started.
      */
     private fun startContextService(context: Context) {
-        if (coreController.isRunning) {
+        if (coreEngine.isRunning) {
             LogUtil.w(AppConfig.TAG, "StartCore-Manager: Core already running")
             return
         }
@@ -122,6 +127,11 @@ object CoreServiceManager {
         val config = MmkvManager.decodeServerConfig(guid)
         if (config == null) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to decode server config")
+            return
+        }
+
+        if (!ensureCoreEngine(config)) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to resolve core engine")
             return
         }
 
@@ -168,7 +178,7 @@ object CoreServiceManager {
      * Starts the V2Ray core service.
      */
     fun startCoreLoop(vpnInterface: ParcelFileDescriptor?): Boolean {
-        if (coreController.isRunning) {
+        if (coreEngine.isRunning) {
             LogUtil.w(AppConfig.TAG, "StartCore-Manager: Core already running")
             return false
         }
@@ -188,6 +198,11 @@ object CoreServiceManager {
         val config = MmkvManager.decodeServerConfig(guid)
         if (config == null) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to decode server config")
+            return false
+        }
+
+        if (!ensureCoreEngine(config)) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to resolve core engine")
             return false
         }
 
@@ -218,13 +233,13 @@ object CoreServiceManager {
 
         try {
             NotificationManager.showNotification(currentConfig)
-            coreController.startLoop(result.content, tunFd)
+            coreEngine.startLoop(result.content, tunFd)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to start core loop", e)
             return false
         }
 
-        if (coreController.isRunning == false) {
+        if (coreEngine.isRunning == false) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Core failed to start")
             MessageUtil.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, "")
             NotificationManager.cancelNotification()
@@ -250,10 +265,10 @@ object CoreServiceManager {
     fun stopCoreLoop(): Boolean {
         val service = getService() ?: return false
 
-        if (coreController.isRunning) {
+        if (coreEngine.isRunning) {
             CoroutineScope(Dispatchers.IO).launch {
                 try {
-                    coreController.stopLoop()
+                    coreEngine.stopLoop()
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to stop V2Ray loop", e)
                 }
@@ -279,7 +294,7 @@ object CoreServiceManager {
      * @return The statistics value.
      */
     fun queryStats(tag: String, link: String): Long {
-        return coreController.queryStats(tag, link)
+        return coreEngine.queryStats(tag, link)
     }
 
     /**
@@ -288,7 +303,7 @@ object CoreServiceManager {
      * Also fetches remote IP information if the delay test was successful.
      */
     private fun measureV2rayDelay() {
-        if (coreController.isRunning == false) {
+        if (coreEngine.isRunning == false) {
             return
         }
 
@@ -298,14 +313,14 @@ object CoreServiceManager {
             var errorStr = ""
 
             try {
-                time = coreController.measureDelay(SettingsManager.getDelayTestUrl())
+                time = coreEngine.measureDelay(SettingsManager.getDelayTestUrl())
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to measure delay", e)
                 errorStr = e.message?.substringAfter("\":") ?: "empty message"
             }
             if (time == -1L) {
                 try {
-                    time = coreController.measureDelay(SettingsManager.getDelayTestUrl(true))
+                    time = coreEngine.measureDelay(SettingsManager.getDelayTestUrl(true))
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to measure delay", e)
                     errorStr = e.message?.substringAfter("\":") ?: "empty message"
@@ -336,11 +351,33 @@ object CoreServiceManager {
         return serviceControl?.get()?.getService()
     }
 
+    private fun ensureCoreEngine(config: ProfileItem): Boolean {
+        val resolvedCore = CoreSelector.resolve(config)
+        if (coreEngine.type == resolvedCore) {
+            return true
+        }
+        if (coreEngine.isRunning) {
+            LogUtil.w(AppConfig.TAG, "StartCore-Manager: Cannot switch core while running")
+            return false
+        }
+
+        return try {
+            coreEngine = CoreEngineFactory.create(resolvedCore, coreEventHandler)
+            val service = getService()
+            coreEngine.initCoreEnv(service)
+            processFinder?.let { coreEngine.registerProcessFinder(it) }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to create core engine $resolvedCore", e)
+            false
+        }
+    }
+
     /**
      * Core callback handler implementation for handling V2Ray core events.
      * Handles startup, shutdown, socket protection, and status emission.
      */
-    private class CoreCallback : CoreCallbackHandler {
+    private class CoreCallback : CoreEventHandler {
         /**
          * Called when V2Ray core starts up.
          * @return 0 for success, any other value for failure.
@@ -370,7 +407,7 @@ object CoreServiceManager {
          * @param s Status message.
          * @return Always returns 0.
          */
-        override fun onEmitStatus(l: Long, s: String?): Long {
+        override fun onEmitStatus(statusCode: Long, message: String?): Long {
             return 0
         }
     }
@@ -379,7 +416,7 @@ object CoreServiceManager {
      * Process finder implementation for Xray core.
      * Uses ConnectivityManager to find the owning UID of a connection based on network parameters.
      */
-    private class XrayProcessFinder(context: Context) : ProcessFinder {
+    private class XrayProcessFinder(context: Context) : AppProcessFinder {
         private val cm: ConnectivityManager? = context.getSystemService(ConnectivityManager::class.java)
 
         override fun findProcessByConnection(network: String, srcIP: String, srcPort: Long, destIP: String, destPort: Long): Long {
@@ -427,7 +464,7 @@ object CoreServiceManager {
             val serviceControl = serviceControl?.get() ?: return
             when (intent?.getIntExtra("key", 0)) {
                 AppConfig.MSG_REGISTER_CLIENT -> {
-                    if (coreController.isRunning) {
+                    if (coreEngine.isRunning) {
                         MessageUtil.sendMsg2UI(serviceControl.getService(), AppConfig.MSG_STATE_RUNNING, "")
                     } else {
                         MessageUtil.sendMsg2UI(serviceControl.getService(), AppConfig.MSG_STATE_NOT_RUNNING, "")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -99,7 +99,9 @@ object CoreServiceManager {
      * Checks if the V2Ray service is running.
      * @return True if the service is running, false otherwise.
      */
-    fun isRunning() = coreEngine.isRunning
+    fun isRunning(): Boolean {
+        return coreEngine.isRunning || (serviceControl?.get()?.isServiceRunning() == true)
+    }
 
 
     /**
@@ -119,15 +121,17 @@ object CoreServiceManager {
             return
         }
 
-        val guid = MmkvManager.getSelectServer()
+        val guid = resolveLaunchServerGuid()
         if (guid == null) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: No server selected")
+            context.toast(R.string.app_tile_first_use)
             return
         }
 
         val config = MmkvManager.decodeServerConfig(guid)
         if (config == null) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to decode server config")
+            context.toast(R.string.toast_services_failure)
             return
         }
 
@@ -170,7 +174,25 @@ object CoreServiceManager {
             ContextCompat.startForegroundService(context, intent)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to start service", e)
+            context.toast(R.string.toast_services_failure)
         }
+    }
+
+    private fun resolveLaunchServerGuid(): String? {
+        val selectedGuid = MmkvManager.getSelectServer()
+        if (!selectedGuid.isNullOrBlank() && MmkvManager.decodeServerConfig(selectedGuid) != null) {
+            return selectedGuid
+        }
+
+        val fallbackGuid = MmkvManager.decodeAllServerList()
+            .firstOrNull { guid -> MmkvManager.decodeServerConfig(guid) != null }
+
+        if (!fallbackGuid.isNullOrBlank()) {
+            MmkvManager.setSelectServer(fallbackGuid)
+            LogUtil.w(AppConfig.TAG, "StartCore-Manager: Recovered missing selected server with fallback guid=$fallbackGuid")
+        }
+
+        return fallbackGuid
     }
 
     /**
@@ -211,8 +233,7 @@ object CoreServiceManager {
         val result = buildRuntimeConfig(service, guid, config)
         LogUtil.d(AppConfig.TAG, result.content)
         if (!result.status) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to build runtime config for ${coreEngine.type}")
-            return false
+            return failStart(service, "StartCore-Manager: Failed to build runtime config for ${coreEngine.type}")
         }
 
         try {
@@ -222,8 +243,7 @@ object CoreServiceManager {
             mFilter.addAction(Intent.ACTION_USER_PRESENT)
             ContextCompat.registerReceiver(service, mMsgReceive, mFilter, Utils.receiverFlags())
         } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to register receiver", e)
-            return false
+            return failStart(service, "StartCore-Manager: Failed to register receiver", e)
         }
 
         currentConfig = config
@@ -236,15 +256,11 @@ object CoreServiceManager {
             NotificationManager.showNotification(currentConfig)
             coreEngine.startLoop(result.content, tunFd)
         } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to start core loop", e)
-            return false
+            return failStart(service, "StartCore-Manager: Failed to start core loop", e)
         }
 
         if (coreEngine.isRunning == false) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Core failed to start")
-            MessageUtil.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, "")
-            NotificationManager.cancelNotification()
-            return false
+            return failStart(service, "StartCore-Manager: Core failed to start")
         }
 
         try {
@@ -256,6 +272,17 @@ object CoreServiceManager {
             return false
         }
         return true
+    }
+
+    private fun failStart(service: Service, message: String, error: Exception? = null): Boolean {
+        if (error == null) {
+            LogUtil.e(AppConfig.TAG, message)
+        } else {
+            LogUtil.e(AppConfig.TAG, message, error)
+        }
+        MessageUtil.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, error?.message ?: message)
+        NotificationManager.cancelNotification()
+        return false
     }
 
     /**
@@ -327,6 +354,9 @@ object CoreServiceManager {
                     errorStr = e.message?.substringAfter("\":") ?: "empty message"
                 }
             }
+            if (time == -1L && errorStr.isBlank()) {
+                errorStr = service.getString(R.string.toast_failure)
+            }
 
             val result = if (time >= 0) {
                 service.getString(R.string.connection_test_available, time)
@@ -393,7 +423,7 @@ object CoreServiceManager {
             return ConfigResult(false)
         }
 
-        return ConfigResult(true, guid, raw)
+        return ConfigResult(true, guid, CoreConfigManager.normalizeSingBoxCustomConfig(raw))
     }
 
     /**
@@ -487,7 +517,7 @@ object CoreServiceManager {
             val serviceControl = serviceControl?.get() ?: return
             when (intent?.getIntExtra("key", 0)) {
                 AppConfig.MSG_REGISTER_CLIENT -> {
-                    if (coreEngine.isRunning) {
+                    if (isRunning()) {
                         MessageUtil.sendMsg2UI(serviceControl.getService(), AppConfig.MSG_STATE_RUNNING, "")
                     } else {
                         MessageUtil.sendMsg2UI(serviceControl.getService(), AppConfig.MSG_STATE_NOT_RUNNING, "")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -7,6 +7,8 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelFileDescriptor
 import android.system.OsConstants
 import androidx.core.content.ContextCompat
@@ -35,8 +37,11 @@ import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 object CoreServiceManager {
 
@@ -45,6 +50,21 @@ object CoreServiceManager {
     private val mMsgReceive = ReceiveMessageHandler()
     private var currentConfig: ProfileItem? = null
     private var processFinder: XrayProcessFinder? = null
+
+    /**
+     * Bumped when [stopCoreLoop] runs so an in-flight [startCoreLoop] (e.g. sing-box binary install)
+     * can abort cleanly instead of racing the next session — common when toggling quickly on OEM ROMs.
+     */
+    private val coreLifecycleGeneration = AtomicInteger(0)
+
+    private val coreLoopStartExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "CoreLoopStart").apply {
+            isDaemon = true
+            priority = Thread.NORM_PRIORITY
+        }
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     var serviceControl: SoftReference<ServiceControl>? = null
         set(value) {
@@ -200,7 +220,21 @@ object CoreServiceManager {
      * `registerReceiver(Context, BroadcastReceiver, IntentFilter, int)`.
      * Starts the V2Ray core service.
      */
+    fun startCoreLoopAsync(vpnInterface: ParcelFileDescriptor?, callback: (Boolean) -> Unit) {
+        coreLoopStartExecutor.execute {
+            val result = try {
+                startCoreLoop(vpnInterface)
+            } catch (t: Throwable) {
+                LogUtil.e(AppConfig.TAG, "StartCore-Manager: Unexpected failure starting core loop", t)
+                false
+            }
+            mainHandler.post { callback(result) }
+        }
+    }
+
     fun startCoreLoop(vpnInterface: ParcelFileDescriptor?): Boolean {
+        val generationAtStart = coreLifecycleGeneration.get()
+
         if (coreEngine.isRunning) {
             LogUtil.w(AppConfig.TAG, "StartCore-Manager: Core already running")
             return false
@@ -236,6 +270,10 @@ object CoreServiceManager {
             return failStart(service, "StartCore-Manager: Failed to build runtime config for ${coreEngine.type}")
         }
 
+        if (abortStartIfStale(service, generationAtStart, "after config build")) {
+            return false
+        }
+
         try {
             val mFilter = IntentFilter(AppConfig.BROADCAST_ACTION_SERVICE)
             mFilter.addAction(Intent.ACTION_SCREEN_ON)
@@ -244,6 +282,10 @@ object CoreServiceManager {
             ContextCompat.registerReceiver(service, mMsgReceive, mFilter, Utils.receiverFlags())
         } catch (e: Exception) {
             return failStart(service, "StartCore-Manager: Failed to register receiver", e)
+        }
+
+        if (abortStartIfStale(service, generationAtStart, "after registerReceiver")) {
+            return false
         }
 
         currentConfig = config
@@ -259,6 +301,11 @@ object CoreServiceManager {
             return failStart(service, "StartCore-Manager: Failed to start core loop", e)
         }
 
+        if (abortStartIfStale(service, generationAtStart, "after startLoop")) {
+            runCatching { coreEngine.stopLoop() }
+            return false
+        }
+
         if (coreEngine.isRunning == false) {
             return failStart(service, "StartCore-Manager: Core failed to start")
         }
@@ -268,9 +315,21 @@ object CoreServiceManager {
             NotificationManager.startSpeedNotification(currentConfig)
             LogUtil.i(AppConfig.TAG, "StartCore-Manager: Core started successfully")
         } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to complete startup", e)
+            return failStart(service, "StartCore-Manager: Failed to complete startup", e)
+        }
+        return true
+    }
+
+    private fun abortStartIfStale(service: Service, generationAtStart: Int, phase: String): Boolean {
+        if (generationAtStart == coreLifecycleGeneration.get()) {
             return false
         }
+        LogUtil.w(AppConfig.TAG, "StartCore-Manager: Aborted start ($phase) — lifecycle generation changed")
+        runCatching {
+            service.unregisterReceiver(mMsgReceive)
+        }
+        NotificationManager.cancelNotification()
+        currentConfig = null
         return true
     }
 
@@ -279,6 +338,9 @@ object CoreServiceManager {
             LogUtil.e(AppConfig.TAG, message)
         } else {
             LogUtil.e(AppConfig.TAG, message, error)
+        }
+        runCatching {
+            service.unregisterReceiver(mMsgReceive)
         }
         MessageUtil.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, error?.message ?: message)
         NotificationManager.cancelNotification()
@@ -291,15 +353,17 @@ object CoreServiceManager {
      * @return True if the core was stopped successfully, false otherwise.
      */
     fun stopCoreLoop(): Boolean {
+        coreLifecycleGeneration.incrementAndGet()
+
         val service = getService() ?: return false
 
         if (coreEngine.isRunning) {
-            CoroutineScope(Dispatchers.IO).launch {
-                try {
+            try {
+                runBlocking(Dispatchers.IO) {
                     coreEngine.stopLoop()
-                } catch (e: Exception) {
-                    LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to stop V2Ray loop", e)
                 }
+            } catch (e: Exception) {
+                LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to stop core loop", e)
             }
         }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -19,6 +19,7 @@ import com.v2ray.ang.core.engine.CoreEventHandler
 import com.v2ray.ang.core.engine.CoreSelector
 import com.v2ray.ang.core.engine.CoreType
 import com.v2ray.ang.contracts.ServiceControl
+import com.v2ray.ang.dto.ConfigResult
 import com.v2ray.ang.dto.ProfileItem
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.extension.toast
@@ -207,10 +208,10 @@ object CoreServiceManager {
         }
 
         LogUtil.i(AppConfig.TAG, "StartCore-Manager: Starting core loop for ${config.remarks}")
-        val result = CoreConfigManager.getV2rayConfig(service, guid)
+        val result = buildRuntimeConfig(service, guid, config)
         LogUtil.d(AppConfig.TAG, result.content)
         if (!result.status) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to get V2Ray config")
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to build runtime config for ${coreEngine.type}")
             return false
         }
 
@@ -371,6 +372,28 @@ object CoreServiceManager {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to create core engine $resolvedCore", e)
             false
         }
+    }
+
+    private fun buildRuntimeConfig(service: Service, guid: String, config: ProfileItem): ConfigResult {
+        return when (coreEngine.type) {
+            CoreType.XRAY -> CoreConfigManager.getV2rayConfig(service, guid)
+            CoreType.SING_BOX -> buildSingBoxRuntimeConfig(guid, config)
+        }
+    }
+
+    private fun buildSingBoxRuntimeConfig(guid: String, config: ProfileItem): ConfigResult {
+        if (!CoreSelector.isExplicitSingBoxTestProfile(config)) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Sing-box runtime is currently limited to explicitly marked CUSTOM profiles")
+            return ConfigResult(false)
+        }
+
+        val raw = MmkvManager.decodeServerRaw(guid)
+        if (raw.isNullOrBlank()) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Missing raw sing-box config for $guid")
+            return ConfigResult(false)
+        }
+
+        return ConfigResult(true, guid, raw)
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/AppProcessFinder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/AppProcessFinder.kt
@@ -1,0 +1,11 @@
+package com.v2ray.ang.core.engine
+
+interface AppProcessFinder {
+    fun findProcessByConnection(
+        network: String,
+        srcIP: String,
+        srcPort: Long,
+        destIP: String,
+        destPort: Long,
+    ): Long
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreCapability.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreCapability.kt
@@ -1,0 +1,10 @@
+package com.v2ray.ang.core.engine
+
+enum class CoreCapability {
+    TUN,
+    PER_APP_PROXY,
+    RULE_SET,
+    PROXY_CHAIN,
+    REAL_DELAY,
+    DNS_MODULE,
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEngine.kt
@@ -1,0 +1,21 @@
+package com.v2ray.ang.core.engine
+
+import android.content.Context
+
+interface CoreEngine {
+    val type: CoreType
+    val isRunning: Boolean
+    val supportedCapabilities: Set<CoreCapability>
+
+    fun initCoreEnv(context: Context?)
+
+    fun startLoop(configContent: String, tunFd: Int)
+
+    fun stopLoop()
+
+    fun queryStats(tag: String, link: String): Long
+
+    fun measureDelay(testUrl: String): Long
+
+    fun registerProcessFinder(processFinder: AppProcessFinder)
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEngineFactory.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEngineFactory.kt
@@ -4,7 +4,7 @@ object CoreEngineFactory {
     fun create(coreType: CoreType, eventHandler: CoreEventHandler): CoreEngine {
         return when (coreType) {
             CoreType.XRAY -> XrayCoreEngine(eventHandler)
-            CoreType.SING_BOX -> throw UnsupportedOperationException("Sing-box engine is not implemented yet")
+            CoreType.SING_BOX -> SingBoxEngine(eventHandler)
         }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEngineFactory.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEngineFactory.kt
@@ -1,0 +1,10 @@
+package com.v2ray.ang.core.engine
+
+object CoreEngineFactory {
+    fun create(coreType: CoreType, eventHandler: CoreEventHandler): CoreEngine {
+        return when (coreType) {
+            CoreType.XRAY -> XrayCoreEngine(eventHandler)
+            CoreType.SING_BOX -> throw UnsupportedOperationException("Sing-box engine is not implemented yet")
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEventHandler.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreEventHandler.kt
@@ -1,0 +1,9 @@
+package com.v2ray.ang.core.engine
+
+interface CoreEventHandler {
+    fun startup(): Long
+
+    fun shutdown(): Long
+
+    fun onEmitStatus(statusCode: Long, message: String?): Long
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreSelector.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreSelector.kt
@@ -1,8 +1,11 @@
 package com.v2ray.ang.core.engine
 
 import com.v2ray.ang.dto.ProfileItem
+import com.v2ray.ang.enums.EConfigType
 
 object CoreSelector {
+    const val SING_BOX_TEST_PREFIX = "[sing-box]"
+
     /**
      * Keeps the current runtime behavior unchanged while introducing a single
      * place for future per-profile or per-subscription core selection.
@@ -11,6 +14,14 @@ object CoreSelector {
      * resolved feature requirements and route eligible profiles to sing-box.
      */
     fun resolve(profile: ProfileItem): CoreType {
+        if (isExplicitSingBoxTestProfile(profile)) {
+            return CoreType.SING_BOX
+        }
         return CoreType.XRAY
+    }
+
+    fun isExplicitSingBoxTestProfile(profile: ProfileItem): Boolean {
+        return profile.configType == EConfigType.CUSTOM &&
+                profile.remarks.trimStart().startsWith(SING_BOX_TEST_PREFIX, ignoreCase = true)
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreSelector.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreSelector.kt
@@ -6,6 +6,9 @@ object CoreSelector {
     /**
      * Keeps the current runtime behavior unchanged while introducing a single
      * place for future per-profile or per-subscription core selection.
+     *
+     * Future work can inspect protocol families, subscription metadata, or
+     * resolved feature requirements and route eligible profiles to sing-box.
      */
     fun resolve(profile: ProfileItem): CoreType {
         return CoreType.XRAY

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreSelector.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreSelector.kt
@@ -1,0 +1,13 @@
+package com.v2ray.ang.core.engine
+
+import com.v2ray.ang.dto.ProfileItem
+
+object CoreSelector {
+    /**
+     * Keeps the current runtime behavior unchanged while introducing a single
+     * place for future per-profile or per-subscription core selection.
+     */
+    fun resolve(profile: ProfileItem): CoreType {
+        return CoreType.XRAY
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreType.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/CoreType.kt
@@ -1,0 +1,6 @@
+package com.v2ray.ang.core.engine
+
+enum class CoreType {
+    XRAY,
+    SING_BOX,
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxBinaryInstaller.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxBinaryInstaller.kt
@@ -1,0 +1,54 @@
+package com.v2ray.ang.core.engine
+
+import android.content.Context
+import android.os.Build
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.util.LogUtil
+import java.io.FileOutputStream
+
+class SingBoxBinaryInstaller {
+    companion object {
+        private const val ASSET_ROOT = "sing-box"
+        private const val BINARY_NAME = "sing-box"
+        private val SUPPORTED_ASSET_ABIS = setOf("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
+    }
+
+    fun install(context: Context, layout: SingBoxRuntimeLayout): Boolean {
+        val assetPath = resolveAssetPath(context) ?: return false
+
+        layout.ensureDirectories()
+        context.assets.open(assetPath).use { input ->
+            FileOutputStream(layout.binaryFile).use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        if (!layout.binaryFile.setExecutable(true, true)) {
+            LogUtil.w(AppConfig.TAG, "Failed to mark sing-box binary executable via setExecutable")
+        }
+        layout.binaryFile.setReadable(true, true)
+
+        LogUtil.i(AppConfig.TAG, "Installed sing-box binary from apk assets: $assetPath")
+        return true
+    }
+
+    fun expectedAssetLocations(): List<String> {
+        return Build.SUPPORTED_ABIS
+            .distinct()
+            .filter { SUPPORTED_ASSET_ABIS.contains(it) }
+            .map { "$ASSET_ROOT/$it/$BINARY_NAME" }
+    }
+
+    private fun resolveAssetPath(context: Context): String? {
+        return expectedAssetLocations().firstOrNull { assetExists(context, it) }
+    }
+
+    private fun assetExists(context: Context, path: String): Boolean {
+        return try {
+            context.assets.open(path).close()
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.core.engine
 
 import android.content.Context
+import android.os.SystemClock
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.service.ProcessService
@@ -38,7 +39,8 @@ class SingBoxEngine(
         runtimeLayout = SingBoxRuntimeLayout.fromContext(context.applicationContext).also {
             it.ensureDirectories()
         }
-        ensureBinaryInstalled()
+        // Binary install can be tens of MB from assets; keep it out of Service.onCreate / main thread.
+        // [SingBoxEngine.startLoop] runs on CoreLoopStart thread via CoreServiceManager.startCoreLoopAsync.
         LogUtil.i(AppConfig.TAG, "Sing-box runtime layout initialized at ${runtimeLayout?.rootDir}")
     }
 
@@ -72,8 +74,7 @@ class SingBoxEngine(
             workingDirectory = layout.workingDir,
             logFile = layout.logFile,
         )
-        Thread.sleep(300L)
-        started = processService.isRunning()
+        started = waitForProcessAlive(timeoutMs = 12_000L)
         if (!started) {
             val logTail = readStartupLogTail(layout)
             throw IllegalStateException(
@@ -149,6 +150,21 @@ class SingBoxEngine(
         if (!binaryInstaller.install(context, layout)) {
             LogUtil.i(AppConfig.TAG, "No bundled sing-box binary found in assets yet")
         }
+    }
+
+    /** Busy waits with short sleeps; must run off the main thread (see [CoreServiceManager.startCoreLoopAsync]). */
+    private fun waitForProcessAlive(timeoutMs: Long): Boolean {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (processService.isRunning()) return true
+            try {
+                Thread.sleep(50L)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return processService.isRunning()
+            }
+        }
+        return processService.isRunning()
     }
 
     private fun readStartupLogTail(layout: SingBoxRuntimeLayout): String {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
@@ -17,8 +17,9 @@ class SingBoxEngine(
     override val supportedCapabilities: Set<CoreCapability> = emptySet()
 
     override val isRunning: Boolean
-        get() = started
+        get() = started || processService.isRunning()
 
+    private val binaryInstaller = SingBoxBinaryInstaller()
     private val processService = ProcessService()
     private var runtimeLayout: SingBoxRuntimeLayout? = null
     private var processFinder: AppProcessFinder? = null
@@ -32,11 +33,12 @@ class SingBoxEngine(
         runtimeLayout = SingBoxRuntimeLayout.fromContext(context.applicationContext).also {
             it.ensureDirectories()
         }
+        ensureBinaryInstalled()
         LogUtil.i(AppConfig.TAG, "Sing-box runtime layout initialized at ${runtimeLayout?.rootDir}")
     }
 
     override fun startLoop(configContent: String, tunFd: Int) {
-        appContext ?: throw IllegalStateException("Sing-box engine context is not initialized")
+        val context = appContext ?: throw IllegalStateException("Sing-box engine context is not initialized")
         val layout = runtimeLayout ?: throw IllegalStateException("Sing-box runtime layout is not initialized")
 
         layout.ensureDirectories()
@@ -48,14 +50,23 @@ class SingBoxEngine(
         if (processFinder != null) {
             LogUtil.d(AppConfig.TAG, "Sing-box skeleton has a process finder registered for future per-app routing support")
         }
-        if (!layout.binaryFile.exists()) {
-            throw UnsupportedOperationException("Sing-box binary is not installed yet")
+        ensureBinaryInstalled()
+        require(layout.binaryFile.exists()) {
+            "Sing-box binary is not installed. Expected apk assets in: ${binaryInstaller.expectedAssetLocations().joinToString()}"
         }
 
         LogUtil.i(AppConfig.TAG, "Sing-box bootstrap command prepared: ${buildStartCommand(layout)}")
         processService.stopProcess()
-        started = false
-        throw UnsupportedOperationException("Sing-box runtime bootstrap is not implemented yet")
+        processService.runProcess(
+            context = context,
+            cmd = buildStartCommand(layout),
+            workingDirectory = layout.workingDir,
+            logFile = layout.logFile,
+        )
+        started = processService.isRunning()
+        if (!started) {
+            throw IllegalStateException("Sing-box process failed to start")
+        }
     }
 
     override fun stopLoop() {
@@ -84,5 +95,16 @@ class SingBoxEngine(
             "-c",
             layout.configFile.absolutePath,
         )
+    }
+
+    private fun ensureBinaryInstalled() {
+        val context = appContext ?: return
+        val layout = runtimeLayout ?: return
+        if (layout.binaryFile.exists()) {
+            return
+        }
+        if (!binaryInstaller.install(context, layout)) {
+            LogUtil.i(AppConfig.TAG, "No bundled sing-box binary found in assets yet")
+        }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
@@ -1,0 +1,88 @@
+package com.v2ray.ang.core.engine
+
+import android.content.Context
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.service.ProcessService
+import com.v2ray.ang.util.LogUtil
+
+class SingBoxEngine(
+    private val _eventHandler: CoreEventHandler,
+) : CoreEngine {
+    override val type = CoreType.SING_BOX
+
+    /**
+     * The runtime is not wired into production flows yet, so we expose no
+     * active capabilities until the bootstrap and validation work lands.
+     */
+    override val supportedCapabilities: Set<CoreCapability> = emptySet()
+
+    override val isRunning: Boolean
+        get() = started
+
+    private val processService = ProcessService()
+    private var runtimeLayout: SingBoxRuntimeLayout? = null
+    private var processFinder: AppProcessFinder? = null
+    private var appContext: Context? = null
+    private var started = false
+
+    override fun initCoreEnv(context: Context?) {
+        if (context == null) return
+
+        appContext = context.applicationContext
+        runtimeLayout = SingBoxRuntimeLayout.fromContext(context.applicationContext).also {
+            it.ensureDirectories()
+        }
+        LogUtil.i(AppConfig.TAG, "Sing-box runtime layout initialized at ${runtimeLayout?.rootDir}")
+    }
+
+    override fun startLoop(configContent: String, tunFd: Int) {
+        appContext ?: throw IllegalStateException("Sing-box engine context is not initialized")
+        val layout = runtimeLayout ?: throw IllegalStateException("Sing-box runtime layout is not initialized")
+
+        layout.ensureDirectories()
+        layout.configFile.writeText(configContent)
+
+        if (tunFd != 0) {
+            LogUtil.i(AppConfig.TAG, "Sing-box skeleton received tunFd=$tunFd; TUN handoff will be wired in a follow-up patch")
+        }
+        if (processFinder != null) {
+            LogUtil.d(AppConfig.TAG, "Sing-box skeleton has a process finder registered for future per-app routing support")
+        }
+        if (!layout.binaryFile.exists()) {
+            throw UnsupportedOperationException("Sing-box binary is not installed yet")
+        }
+
+        LogUtil.i(AppConfig.TAG, "Sing-box bootstrap command prepared: ${buildStartCommand(layout)}")
+        processService.stopProcess()
+        started = false
+        throw UnsupportedOperationException("Sing-box runtime bootstrap is not implemented yet")
+    }
+
+    override fun stopLoop() {
+        processService.stopProcess()
+        started = false
+    }
+
+    override fun queryStats(tag: String, link: String): Long {
+        LogUtil.d(AppConfig.TAG, "Sing-box stats query requested before runtime implementation: $tag/$link")
+        return 0L
+    }
+
+    override fun measureDelay(testUrl: String): Long {
+        LogUtil.d(AppConfig.TAG, "Sing-box delay test requested before runtime implementation: $testUrl")
+        return -1L
+    }
+
+    override fun registerProcessFinder(processFinder: AppProcessFinder) {
+        this.processFinder = processFinder
+    }
+
+    internal fun buildStartCommand(layout: SingBoxRuntimeLayout = runtimeLayout ?: error("Sing-box runtime layout is not initialized")): MutableList<String> {
+        return mutableListOf(
+            layout.binaryFile.absolutePath,
+            "run",
+            "-c",
+            layout.configFile.absolutePath,
+        )
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxEngine.kt
@@ -2,8 +2,13 @@ package com.v2ray.ang.core.engine
 
 import android.content.Context
 import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
 import com.v2ray.ang.service.ProcessService
 import com.v2ray.ang.util.LogUtil
+import java.net.HttpURLConnection
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.URL
 
 class SingBoxEngine(
     private val _eventHandler: CoreEventHandler,
@@ -42,6 +47,10 @@ class SingBoxEngine(
         val layout = runtimeLayout ?: throw IllegalStateException("Sing-box runtime layout is not initialized")
 
         layout.ensureDirectories()
+        layout.logFile.parentFile?.mkdirs()
+        if (layout.logFile.exists()) {
+            layout.logFile.writeText("")
+        }
         layout.configFile.writeText(configContent)
 
         if (tunFd != 0) {
@@ -63,9 +72,19 @@ class SingBoxEngine(
             workingDirectory = layout.workingDir,
             logFile = layout.logFile,
         )
+        Thread.sleep(300L)
         started = processService.isRunning()
         if (!started) {
-            throw IllegalStateException("Sing-box process failed to start")
+            val logTail = readStartupLogTail(layout)
+            throw IllegalStateException(
+                buildString {
+                    append("Sing-box process failed to start")
+                    if (logTail.isNotBlank()) {
+                        append(": ")
+                        append(logTail)
+                    }
+                }
+            )
         }
     }
 
@@ -80,8 +99,32 @@ class SingBoxEngine(
     }
 
     override fun measureDelay(testUrl: String): Long {
-        LogUtil.d(AppConfig.TAG, "Sing-box delay test requested before runtime implementation: $testUrl")
-        return -1L
+        val url = runCatching { URL(testUrl) }.getOrElse { error ->
+            LogUtil.e(AppConfig.TAG, "Invalid sing-box delay test url: $testUrl", error)
+            return -1L
+        }
+        val proxy = Proxy(Proxy.Type.HTTP, InetSocketAddress("127.0.0.1", AppConfig.PORT_SOCKS.toInt()))
+        val startAt = System.nanoTime()
+
+        return runCatching {
+            val connection = (url.openConnection(proxy) as HttpURLConnection).apply {
+                requestMethod = "GET"
+                instanceFollowRedirects = false
+                connectTimeout = 5000
+                readTimeout = 5000
+                useCaches = false
+            }
+            connection.responseCode
+            connection.inputStream.use { it.read() }
+            ((System.nanoTime() - startAt) / 1_000_000L).coerceAtLeast(0L)
+        }.onFailure { error ->
+            LogUtil.e(AppConfig.TAG, "Sing-box delay test failed for $testUrl", error)
+        }.getOrElse { error ->
+            throw IllegalStateException(
+                error.message ?: appContext?.getString(R.string.toast_failure) ?: "Failure",
+                error
+            )
+        }
     }
 
     override fun registerProcessFinder(processFinder: AppProcessFinder) {
@@ -106,5 +149,12 @@ class SingBoxEngine(
         if (!binaryInstaller.install(context, layout)) {
             LogUtil.i(AppConfig.TAG, "No bundled sing-box binary found in assets yet")
         }
+    }
+
+    private fun readStartupLogTail(layout: SingBoxRuntimeLayout): String {
+        return runCatching {
+            if (!layout.logFile.exists()) return ""
+            layout.logFile.readText().trim().takeLast(1500)
+        }.getOrDefault("")
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxRuntimeLayout.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/SingBoxRuntimeLayout.kt
@@ -1,0 +1,47 @@
+package com.v2ray.ang.core.engine
+
+import android.content.Context
+import java.io.File
+
+data class SingBoxRuntimeLayout(
+    val rootDir: File,
+    val binaryDir: File,
+    val workingDir: File,
+    val logDir: File,
+    val configFile: File,
+    val logFile: File,
+    val binaryFile: File,
+) {
+    fun ensureDirectories() {
+        rootDir.mkdirs()
+        binaryDir.mkdirs()
+        workingDir.mkdirs()
+        logDir.mkdirs()
+    }
+
+    companion object {
+        private const val ROOT_DIR_NAME = "core-sing-box"
+        private const val BINARY_DIR_NAME = "bin"
+        private const val WORKING_DIR_NAME = "runtime"
+        private const val LOG_DIR_NAME = "logs"
+        private const val CONFIG_FILE_NAME = "config.json"
+        private const val LOG_FILE_NAME = "sing-box.log"
+        private const val BINARY_FILE_NAME = "sing-box"
+
+        fun fromContext(context: Context): SingBoxRuntimeLayout {
+            val rootDir = File(context.noBackupFilesDir, ROOT_DIR_NAME)
+            val binaryDir = File(rootDir, BINARY_DIR_NAME)
+            val workingDir = File(rootDir, WORKING_DIR_NAME)
+            val logDir = File(rootDir, LOG_DIR_NAME)
+            return SingBoxRuntimeLayout(
+                rootDir = rootDir,
+                binaryDir = binaryDir,
+                workingDir = workingDir,
+                logDir = logDir,
+                configFile = File(workingDir, CONFIG_FILE_NAME),
+                logFile = File(logDir, LOG_FILE_NAME),
+                binaryFile = File(binaryDir, BINARY_FILE_NAME),
+            )
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/XrayCoreEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/engine/XrayCoreEngine.kt
@@ -1,0 +1,62 @@
+package com.v2ray.ang.core.engine
+
+import android.content.Context
+import com.v2ray.ang.core.CoreNativeManager
+import libv2ray.CoreCallbackHandler
+import libv2ray.CoreController
+import libv2ray.ProcessFinder
+
+class XrayCoreEngine(
+    private val eventHandler: CoreEventHandler,
+) : CoreEngine {
+    override val type = CoreType.XRAY
+    override val supportedCapabilities = setOf(
+        CoreCapability.TUN,
+        CoreCapability.PER_APP_PROXY,
+        CoreCapability.RULE_SET,
+        CoreCapability.PROXY_CHAIN,
+        CoreCapability.REAL_DELAY,
+        CoreCapability.DNS_MODULE,
+    )
+
+    private val coreController: CoreController = CoreNativeManager.newCoreController(object : CoreCallbackHandler {
+        override fun startup(): Long = eventHandler.startup()
+
+        override fun shutdown(): Long = eventHandler.shutdown()
+
+        override fun onEmitStatus(statusCode: Long, message: String?): Long {
+            return eventHandler.onEmitStatus(statusCode, message)
+        }
+    })
+
+    override val isRunning: Boolean
+        get() = coreController.isRunning
+
+    override fun initCoreEnv(context: Context?) {
+        CoreNativeManager.initCoreEnv(context)
+    }
+
+    override fun startLoop(configContent: String, tunFd: Int) {
+        coreController.startLoop(configContent, tunFd)
+    }
+
+    override fun stopLoop() {
+        coreController.stopLoop()
+    }
+
+    override fun queryStats(tag: String, link: String): Long {
+        return coreController.queryStats(tag, link)
+    }
+
+    override fun measureDelay(testUrl: String): Long {
+        return coreController.measureDelay(testUrl)
+    }
+
+    override fun registerProcessFinder(processFinder: AppProcessFinder) {
+        coreController.registerProcessFinder(object : ProcessFinder {
+            override fun findProcessByConnection(network: String, srcIP: String, srcPort: Long, destIP: String, destPort: Long): Long {
+                return processFinder.findProcessByConnection(network, srcIP, srcPort, destIP, destPort)
+            }
+        })
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/enums/NotificationChannelType.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/enums/NotificationChannelType.kt
@@ -9,6 +9,11 @@ enum class NotificationChannelType(
     val channelName: String,
     val notificationId: Int
 ) {
+    SERVICE_RUNNING(
+        channelId = "service_running_channel",
+        channelName = "Service Running",
+        notificationId = 11
+    ),
     SUBSCRIPTION_UPDATE(
         channelId = "subscription_update_channel",
         channelName = "Subscription Update Service",

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/AnytlsFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/AnytlsFmt.kt
@@ -1,0 +1,87 @@
+package com.v2ray.ang.fmt
+
+import com.v2ray.ang.extension.idnHost
+import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.util.Utils
+import java.net.URI
+
+object AnytlsFmt : FmtBase() {
+    private val infoRemarkKeywords = listOf(
+        "剩余流量",
+        "距离下次重置",
+        "套餐到期",
+        "到期时间",
+        "流量重置",
+        "expire",
+        "expiration",
+        "remaining",
+        "traffic",
+        "reset",
+    )
+
+    fun parse(str: String): RawProfileImport? {
+        val allowInsecure = runCatching {
+            MmkvManager.decodeSettingsBool(AppConfig.PREF_ALLOW_INSECURE, false)
+        }.getOrDefault(false)
+        val uri = URI(Utils.fixIllegalUrl(str))
+        val remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
+        if (isSubscriptionInfoRemark(remarks)) {
+            return null
+        }
+
+        val queryParam = if (uri.rawQuery.isNullOrEmpty()) emptyMap() else getQueryParam(uri)
+        val insecure = when {
+            queryParam["insecure"] == "1" -> true
+            queryParam["insecure"] == "0" -> false
+            else -> allowInsecure
+        }
+        val alpn = queryParam["alpn"]
+            ?.split(",")
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
+        val fingerPrint = queryParam["fp"] ?: queryParam["client-fingerprint"]
+
+        val outbound = linkedMapOf<String, Any?>(
+            "type" to "anytls",
+            "tag" to AppConfig.TAG_PROXY,
+            "server" to uri.idnHost,
+            "server_port" to uri.port,
+            "password" to uri.userInfo,
+            "tls" to linkedMapOf<String, Any?>(
+                "enabled" to true,
+                "server_name" to (queryParam["sni"] ?: queryParam["servername"]),
+                "insecure" to insecure,
+            ).apply {
+                if (alpn.isNotEmpty()) {
+                    this["alpn"] = alpn
+                }
+                fingerPrint?.let {
+                    this["utls"] = linkedMapOf(
+                        "enabled" to true,
+                        "fingerprint" to it,
+                    )
+                }
+            }
+        )
+
+        val rawConfig = RawProfileFmt.createRawConfig(outbound) ?: return null
+        val profile = RawProfileFmt.createProfile(
+            name = remarks,
+            server = uri.idnHost,
+            serverPort = uri.port,
+            password = uri.userInfo,
+            sni = queryParam["sni"] ?: queryParam["servername"],
+            alpn = alpn,
+            fingerPrint = fingerPrint,
+            insecure = insecure,
+        )
+        return RawProfileImport(profile = profile, rawConfig = rawConfig)
+    }
+
+    private fun isSubscriptionInfoRemark(remarks: String): Boolean {
+        val normalized = remarks.trim().lowercase()
+        return infoRemarkKeywords.any { keyword -> normalized.contains(keyword) }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ClashYamlFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ClashYamlFmt.kt
@@ -1,0 +1,294 @@
+package com.v2ray.ang.fmt
+
+import com.v2ray.ang.AppConfig
+import org.yaml.snakeyaml.LoaderOptions
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.SafeConstructor
+
+object ClashYamlFmt {
+    private val clashProxyRegex = Regex("""(?m)^\s*proxies\s*:""")
+
+    fun isClashYaml(str: String?): Boolean {
+        val text = str?.trim().orEmpty()
+        if (text.isEmpty()) return false
+        if (text.startsWith("{") || text.startsWith("[")) return false
+        return clashProxyRegex.containsMatchIn(text)
+    }
+
+    fun parse(str: String): List<RawProfileImport> {
+        if (!isClashYaml(str)) return emptyList()
+
+        val yaml = Yaml(SafeConstructor(LoaderOptions()))
+        val root = yaml.load<Any?>(str) as? Map<*, *> ?: return emptyList()
+        val proxies = root["proxies"] as? List<*> ?: return emptyList()
+
+        return proxies.mapNotNull { node ->
+            parseProxy(asStringKeyMap(node as? Map<*, *> ?: return@mapNotNull null))
+        }
+    }
+
+    private fun parseProxy(source: Map<String, Any?>): RawProfileImport? {
+        val type = getString(source, "type")?.lowercase() ?: return null
+        val server = getString(source, "server") ?: return null
+        val serverPort = getInt(source, "port") ?: return null
+        val tls = buildTls(source, forceEnabled = type in setOf("anytls", "trojan", "hysteria2"))
+
+        val outbound = when (type) {
+            "anytls" -> mutableMapOf<String, Any?>(
+                "type" to "anytls",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "password" to (getString(source, "password") ?: return null),
+                "tls" to (tls ?: return null),
+            )
+
+            "trojan" -> mutableMapOf<String, Any?>(
+                "type" to "trojan",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "password" to (getString(source, "password") ?: return null),
+            ).apply {
+                tls?.let { this["tls"] = it }
+                buildTransport(source)?.let { this["transport"] = it }
+            }
+
+            "vless" -> mutableMapOf<String, Any?>(
+                "type" to "vless",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "uuid" to (getString(source, "uuid") ?: return null),
+            ).apply {
+                getString(source, "flow")?.let { this["flow"] = it }
+                tls?.let { this["tls"] = it }
+                buildTransport(source)?.let { this["transport"] = it }
+            }
+
+            "vmess" -> mutableMapOf<String, Any?>(
+                "type" to "vmess",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "uuid" to (getString(source, "uuid") ?: return null),
+            ).apply {
+                getString(source, "cipher")?.let { this["security"] = it }
+                getInt(source, "alterId")?.let { this["alter_id"] = it }
+                tls?.let { this["tls"] = it }
+                buildTransport(source)?.let { this["transport"] = it }
+            }
+
+            "ss", "shadowsocks" -> mutableMapOf<String, Any?>(
+                "type" to "shadowsocks",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "method" to (getString(source, "cipher") ?: getString(source, "method") ?: return null),
+                "password" to (getString(source, "password") ?: return null),
+            )
+
+            "socks5", "socks" -> mutableMapOf<String, Any?>(
+                "type" to "socks",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "version" to "5",
+            ).apply {
+                getString(source, "username")?.let { this["username"] = it }
+                getString(source, "password")?.let { this["password"] = it }
+            }
+
+            "http" -> mutableMapOf<String, Any?>(
+                "type" to "http",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+            ).apply {
+                getString(source, "username")?.let { this["username"] = it }
+                getString(source, "password")?.let { this["password"] = it }
+                tls?.let { this["tls"] = it }
+            }
+
+            "hysteria2", "hy2" -> mutableMapOf<String, Any?>(
+                "type" to "hysteria2",
+                "tag" to AppConfig.TAG_PROXY,
+                "server" to server,
+                "server_port" to serverPort,
+                "password" to (getString(source, "password") ?: return null),
+                "tls" to (tls ?: return null),
+            )
+
+            else -> return null
+        }
+
+        val name = getString(source, "name")
+            ?.takeIf { it.isNotBlank() }
+            ?: "$type $server:$serverPort"
+        val rawConfig = RawProfileFmt.createRawConfig(outbound) ?: return null
+        val profile = RawProfileFmt.createProfile(
+            name = name,
+            server = server,
+            serverPort = serverPort,
+            password = getString(source, "password"),
+            method = getString(source, "cipher") ?: getString(source, "method"),
+            username = getString(source, "username"),
+            sni = getString(source, "servername") ?: getString(source, "sni"),
+            alpn = getStringList(source, "alpn"),
+            fingerPrint = getString(source, "client-fingerprint"),
+            insecure = getBoolean(source, "skip-cert-verify"),
+        ).apply {
+            security = getString(source, "cipher")
+        }
+
+        return RawProfileImport(profile = profile, rawConfig = rawConfig)
+    }
+
+    private fun buildTls(source: Map<String, Any?>, forceEnabled: Boolean = false): Map<String, Any?>? {
+        val serverName = getString(source, "servername") ?: getString(source, "sni")
+        val insecure = getBoolean(source, "skip-cert-verify")
+        val alpn = getStringList(source, "alpn")
+        val fingerprint = getString(source, "client-fingerprint")
+        val reality = asStringKeyMap(getMap(source, "reality-opts"))
+        val enabled = forceEnabled ||
+                getBoolean(source, "tls") == true ||
+                !serverName.isNullOrBlank() ||
+                insecure == true ||
+                alpn.isNotEmpty() ||
+                !fingerprint.isNullOrBlank() ||
+                reality.isNotEmpty()
+        if (!enabled) return null
+
+        return linkedMapOf<String, Any?>(
+            "enabled" to true,
+        ).apply {
+            serverName?.let { this["server_name"] = it }
+            if (insecure != null) {
+                this["insecure"] = insecure
+            }
+            if (alpn.isNotEmpty()) {
+                this["alpn"] = alpn
+            }
+            fingerprint?.let {
+                this["utls"] = linkedMapOf(
+                    "enabled" to true,
+                    "fingerprint" to it,
+                )
+            }
+            if (reality.isNotEmpty()) {
+                this["reality"] = linkedMapOf<String, Any?>(
+                    "enabled" to true,
+                ).apply {
+                    getString(reality, "public-key")?.let { this["public_key"] = it }
+                    getString(reality, "short-id")?.let { this["short_id"] = it }
+                }
+            }
+        }
+    }
+
+    private fun buildTransport(source: Map<String, Any?>): Map<String, Any?>? {
+        return when (getString(source, "network")?.lowercase()) {
+            null, "", "tcp" -> null
+            "ws" -> buildWebSocketTransport(source)
+            "grpc" -> buildGrpcTransport(source)
+            "http", "h2" -> buildHttpTransport(source)
+            "httpupgrade", "http-upgrade" -> buildHttpUpgradeTransport(source)
+            else -> null
+        }
+    }
+
+    private fun buildWebSocketTransport(source: Map<String, Any?>): Map<String, Any?> {
+        val wsOpts = asStringKeyMap(getMap(source, "ws-opts"))
+        val headers = mutableMapOf<String, String>()
+        val headerHost = getString(asStringKeyMap(getMap(wsOpts, "headers")), "Host")
+        val host = headerHost ?: getStringList(source, "host").firstOrNull()
+        host?.let { headers["Host"] = it }
+
+        return linkedMapOf<String, Any?>(
+            "type" to "ws",
+        ).apply {
+            getString(wsOpts, "path")?.let { this["path"] = it }
+            if (headers.isNotEmpty()) {
+                this["headers"] = headers
+            }
+        }
+    }
+
+    private fun buildGrpcTransport(source: Map<String, Any?>): Map<String, Any?> {
+        val grpcOpts = asStringKeyMap(getMap(source, "grpc-opts"))
+        return linkedMapOf<String, Any?>(
+            "type" to "grpc",
+        ).apply {
+            (getString(grpcOpts, "grpc-service-name") ?: getString(source, "grpc-service-name"))
+                ?.let { this["service_name"] = it }
+        }
+    }
+
+    private fun buildHttpTransport(source: Map<String, Any?>): Map<String, Any?> {
+        val httpOpts = asStringKeyMap(getMap(source, "http-opts"))
+            .ifEmpty { asStringKeyMap(getMap(source, "h2-opts")) }
+        val hosts = getStringList(httpOpts, "host").ifEmpty { getStringList(source, "host") }
+
+        return linkedMapOf<String, Any?>(
+            "type" to "http",
+        ).apply {
+            if (hosts.isNotEmpty()) {
+                this["host"] = hosts
+            }
+            getString(httpOpts, "path")?.let { this["path"] = it }
+        }
+    }
+
+    private fun buildHttpUpgradeTransport(source: Map<String, Any?>): Map<String, Any?> {
+        val host = getStringList(source, "host").firstOrNull()
+        return linkedMapOf<String, Any?>(
+            "type" to "httpupgrade",
+        ).apply {
+            host?.let { this["host"] = it }
+            getString(source, "path")?.let { this["path"] = it }
+        }
+    }
+
+    private fun getMap(source: Map<String, Any?>, key: String): Map<*, *>? {
+        return source[key] as? Map<*, *>
+    }
+
+    private fun getString(source: Map<String, Any?>, key: String): String? {
+        return source[key]?.toString()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun getInt(source: Map<String, Any?>, key: String): Int? {
+        val value = source[key] ?: return null
+        return when (value) {
+            is Int -> value
+            is Long -> value.toInt()
+            is Double -> value.toInt()
+            is Float -> value.toInt()
+            is String -> value.toIntOrNull()
+            else -> null
+        }
+    }
+
+    private fun getBoolean(source: Map<String, Any?>, key: String): Boolean? {
+        val value = source[key] ?: return null
+        return when (value) {
+            is Boolean -> value
+            is String -> value.equals("true", ignoreCase = true)
+            else -> null
+        }
+    }
+
+    private fun getStringList(source: Map<String, Any?>, key: String): List<String> {
+        val value = source[key] ?: return emptyList()
+        return when (value) {
+            is List<*> -> value.mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+            is String -> listOf(value).filter(String::isNotBlank)
+            else -> emptyList()
+        }
+    }
+
+    private fun asStringKeyMap(source: Map<*, *>?): Map<String, Any?> {
+        if (source == null) return emptyMap()
+        return source.entries.associate { (key, value) -> key.toString() to value }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/RawProfileFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/RawProfileFmt.kt
@@ -1,0 +1,71 @@
+package com.v2ray.ang.fmt
+
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.core.engine.CoreSelector
+import com.v2ray.ang.dto.ProfileItem
+import com.v2ray.ang.enums.EConfigType
+import com.v2ray.ang.util.JsonUtil
+
+data class RawProfileImport(
+    val profile: ProfileItem,
+    val rawConfig: String,
+)
+
+object RawProfileFmt {
+    fun createProfile(
+        name: String,
+        server: String,
+        serverPort: Int,
+        password: String? = null,
+        method: String? = null,
+        username: String? = null,
+        sni: String? = null,
+        alpn: List<String> = emptyList(),
+        fingerPrint: String? = null,
+        insecure: Boolean? = null,
+    ): ProfileItem {
+        return ProfileItem.create(EConfigType.CUSTOM).apply {
+            remarks = "${CoreSelector.SING_BOX_TEST_PREFIX} $name"
+            this.server = server
+            this.serverPort = serverPort.toString()
+            this.password = password
+            this.method = method
+            this.username = username
+            this.sni = sni
+            this.alpn = alpn.joinToString(",").ifBlank { null }
+            this.fingerPrint = fingerPrint
+            this.insecure = insecure
+        }
+    }
+
+    fun createRawConfig(outbound: Map<String, Any?>): String? {
+        return JsonUtil.toJsonPretty(
+            linkedMapOf(
+                "log" to linkedMapOf(
+                    "level" to "warn",
+                    "timestamp" to true,
+                ),
+                "inbounds" to listOf(
+                    linkedMapOf(
+                        "type" to "mixed",
+                        "tag" to "mixed-in",
+                        "listen" to AppConfig.LOOPBACK,
+                        "listen_port" to AppConfig.PORT_SOCKS.toInt(),
+                        "set_system_proxy" to false,
+                    )
+                ),
+                "outbounds" to listOf(
+                    outbound,
+                    linkedMapOf(
+                        "type" to "direct",
+                        "tag" to AppConfig.TAG_DIRECT,
+                    )
+                ),
+                "route" to linkedMapOf(
+                    "auto_detect_interface" to true,
+                    "final" to AppConfig.TAG_PROXY,
+                )
+            )
+        )
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/RawProfileFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/RawProfileFmt.kt
@@ -5,6 +5,7 @@ import com.v2ray.ang.core.engine.CoreSelector
 import com.v2ray.ang.dto.ProfileItem
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.util.JsonUtil
+import com.v2ray.ang.util.Utils
 
 data class RawProfileImport(
     val profile: ProfileItem,
@@ -12,6 +13,10 @@ data class RawProfileImport(
 )
 
 object RawProfileFmt {
+    private const val TAG_HOSTS_DNS = "hosts_dns"
+    private const val TAG_DIRECT_DNS = "direct_dns"
+    private const val TAG_REMOTE_DNS = "remote_dns"
+
     fun createProfile(
         name: String,
         server: String,
@@ -39,11 +44,89 @@ object RawProfileFmt {
     }
 
     fun createRawConfig(outbound: Map<String, Any?>): String? {
+        val outboundServer = outbound["server"] as? String
+        val outboundDomain = outboundServer?.takeIf { it.isNotBlank() && !Utils.isPureIpAddress(it) }
+        val directDnsDomains = listOf(
+            "alidns.com",
+            "doh.pub",
+            "dot.pub",
+            "onedns.net",
+            "dns.alidns.com",
+        )
+        val dnsRules = mutableListOf<Map<String, Any?>>().apply {
+            if (outboundDomain != null) {
+                add(
+                    linkedMapOf(
+                        "action" to "route",
+                        "server" to TAG_DIRECT_DNS,
+                        "domain" to listOf(outboundDomain),
+                    )
+                )
+            }
+            add(
+                linkedMapOf(
+                    "action" to "route",
+                    "server" to TAG_DIRECT_DNS,
+                    "domain_suffix" to directDnsDomains,
+                )
+            )
+        }
+        val routeRules = mutableListOf<Map<String, Any?>>(
+            linkedMapOf(
+                "action" to "sniff",
+            ),
+            linkedMapOf(
+                "protocol" to listOf("dns"),
+                "action" to "hijack-dns",
+            ),
+            linkedMapOf(
+                "ip_is_private" to true,
+                "action" to "route",
+                "outbound" to AppConfig.TAG_DIRECT,
+            ),
+            linkedMapOf(
+                "domain_suffix" to directDnsDomains,
+                "action" to "route",
+                "outbound" to AppConfig.TAG_DIRECT,
+            ),
+        )
+
         return JsonUtil.toJsonPretty(
             linkedMapOf(
                 "log" to linkedMapOf(
                     "level" to "warn",
                     "timestamp" to true,
+                ),
+                "dns" to linkedMapOf(
+                    "servers" to listOf(
+                        linkedMapOf(
+                            "type" to "hosts",
+                            "tag" to TAG_HOSTS_DNS,
+                            "predefined" to linkedMapOf(
+                                "cloudflare-dns.com" to listOf("104.16.249.249", "104.16.248.249"),
+                                "one.one.one.one" to listOf("1.1.1.1", "1.0.0.1"),
+                                "dns.google" to listOf("8.8.8.8", "8.8.4.4"),
+                                "dns.alidns.com" to listOf("223.5.5.5", "223.6.6.6"),
+                            ),
+                        ),
+                        linkedMapOf(
+                            "type" to "udp",
+                            "tag" to TAG_DIRECT_DNS,
+                            "server" to AppConfig.DNS_DIRECT,
+                        ),
+                        linkedMapOf(
+                            "type" to "https",
+                            "tag" to TAG_REMOTE_DNS,
+                            "server" to "cloudflare-dns.com",
+                            "path" to "/dns-query",
+                            "domain_resolver" to TAG_HOSTS_DNS,
+                            "detour" to AppConfig.TAG_PROXY,
+                        ),
+                    ),
+                    "rules" to dnsRules,
+                    "final" to TAG_REMOTE_DNS,
+                    "independent_cache" to true,
+                    "strategy" to "prefer_ipv4",
                 ),
                 "inbounds" to listOf(
                     linkedMapOf(
@@ -62,7 +145,11 @@ object RawProfileFmt {
                     )
                 ),
                 "route" to linkedMapOf(
-                    "auto_detect_interface" to true,
+                    "default_domain_resolver" to linkedMapOf(
+                        "server" to TAG_DIRECT_DNS,
+                        "strategy" to "prefer_ipv4",
+                    ),
+                    "rules" to routeRules,
                     "final" to AppConfig.TAG_PROXY,
                 )
             )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -13,8 +13,11 @@ import com.v2ray.ang.dto.SubscriptionItem
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.extension.isNotNullEmpty
+import com.v2ray.ang.fmt.AnytlsFmt
+import com.v2ray.ang.fmt.ClashYamlFmt
 import com.v2ray.ang.fmt.CustomFmt
 import com.v2ray.ang.fmt.Hysteria2Fmt
+import com.v2ray.ang.fmt.RawProfileImport
 import com.v2ray.ang.fmt.ShadowsocksFmt
 import com.v2ray.ang.fmt.SocksFmt
 import com.v2ray.ang.fmt.TrojanFmt
@@ -29,6 +32,10 @@ import com.v2ray.ang.util.Utils
 import java.net.URI
 
 object AngConfigManager {
+    private data class ParsedConfig(
+        val profile: ProfileItem,
+        val rawConfig: String? = null,
+    )
 
 
     /**
@@ -160,7 +167,13 @@ object AngConfigManager {
      * @return A pair containing the number of configurations and subscriptions imported.
      */
     fun importBatchConfig(server: String?, subid: String, append: Boolean): Pair<Int, Int> {
-        var count = parseBatchConfig(Utils.decode(server), subid, append)
+        var count = parseClashYamlServer(Utils.decode(server), subid, append)
+        if (count <= 0) {
+            count = parseClashYamlServer(server, subid, append)
+        }
+        if (count <= 0) {
+            count = parseBatchConfig(Utils.decode(server), subid, append)
+        }
         if (count <= 0) {
             count = parseBatchConfig(server, subid, append)
         }
@@ -232,7 +245,7 @@ object AngConfigManager {
             val subItem = MmkvManager.decodeSubscription(subid)
 
             // Parse all configs first (no I/O during parsing)
-            val configs = mutableListOf<ProfileItem>()
+            val configs = mutableListOf<ParsedConfig>()
             servers.lines()
                 .distinct()
                 .reversed()
@@ -260,6 +273,63 @@ object AngConfigManager {
         return 0
     }
 
+    private fun parseClashYamlServer(server: String?, subid: String, append: Boolean): Int {
+        try {
+            if (server.isNullOrBlank() || !ClashYamlFmt.isClashYaml(server)) {
+                return 0
+            }
+
+            val removedSelected = if (subid.isNotBlank() && !append) {
+                MmkvManager.getSelectServer()
+                    .takeIf { it?.isNotBlank() == true }
+                    ?.let { MmkvManager.decodeServerConfig(it) }
+                    ?.takeIf { it.subscriptionId == subid }
+            } else {
+                null
+            }
+
+            val subItem = MmkvManager.decodeSubscription(subid)
+            val configs = ClashYamlFmt.parse(server)
+                .mapNotNull { parsed ->
+                    toParsedConfig(parsed, subid, subItem)
+                }
+
+            if (configs.isEmpty()) {
+                return 0
+            }
+
+            if (!append) {
+                MmkvManager.removeServerViaSubid(subid)
+            }
+            val keyToProfile = batchSaveConfigs(configs, subid)
+            val matchKey = findMatchedProfileKey(keyToProfile, removedSelected)
+            matchKey?.let { MmkvManager.setSelectServer(it) }
+            return configs.size
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to parse Clash YAML config server", e)
+        }
+        return 0
+    }
+
+    private fun toParsedConfig(
+        parsed: RawProfileImport,
+        subid: String,
+        subItem: SubscriptionItem?,
+    ): ParsedConfig? {
+        val config = parsed.profile
+        val filter = subItem?.filter
+
+        if (filter.isNotNullEmpty() && config.remarks.isNotNullEmpty()) {
+            val matched = Regex(pattern = filter.orEmpty())
+                .containsMatchIn(input = config.remarks)
+            if (!matched) return null
+        }
+
+        config.subscriptionId = subid
+        config.description = generateDescription(config)
+        return ParsedConfig(profile = config, rawConfig = parsed.rawConfig)
+    }
+
     /**
      * Batch save configurations to reduce serverList read/write operations.
      * Reads serverList once, saves all configs, then writes serverList once.
@@ -268,17 +338,19 @@ object AngConfigManager {
      * @param subid The subscription ID.
      * @return Map of generated keys to their corresponding ProfileItem.
      */
-    private fun batchSaveConfigs(configs: List<ProfileItem>, subid: String): Map<String, ProfileItem> {
+    private fun batchSaveConfigs(configs: List<ParsedConfig>, subid: String): Map<String, ProfileItem> {
         val keyToProfile = mutableMapOf<String, ProfileItem>()
 
         // Read serverList once
         val serverList = MmkvManager.decodeServerList(subid)
         var needSetSelected = MmkvManager.getSelectServer().isNullOrBlank()
 
-        configs.forEach { config ->
+        configs.forEach { imported ->
+            val config = imported.profile
             val key = Utils.getUuid()
             // Save profile directly without updating serverList
             MmkvManager.encodeProfileDirect(key, JsonUtil.toJson(config))
+            imported.rawConfig?.let { MmkvManager.encodeServerRaw(key, it) }
 
             if (!serverList.contains(key)) {
                 serverList.add(0, key)
@@ -376,7 +448,7 @@ object AngConfigManager {
                     }
                     var count = 0
                     for (srv in serverList.reversed()) {
-                        val config = CustomFmt.parse(JsonUtil.toJson(srv)) ?: continue
+                        val config = CustomFmt.parse(JsonUtil.toJson(srv))
                         config.subscriptionId = subid
                         config.description = generateDescription(config)
                         val key = MmkvManager.encodeServerConfig("", config)
@@ -391,7 +463,7 @@ object AngConfigManager {
 
             try {
                 // For compatibility
-                val config = CustomFmt.parse(server) ?: return 0
+                val config = CustomFmt.parse(server)
                 config.subscriptionId = subid
                 config.description = generateDescription(config)
                 if (!append) {
@@ -436,10 +508,13 @@ object AngConfigManager {
         str: String?,
         subid: String,
         subItem: SubscriptionItem?
-    ): ProfileItem? {
+    ): ParsedConfig? {
         try {
             if (str == null || TextUtils.isEmpty(str)) {
                 return null
+            }
+            if (str.startsWith("anytls://", ignoreCase = true)) {
+                return toParsedConfig(AnytlsFmt.parse(str) ?: return null, subid, subItem)
             }
 
             val config = if (str.startsWith(EConfigType.VMESS.protocolScheme)) {
@@ -474,7 +549,7 @@ object AngConfigManager {
             config.subscriptionId = subid
             config.description = generateDescription(config)
 
-            return config
+            return ParsedConfig(config)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to parse config", e)
             return null
@@ -580,7 +655,13 @@ object AngConfigManager {
      * @return The number of configurations parsed.
      */
     private fun parseConfigViaSub(server: String?, subid: String, append: Boolean): Int {
-        var count = parseBatchConfig(Utils.decode(server), subid, append)
+        var count = parseClashYamlServer(Utils.decode(server), subid, append)
+        if (count <= 0) {
+            count = parseClashYamlServer(server, subid, append)
+        }
+        if (count <= 0) {
+            count = parseBatchConfig(Utils.decode(server), subid, append)
+        }
         if (count <= 0) {
             count = parseBatchConfig(server, subid, append)
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.handler
 import android.content.Context
 import android.graphics.Bitmap
 import android.text.TextUtils
+import android.webkit.URLUtil
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.HY2
 import com.v2ray.ang.R
@@ -208,7 +209,7 @@ object AngConfigManager {
             servers.lines()
                 .distinct()
                 .forEach { str ->
-                    if (Utils.isValidSubUrl(str)) {
+                    if (isImportableSubscriptionUrl(str)) {
                         count += importUrlAsSubscription(str)
                     }
                 }
@@ -688,8 +689,15 @@ object AngConfigManager {
         val subItem = SubscriptionItem()
         subItem.remarks = uri.fragment ?: "import sub"
         subItem.url = url
+        subItem.allowInsecureUrl = URLUtil.isHttpUrl(url)
         MmkvManager.encodeSubscription("", subItem)
         return 1
+    }
+
+    private fun isImportableSubscriptionUrl(value: String?): Boolean {
+        if (value.isNullOrBlank()) return false
+        if (Utils.isValidSubUrl(value)) return true
+        return URLUtil.isHttpUrl(value) && Utils.isValidUrl(value)
     }
 
     /** Generates a description for the profile.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -208,6 +208,7 @@ object MmkvManager {
             mainStorage.remove(KEY_SELECTED_SERVER)
         }
         profileFullStorage.remove(guid)
+        serverRawStorage.remove(guid)
         serverAffStorage.remove(guid)
     }
 
@@ -226,6 +227,7 @@ object MmkvManager {
                 mainStorage.remove(KEY_SELECTED_SERVER)
             }
             profileFullStorage.remove(guid)
+            serverRawStorage.remove(guid)
             serverAffStorage.remove(guid)
         }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -26,6 +26,7 @@ import com.v2ray.ang.handler.MmkvManager.decodeSubsList
 import com.v2ray.ang.handler.MmkvManager.decodeSubscription
 import com.v2ray.ang.handler.MmkvManager.encodeSubscription
 import com.v2ray.ang.handler.MmkvManager.removeSubscription
+import com.v2ray.ang.service.HevTunNative
 import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
@@ -461,7 +462,8 @@ object SettingsManager {
      * @return True if HEV TUN is used, false otherwise.
      */
     fun isUsingHevTun(): Boolean {
-        return MmkvManager.decodeSettingsBool(AppConfig.PREF_USE_HEV_TUNNEL, true)
+        return MmkvManager.decodeSettingsBool(AppConfig.PREF_USE_HEV_TUNNEL, true) &&
+                HevTunNative.isBundled()
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
@@ -13,6 +13,8 @@ import com.v2ray.ang.util.MyContextWrapper
 import java.lang.ref.SoftReference
 
 class CoreProxyOnlyService : Service(), ServiceControl {
+    private var isRunning = false
+
     /**
      * Initializes the service.
      */
@@ -31,6 +33,7 @@ class CoreProxyOnlyService : Service(), ServiceControl {
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Service command received")
+        isRunning = true
         CoreServiceManager.startCoreLoop(null)
         return START_STICKY
     }
@@ -40,6 +43,7 @@ class CoreProxyOnlyService : Service(), ServiceControl {
      */
     override fun onDestroy() {
         super.onDestroy()
+        isRunning = false
         CoreServiceManager.stopCoreLoop()
     }
 
@@ -62,7 +66,12 @@ class CoreProxyOnlyService : Service(), ServiceControl {
      * Stops the service.
      */
     override fun stopService() {
+        isRunning = false
         stopSelf()
+    }
+
+    override fun isServiceRunning(): Boolean {
+        return isRunning
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
@@ -5,11 +5,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
 import com.v2ray.ang.contracts.ServiceControl
+import com.v2ray.ang.enums.NotificationChannelType
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.core.CoreServiceManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.MyContextWrapper
+import com.v2ray.ang.util.NotificationHelper
 import java.lang.ref.SoftReference
 
 class CoreProxyOnlyService : Service(), ServiceControl {
@@ -33,9 +36,29 @@ class CoreProxyOnlyService : Service(), ServiceControl {
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Service command received")
-        isRunning = true
-        CoreServiceManager.startCoreLoop(null)
+        ensureForegroundStarted()
+        CoreServiceManager.startCoreLoopAsync(null) { ok ->
+            if (!ok) {
+                isRunning = false
+                stopSelf()
+            } else {
+                isRunning = true
+            }
+        }
         return START_STICKY
+    }
+
+    private fun ensureForegroundStarted() {
+        try {
+            NotificationHelper.startForeground(
+                service = this,
+                channelType = NotificationChannelType.SERVICE_RUNNING,
+                title = getString(R.string.app_name),
+                content = getString(R.string.toast_services_start),
+            )
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Proxy: Failed to enter foreground", e)
+        }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -18,14 +18,18 @@ import androidx.annotation.RequiresApi
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.LOOPBACK
 import com.v2ray.ang.BuildConfig
+import com.v2ray.ang.R
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.contracts.Tun2SocksControl
+import com.v2ray.ang.core.engine.CoreSelector
+import com.v2ray.ang.core.engine.CoreType
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.core.CoreServiceManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.MyContextWrapper
+import com.v2ray.ang.util.NotificationHelper
 import com.v2ray.ang.util.Utils
 import java.lang.ref.SoftReference
 
@@ -113,6 +117,7 @@ class CoreVpnService : VpnService(), ServiceControl {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received")
+        ensureForegroundStarted()
         setupVpnService()
         startService()
         return START_STICKY
@@ -135,8 +140,25 @@ class CoreVpnService : VpnService(), ServiceControl {
         }
     }
 
+    private fun ensureForegroundStarted() {
+        try {
+            NotificationHelper.startForeground(
+                service = this,
+                channelType = com.v2ray.ang.enums.NotificationChannelType.SERVICE_RUNNING,
+                title = getString(R.string.app_name),
+                content = getString(R.string.toast_services_start)
+            )
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "StartCore-VPN: Failed to enter foreground early", e)
+        }
+    }
+
     override fun stopService() {
         stopAllService(true)
+    }
+
+    override fun isServiceRunning(): Boolean {
+        return isRunning
     }
 
     override fun vpnProtect(socket: Int): Boolean {
@@ -243,13 +265,15 @@ class CoreVpnService : VpnService(), ServiceControl {
             }
         }
 
-        // Configure DNS servers
-        //if (MmkvManager.decodeSettingsBool(AppConfig.PREF_LOCAL_DNS_ENABLED) == true) {
-        //  builder.addDnsServer(PRIVATE_VLAN4_ROUTER)
-        //} else {
-        SettingsManager.getVpnDnsServers().forEach {
-            if (Utils.isPureIpAddress(it)) {
-                builder.addDnsServer(it)
+        // Use the bridge-local DNS endpoint for sing-box tun2socks profiles so
+        // Android resolves hostnames through HEV mapdns instead of external UDP DNS.
+        if (shouldUseBridgeLocalDns()) {
+            builder.addDnsServer(vpnConfig.ipv4Router)
+        } else {
+            SettingsManager.getVpnDnsServers().forEach {
+                if (Utils.isPureIpAddress(it)) {
+                    builder.addDnsServer(it)
+                }
             }
         }
 
@@ -330,7 +354,8 @@ class CoreVpnService : VpnService(), ServiceControl {
      * Starts the tun2socks process with the appropriate parameters.
      */
     private fun runTun2socks() {
-        if (SettingsManager.isUsingHevTun()) {
+        val useTunBridge = shouldUseTun2SocksBridge()
+        if (useTunBridge) {
             tun2SocksService = TProxyService(
                 context = applicationContext,
                 vpnInterface = mInterface,
@@ -342,6 +367,34 @@ class CoreVpnService : VpnService(), ServiceControl {
         }
 
         tun2SocksService?.startTun2Socks()
+    }
+
+    private fun shouldUseTun2SocksBridge(): Boolean {
+        if (SettingsManager.isUsingHevTun()) {
+            return true
+        }
+
+        if (!isSingBoxProfileSelected()) {
+            return false
+        }
+
+        if (!HevTunNative.isBundled()) {
+            LogUtil.w(AppConfig.TAG, "StartCore-VPN: sing-box selected but HEV bridge is not bundled correctly")
+            return false
+        }
+
+        LogUtil.i(AppConfig.TAG, "StartCore-VPN: enabling HEV tun2socks bridge for sing-box profile")
+        return true
+    }
+
+    private fun shouldUseBridgeLocalDns(): Boolean {
+        return shouldUseTun2SocksBridge() && isSingBoxProfileSelected()
+    }
+
+    private fun isSingBoxProfileSelected(): Boolean {
+        val guid = MmkvManager.getSelectServer() ?: return false
+        val profile = MmkvManager.decodeServerConfig(guid) ?: return false
+        return CoreSelector.resolve(profile) == CoreType.SING_BOX
     }
 
     private fun stopAllService(isForced: Boolean = true) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -133,10 +133,11 @@ class CoreVpnService : VpnService(), ServiceControl {
             LogUtil.e(AppConfig.TAG, "StartCore-VPN: Interface not initialized")
             return
         }
-        if (!CoreServiceManager.startCoreLoop(mInterface)) {
-            LogUtil.e(AppConfig.TAG, "StartCore-VPN: Failed to start core loop")
-            stopAllService()
-            return
+        CoreServiceManager.startCoreLoopAsync(mInterface) { ok ->
+            if (!ok) {
+                LogUtil.e(AppConfig.TAG, "StartCore-VPN: Failed to start core loop")
+                stopAllService()
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/HevTunNative.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/HevTunNative.kt
@@ -1,0 +1,53 @@
+package com.v2ray.ang.service
+
+import com.v2ray.ang.AngApplication
+import java.io.File
+
+object HevTunNative {
+    private const val LIBRARY_NAME = "hev-socks5-tunnel"
+    private const val BRIDGE_CLASS_NAME = "hev.htproxy.TProxyService"
+
+    @Volatile
+    private var initialized = false
+
+    @Volatile
+    private var loaded = false
+
+    /**
+     * Returns whether the packaged app contains the HEV native library and the
+     * expected JVM bridge class. This check is safe to call during service
+     * planning because it does not touch JNI at all.
+     */
+    fun isBundled(): Boolean {
+        return hasNativeLibraryFile() && hasBridgeBindingClass()
+    }
+
+    /**
+     * Loads the JNI library on demand. Call this only right before using the
+     * native bridge, never during capability checks.
+     */
+    fun ensureLoaded() {
+        if (loaded) return
+        synchronized(this) {
+            if (loaded) return
+            check(isBundled()) { "HEV bridge is not bundled correctly" }
+            System.loadLibrary(LIBRARY_NAME)
+            loaded = true
+            initialized = true
+        }
+    }
+
+    fun isLoaded(): Boolean = loaded
+
+    private fun hasNativeLibraryFile(): Boolean {
+        val app = runCatching { AngApplication.application }.getOrNull() ?: return false
+        val nativeLibraryDir = app.applicationInfo.nativeLibraryDir ?: return false
+        return File(nativeLibraryDir, System.mapLibraryName(LIBRARY_NAME)).exists()
+    }
+
+    private fun hasBridgeBindingClass(): Boolean {
+        return runCatching {
+            Class.forName(BRIDGE_CLASS_NAME, false, HevTunNative::class.java.classLoader)
+        }.isSuccess
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/ProcessService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/ProcessService.kt
@@ -6,6 +6,7 @@ import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 
 class ProcessService {
     private var process: Process? = null
@@ -15,14 +16,23 @@ class ProcessService {
      * @param context The context.
      * @param cmd The command to run.
      */
-    fun runProcess(context: Context, cmd: MutableList<String>) {
+    fun runProcess(
+        context: Context,
+        cmd: MutableList<String>,
+        workingDirectory: File = context.filesDir,
+        logFile: File? = null,
+    ) {
         LogUtil.i(AppConfig.TAG, cmd.toString())
 
         try {
             val proBuilder = ProcessBuilder(cmd)
             proBuilder.redirectErrorStream(true)
+            if (logFile != null) {
+                logFile.parentFile?.mkdirs()
+                proBuilder.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
+            }
             process = proBuilder
-                .directory(context.filesDir)
+                .directory(workingDirectory)
                 .start()
 
             CoroutineScope(Dispatchers.IO).launch {
@@ -38,6 +48,10 @@ class ProcessService {
         }
     }
 
+    fun isRunning(): Boolean {
+        return process?.isAlive == true
+    }
+
     /**
      * Stops the running process.
      */
@@ -45,6 +59,7 @@ class ProcessService {
         try {
             LogUtil.i(AppConfig.TAG, "runProcess destroy")
             process?.destroy()
+            process = null
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to destroy process", e)
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/ProcessService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/ProcessService.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 class ProcessService {
     private var process: Process? = null
@@ -56,12 +57,22 @@ class ProcessService {
      * Stops the running process.
      */
     fun stopProcess() {
+        val active = process ?: return
+        process = null
         try {
             LogUtil.i(AppConfig.TAG, "runProcess destroy")
-            process?.destroy()
-            process = null
+            active.destroy()
+            val exited = active.waitFor(2L, TimeUnit.SECONDS)
+            if (!exited && active.isAlive) {
+                LogUtil.w(AppConfig.TAG, "runProcess destroy timed out; destroyForcibly")
+                active.destroyForcibly()
+                active.waitFor(500L, TimeUnit.MILLISECONDS)
+            }
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to destroy process", e)
+            runCatching {
+                if (active.isAlive) active.destroyForcibly()
+            }
         }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/TProxyService.kt
@@ -18,28 +18,11 @@ class TProxyService(
     private val isRunningProvider: () -> Boolean,
     private val restartCallback: () -> Unit
 ) : Tun2SocksControl {
-    companion object {
-        @JvmStatic
-        @Suppress("FunctionName")
-        private external fun TProxyStartService(configPath: String, fd: Int)
-
-        @JvmStatic
-        @Suppress("FunctionName")
-        private external fun TProxyStopService()
-
-        @JvmStatic
-        @Suppress("FunctionName")
-        private external fun TProxyGetStats(): LongArray?
-
-        init {
-            System.loadLibrary("hev-socks5-tunnel")
-        }
-    }
-
     /**
      * Starts the tun2socks process with the appropriate parameters.
      */
     override fun startTun2Socks() {
+        HevTunNative.ensureLoaded()
 //        LogUtil.i(AppConfig.TAG, "Starting HevSocks5Tunnel via JNI")
 
         val configContent = buildConfig()
@@ -51,8 +34,8 @@ class TProxyService(
 
         try {
 //            LogUtil.i(AppConfig.TAG, "TProxyStartService...")
-            TProxyStartService(configFile.absolutePath, vpnInterface.fd)
-        } catch (e: Exception) {
+            hev.htproxy.TProxyService.TProxyStartService(configFile.absolutePath, vpnInterface.fd)
+        } catch (e: Throwable) {
             LogUtil.e(AppConfig.TAG, "HevSocks5Tunnel exception: ${e.message}")
         }
     }
@@ -82,6 +65,15 @@ class TProxyService(
                 appendLine("  password: '${escapedSocksPassword}'")
             }
 
+            // Expose a DNS endpoint inside the VPN subnet so Android can resolve
+            // hostnames before the traffic reaches sing-box.
+            appendLine("mapdns:")
+            appendLine("  address: ${vpnConfig.ipv4Router}")
+            appendLine("  port: 53")
+            appendLine("  network: ${AppConfig.HEV_MAP_DNS_NETWORK}")
+            appendLine("  netmask: ${AppConfig.HEV_MAP_DNS_NETMASK}")
+            appendLine("  cache-size: 10000")
+
             // Read-write timeout settings
             val timeoutSetting = MmkvManager.decodeSettingsString(AppConfig.PREF_HEV_TUNNEL_RW_TIMEOUT) ?: AppConfig.HEVTUN_RW_TIMEOUT
             val parts = timeoutSetting.split(",")
@@ -102,9 +94,10 @@ class TProxyService(
      */
     override fun stopTun2Socks() {
         try {
+            HevTunNative.ensureLoaded()
             LogUtil.i(AppConfig.TAG, "TProxyStopService...")
-            TProxyStopService()
-        } catch (e: Exception) {
+            hev.htproxy.TProxyService.TProxyStopService()
+        } catch (e: Throwable) {
             LogUtil.e(AppConfig.TAG, "Failed to stop hev-socks5-tunnel", e)
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -204,6 +204,7 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
 
     override fun onResume() {
         super.onResume()
+        mainViewModel.syncRunningState()
     }
 
     override fun onPause() {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -18,6 +18,7 @@ import com.v2ray.ang.dto.ServersCache
 import com.v2ray.ang.dto.SubscriptionCache
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.TestServiceMessage
+import com.v2ray.ang.core.CoreServiceManager
 import com.v2ray.ang.extension.matchesPattern
 import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.extension.toastError
@@ -53,9 +54,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
      * `registerReceiver(Context, BroadcastReceiver, IntentFilter, int)`.
      */
     fun startListenBroadcast() {
-        isRunning.value = false
+        isRunning.value = CoreServiceManager.isRunning()
         val mFilter = IntentFilter(AppConfig.BROADCAST_ACTION_ACTIVITY)
         ContextCompat.registerReceiver(getApplication(), mMsgReceiver, mFilter, Utils.receiverFlags())
+        syncRunningState()
+    }
+
+    fun syncRunningState() {
+        isRunning.value = CoreServiceManager.isRunning()
         MessageUtil.sendMsg2Service(getApplication(), AppConfig.MSG_REGISTER_CLIENT, "")
     }
 
@@ -458,6 +464,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
                 AppConfig.MSG_STATE_START_FAILURE -> {
                     getApplication<AngApplication>().toastError(R.string.toast_services_failure)
+                    updateTestResultAction.value = intent.getStringExtra("content")
                     isRunning.value = false
                 }
 

--- a/V2rayNG/app/src/main/java/hev/htproxy/TProxyService.kt
+++ b/V2rayNG/app/src/main/java/hev/htproxy/TProxyService.kt
@@ -1,0 +1,17 @@
+package hev.htproxy
+
+class TProxyService {
+    companion object {
+        @JvmStatic
+        @Suppress("FunctionName")
+        external fun TProxyStartService(configPath: String, fd: Int)
+
+        @JvmStatic
+        @Suppress("FunctionName")
+        external fun TProxyStopService()
+
+        @JvmStatic
+        @Suppress("FunctionName")
+        external fun TProxyGetStats(): LongArray?
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/AnytlsFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/AnytlsFmtTest.kt
@@ -1,0 +1,59 @@
+package com.v2ray.ang.fmt
+
+import com.google.gson.JsonParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnytlsFmtTest {
+    @Test
+    fun test_parseNodeUri_generatesCustomSingBoxProfile() {
+        val uri = "anytls://fbf033ed-6818-4640-af09-12783be9db45@a99.zongse001.top:43399/?insecure=1&sni=osxapps.itunes.apple.com#A3%7C%E7%BE%8E%E5%9B%BD-%E5%8E%9F%E7%94%9FIP-US99%7C2X"
+
+        val result = AnytlsFmt.parse(uri)
+
+        assertNotNull(result)
+        val parsed = result!!
+        assertEquals("[sing-box] A3|美国-原生IP-US99|2X", parsed.profile.remarks)
+        assertEquals("a99.zongse001.top", parsed.profile.server)
+        assertEquals("43399", parsed.profile.serverPort)
+        assertEquals("osxapps.itunes.apple.com", parsed.profile.sni)
+        assertTrue(parsed.profile.insecure == true)
+
+        val rawJson = JsonParser.parseString(parsed.rawConfig).asJsonObject
+        val outbound = rawJson.getAsJsonArray("outbounds")[0].asJsonObject
+        val tls = outbound.getAsJsonObject("tls")
+        assertEquals("anytls", outbound.get("type").asString)
+        assertEquals("fbf033ed-6818-4640-af09-12783be9db45", outbound.get("password").asString)
+        assertEquals("osxapps.itunes.apple.com", tls.get("server_name").asString)
+        assertTrue(tls.get("insecure").asBoolean)
+    }
+
+    @Test
+    fun test_parseInfoUri_skipsSubscriptionMetadata() {
+        val uri = "anytls://fbf033ed-6818-4640-af09-12783be9db45@a99.zongse001.top:43399/?insecure=1&sni=osxapps.itunes.apple.com#%E5%89%A9%E4%BD%99%E6%B5%81%E9%87%8F%EF%BC%9A992.77%20GB"
+
+        val result = AnytlsFmt.parse(uri)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun test_parseWithFingerprintAndAlpn_preservesTlsOptions() {
+        val uri = "anytls://password@example.com:443/?insecure=0&sni=cdn.example.com&alpn=h2,http%2F1.1&fp=chrome#demo"
+
+        val result = AnytlsFmt.parse(uri)
+
+        assertNotNull(result)
+        val rawJson = JsonParser.parseString(result!!.rawConfig).asJsonObject
+        val tls = rawJson.getAsJsonArray("outbounds")[0].asJsonObject.getAsJsonObject("tls")
+        val alpn = tls.getAsJsonArray("alpn")
+        assertFalse(tls.get("insecure").asBoolean)
+        assertEquals("chrome", tls.getAsJsonObject("utls").get("fingerprint").asString)
+        assertEquals("h2", alpn[0].asString)
+        assertEquals("http/1.1", alpn[1].asString)
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ClashYamlFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ClashYamlFmtTest.kt
@@ -1,0 +1,104 @@
+package com.v2ray.ang.fmt
+
+import com.google.gson.JsonParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClashYamlFmtTest {
+    @Test
+    fun test_parseAnytlsProxy_generatesCustomSingBoxProfile() {
+        val yaml = """
+            proxies:
+              - name: US
+                type: anytls
+                server: a70.topzz.cc
+                port: 42370
+                password: 5a101599-a536-4cee-a004-17ee96022cac
+                client-fingerprint: chrome
+                alpn:
+                  - h2
+                  - http/1.1
+                sni: osxapps.itunes.apple.com
+                skip-cert-verify: true
+        """.trimIndent()
+
+        val result = ClashYamlFmt.parse(yaml)
+
+        assertEquals(1, result.size)
+        val parsed = result.first()
+        assertEquals("[sing-box] US", parsed.profile.remarks)
+        assertEquals("a70.topzz.cc", parsed.profile.server)
+        assertEquals("42370", parsed.profile.serverPort)
+        assertEquals("chrome", parsed.profile.fingerPrint)
+        assertTrue(parsed.profile.insecure == true)
+
+        val rawJson = JsonParser.parseString(parsed.rawConfig).asJsonObject
+        val outbound = rawJson.getAsJsonArray("outbounds")[0].asJsonObject
+        val tls = outbound.getAsJsonObject("tls")
+        assertEquals("anytls", outbound.get("type").asString)
+        assertEquals("a70.topzz.cc", outbound.get("server").asString)
+        assertEquals(42370, outbound.get("server_port").asInt)
+        assertEquals("osxapps.itunes.apple.com", tls.get("server_name").asString)
+        assertTrue(tls.get("insecure").asBoolean)
+        assertEquals("chrome", tls.getAsJsonObject("utls").get("fingerprint").asString)
+    }
+
+    @Test
+    fun test_parseVmessWsTlsProxy_preservesTransportAndTls() {
+        val yaml = """
+            proxies:
+              - name: VMess WS
+                type: vmess
+                server: vmess.example.com
+                port: 443
+                uuid: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+                alterId: 0
+                cipher: auto
+                tls: true
+                servername: cdn.example.com
+                client-fingerprint: chrome
+                network: ws
+                ws-opts:
+                  path: /ws
+                  headers:
+                    Host: edge.example.com
+        """.trimIndent()
+
+        val result = ClashYamlFmt.parse(yaml)
+
+        assertEquals(1, result.size)
+        val rawJson = JsonParser.parseString(result.first().rawConfig).asJsonObject
+        val outbound = rawJson.getAsJsonArray("outbounds")[0].asJsonObject
+        val tls = outbound.getAsJsonObject("tls")
+        val transport = outbound.getAsJsonObject("transport")
+
+        assertEquals("vmess", outbound.get("type").asString)
+        assertEquals("auto", outbound.get("security").asString)
+        assertEquals(0, outbound.get("alter_id").asInt)
+        assertEquals("cdn.example.com", tls.get("server_name").asString)
+        assertEquals("ws", transport.get("type").asString)
+        assertEquals("/ws", transport.get("path").asString)
+        assertEquals("edge.example.com", transport.getAsJsonObject("headers").get("Host").asString)
+    }
+
+    @Test
+    fun test_isClashYaml_onlyMatchesProxyDocuments() {
+        assertTrue(
+            ClashYamlFmt.isClashYaml(
+                """
+                port: 7890
+                proxies:
+                  - name: demo
+                    type: http
+                    server: example.com
+                    port: 80
+                """.trimIndent()
+            )
+        )
+        assertFalse(ClashYamlFmt.isClashYaml("""{"outbounds": []}"""))
+        assertFalse(ClashYamlFmt.isClashYaml("vmess://example"))
+        assertTrue(ClashYamlFmt.parse("proxies: []").isEmpty())
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.fmt
 
 import android.util.Base64
+import android.util.Log
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.dto.ProfileItem

--- a/V2rayNG/gradle/libs.versions.toml
+++ b/V2rayNG/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ preferenceKtx = "1.2.1"
 recyclerview = "1.4.0"
 viewpager2 = "1.1.0"
 fragment = "1.8.9"
+snakeyaml = "2.4"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
@@ -66,6 +67,7 @@ recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "r
 preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preferenceKtx" }
 androidx-viewpager2 = { module = "androidx.viewpager2:viewpager2", version.ref = "viewpager2" }
 androidx-fragment = { module = "androidx.fragment:fragment-ktx", version.ref = "fragment" }
+org-yaml-snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/docs/rfcs/multi-core-engine-rfc.md
+++ b/docs/rfcs/multi-core-engine-rfc.md
@@ -116,6 +116,13 @@ Current local test entry:
 - a profile remark prefixed with `[sing-box]` is resolved to `SingBoxEngine`;
 - the runtime uses the raw custom JSON from MMKV instead of the Xray config builder.
 
+Current parser bridge status:
+
+- `Clash YAML` documents with a top-level `proxies:` list can be converted into `CUSTOM` profiles backed by raw `sing-box` JSON;
+- direct `anytls://` import can be converted into `CUSTOM` profiles backed by raw `sing-box` JSON;
+- base64 subscriptions that decode into mixed URI lines can now keep native Xray-supported links on the legacy path while routing `anytls://` lines to `SingBoxEngine`;
+- subscription metadata lines such as remaining-traffic or expiry notices should be filtered before profile creation.
+
 Follow-up phases:
 
 1. Add `SingBoxEngine` bootstrap and runtime lifecycle.

--- a/docs/rfcs/multi-core-engine-rfc.md
+++ b/docs/rfcs/multi-core-engine-rfc.md
@@ -4,11 +4,11 @@
 
 This proposal introduces a runtime abstraction layer for `v2rayNG` so the app can evolve from a single embedded Xray runtime into a multi-core client that can host both `Xray` and `sing-box`.
 
-The first PR intentionally keeps runtime behavior unchanged:
+The current branch is no longer architecture-only:
 
-- `Xray` remains the only active engine.
-- Existing startup, shutdown, stats, and delay flows keep their current behavior.
-- New abstractions are added to reduce coupling between the app layer and `libv2ray`.
+- native `VMESS` / `VLESS` / `TROJAN` profiles continue to run on `Xray`;
+- explicitly marked `[sing-box]` `CUSTOM` profiles run on `SingBoxEngine`;
+- Android VPN startup, foreground-service sync, line testing, and AnyTLS raw runtime bootstrap have been exercised on device.
 
 ## Background
 
@@ -26,15 +26,16 @@ That design works well for an embedded Xray runtime, but it becomes a blocker fo
 - Introduce a stable app-level `CoreEngine` interface.
 - Isolate Xray-specific bindings behind `XrayCoreEngine`.
 - Add a single selection hook for future per-profile core resolution.
-- Keep this PR reviewable by avoiding functional changes.
-- Prepare follow-up work for `sing-box` support on Android.
+- Keep runtime selection centralized and reviewable.
+- Add a minimal but usable `sing-box` path for Android `CUSTOM` profiles.
+- Preserve existing `Xray` behavior for native profile types.
 
 ## Non-goals
 
-- Shipping `sing-box` in this PR.
-- Changing subscription parsing in this PR.
-- Changing current profile storage in this PR.
-- Claiming feature parity between `Xray` and `sing-box` yet.
+- Full feature parity between `Xray` and `sing-box`.
+- Automatic per-subscription routing for every protocol family.
+- Replacing native `Xray` handling for `VMESS` / `VLESS` / `TROJAN`.
+- Final UI or storage model for long-term multi-core metadata.
 
 ## Proposed Architecture
 
@@ -69,7 +70,8 @@ Add `CoreSelector.resolve(profile)` as a central decision point.
 
 Current behavior:
 
-- always returns `CoreType.XRAY`.
+- profiles marked as `[sing-box]` and stored as `CUSTOM` resolve to `CoreType.SING_BOX`;
+- all other native profile types currently resolve to `CoreType.XRAY`.
 
 Future behavior:
 
@@ -108,13 +110,20 @@ Expected apk asset layout for future runtime packaging:
 - `app/src/main/assets/sing-box/x86_64/sing-box`
 - `app/src/main/assets/sing-box/x86/sing-box`
 
-The selector still resolves all profiles to `Xray`, so there is no behavior change for end users yet.
-
 Current local test entry:
 
 - only `CUSTOM` profiles are eligible;
 - a profile remark prefixed with `[sing-box]` is resolved to `SingBoxEngine`;
 - the runtime uses the raw custom JSON from MMKV instead of the Xray config builder.
+
+Current Android runtime status:
+
+- `HEV tun2socks` JNI loading is gated so capability probing does not crash the VPN process;
+- `CoreVpnService` foreground startup has been tightened to avoid the prior stuck-on-start path;
+- `sing-box 1.12` DNS bootstrap is generated with `hosts_dns`, `direct_dns`, `remote_dns`, `dns.rules`, and `route.default_domain_resolver`;
+- old `SERVER_RAW` entries are normalized at runtime so existing imported nodes do not require manual re-import after every DNS-template fix;
+- `SingBoxEngine.measureDelay()` now performs a real local-proxy HTTP delay check instead of returning a placeholder failure;
+- foreground UI state is refreshed against the actual service/runtime state when returning to the app.
 
 Current parser bridge status:
 
@@ -144,13 +153,33 @@ Expected `sing-box` support areas:
 
 These targets should be implemented behind the common engine contract instead of leaking engine-specific branching into UI and service code.
 
+## Validation status
+
+Device-side regression checks completed on the current branch:
+
+- `sing-box` path:
+  - scanned/imported `[sing-box]` `CUSTOM` profiles start through `CoreVpnService`;
+  - runtime config is written under `no_backup/core-sing-box/runtime/config.json`;
+  - line test succeeds with a real delay result;
+  - `Google` is reachable in Chrome after the VPN is enabled.
+- `xray` path:
+  - imported native `VMESS` and `VLESS` profiles remain visible as native types in the server list;
+  - starting a `VMESS` node logs `Xray 26.5.3 started`;
+  - line test succeeds with a real delay result;
+  - `Google` is reachable in Chrome after the VPN is enabled.
+
+Current evidence supports the intended split:
+
+- `[sing-box]` `CUSTOM` -> `SingBoxEngine`
+- native `VMESS` / `VLESS` / `TROJAN` -> `XrayCoreEngine`
+
 ## Review strategy
 
-This PR is intentionally scoped as an architectural pre-step:
+This PR is still structured to keep the architecture understandable, but it now includes a constrained functional slice:
 
-- small enough to review safely;
-- no behavior change for current users;
-- unlocks future multi-core work without forcing a one-shot rewrite.
+- common engine abstractions and centralized selection;
+- a minimal Android-usable `sing-box` runtime path for explicit `CUSTOM` profiles;
+- regression coverage to verify that enabling `sing-box` does not break the existing `Xray` path.
 
 ## Open questions
 

--- a/docs/rfcs/multi-core-engine-rfc.md
+++ b/docs/rfcs/multi-core-engine-rfc.md
@@ -99,7 +99,14 @@ The follow-up skeleton adds:
 
 - `SingBoxEngine` as a non-selected runtime implementation;
 - `SingBoxRuntimeLayout` to define stable locations for the future binary, config, and log files;
-- a placeholder process bootstrap path that writes config and prepares the future `sing-box run -c ...` command.
+- a process bootstrap path that writes config, installs the binary from apk assets when available, and prepares `sing-box run -c ...`.
+
+Expected apk asset layout for future runtime packaging:
+
+- `app/src/main/assets/sing-box/arm64-v8a/sing-box`
+- `app/src/main/assets/sing-box/armeabi-v7a/sing-box`
+- `app/src/main/assets/sing-box/x86_64/sing-box`
+- `app/src/main/assets/sing-box/x86/sing-box`
 
 The selector still resolves all profiles to `Xray`, so there is no behavior change for end users yet.
 

--- a/docs/rfcs/multi-core-engine-rfc.md
+++ b/docs/rfcs/multi-core-engine-rfc.md
@@ -110,6 +110,12 @@ Expected apk asset layout for future runtime packaging:
 
 The selector still resolves all profiles to `Xray`, so there is no behavior change for end users yet.
 
+Current local test entry:
+
+- only `CUSTOM` profiles are eligible;
+- a profile remark prefixed with `[sing-box]` is resolved to `SingBoxEngine`;
+- the runtime uses the raw custom JSON from MMKV instead of the Xray config builder.
+
 Follow-up phases:
 
 1. Add `SingBoxEngine` bootstrap and runtime lifecycle.

--- a/docs/rfcs/multi-core-engine-rfc.md
+++ b/docs/rfcs/multi-core-engine-rfc.md
@@ -1,0 +1,129 @@
+# Multi-core Engine RFC
+
+## Summary
+
+This proposal introduces a runtime abstraction layer for `v2rayNG` so the app can evolve from a single embedded Xray runtime into a multi-core client that can host both `Xray` and `sing-box`.
+
+The first PR intentionally keeps runtime behavior unchanged:
+
+- `Xray` remains the only active engine.
+- Existing startup, shutdown, stats, and delay flows keep their current behavior.
+- New abstractions are added to reduce coupling between the app layer and `libv2ray`.
+
+## Background
+
+`v2rayNG` currently couples its Android service lifecycle, delay testing, stats access, and process lookup directly to `libv2ray.CoreController`.
+
+That design works well for an embedded Xray runtime, but it becomes a blocker for:
+
+- supporting multiple cores side by side;
+- selecting a core per profile or per subscription item;
+- routing mixed subscriptions to the correct runtime automatically;
+- introducing a `sing-box` implementation without threading new engine-specific branches through the entire app.
+
+## Goals
+
+- Introduce a stable app-level `CoreEngine` interface.
+- Isolate Xray-specific bindings behind `XrayCoreEngine`.
+- Add a single selection hook for future per-profile core resolution.
+- Keep this PR reviewable by avoiding functional changes.
+- Prepare follow-up work for `sing-box` support on Android.
+
+## Non-goals
+
+- Shipping `sing-box` in this PR.
+- Changing subscription parsing in this PR.
+- Changing current profile storage in this PR.
+- Claiming feature parity between `Xray` and `sing-box` yet.
+
+## Proposed Architecture
+
+### 1. App-facing engine contract
+
+Introduce:
+
+- `CoreType`
+- `CoreCapability`
+- `CoreEventHandler`
+- `AppProcessFinder`
+- `CoreEngine`
+- `CoreEngineFactory`
+
+These types define what the Android app needs from a runtime without exposing `libv2ray` classes to the rest of the service layer.
+
+### 2. Xray adapter
+
+Add `XrayCoreEngine` as the current implementation of `CoreEngine`.
+
+Responsibilities:
+
+- initialize the embedded Xray environment;
+- create and own the `libv2ray.CoreController`;
+- adapt app callbacks to `CoreCallbackHandler`;
+- adapt app process lookup to `libv2ray.ProcessFinder`;
+- provide stats and delay APIs through the common contract.
+
+### 3. Core selection hook
+
+Add `CoreSelector.resolve(profile)` as a central decision point.
+
+Current behavior:
+
+- always returns `CoreType.XRAY`.
+
+Future behavior:
+
+- resolve per-profile, per-subscription, or per-protocol core choice;
+- support automatic fallback and compatibility checks;
+- support mixed subscriptions that require different runtimes.
+
+## Why this shape
+
+This structure keeps the existing runtime stable while creating extension seams in the right places:
+
+- `CoreServiceManager` depends on `CoreEngine`, not `CoreController`.
+- Xray-specific code stays inside the Xray adapter.
+- Future `SingBoxEngine` can be added without rewriting service orchestration again.
+
+## sing-box integration plan
+
+The recommended Android path is:
+
+- keep `Xray` embedded as today;
+- integrate `sing-box` as a dedicated runtime implementation;
+- prefer process or executable isolation for `sing-box` if JNI or Go runtime conflicts appear.
+
+Follow-up phases:
+
+1. Add `SingBoxEngine` bootstrap and runtime lifecycle.
+2. Extend `CoreSelector` with protocol and capability-based resolution.
+3. Add per-profile core preference and automatic selection metadata.
+4. Implement mixed-subscription routing and fallback rules.
+5. Add UI and settings for engine visibility, priority, and failure handling.
+
+## Feature targets for follow-up phases
+
+Expected `sing-box` support areas:
+
+- TUN
+- per-app proxy routing
+- rule sets
+- proxy chains
+- real delay testing
+- DNS module management
+
+These targets should be implemented behind the common engine contract instead of leaking engine-specific branching into UI and service code.
+
+## Review strategy
+
+This PR is intentionally scoped as an architectural pre-step:
+
+- small enough to review safely;
+- no behavior change for current users;
+- unlocks future multi-core work without forcing a one-shot rewrite.
+
+## Open questions
+
+- How should profile metadata persist the selected or resolved core?
+- Should `sing-box` use an embedded library, a dedicated process, or both?
+- Which subscription formats should trigger automatic core resolution in phase two?

--- a/docs/rfcs/multi-core-engine-rfc.md
+++ b/docs/rfcs/multi-core-engine-rfc.md
@@ -93,6 +93,16 @@ The recommended Android path is:
 - integrate `sing-box` as a dedicated runtime implementation;
 - prefer process or executable isolation for `sing-box` if JNI or Go runtime conflicts appear.
 
+### Current scaffold status
+
+The follow-up skeleton adds:
+
+- `SingBoxEngine` as a non-selected runtime implementation;
+- `SingBoxRuntimeLayout` to define stable locations for the future binary, config, and log files;
+- a placeholder process bootstrap path that writes config and prepares the future `sing-box run -c ...` command.
+
+The selector still resolves all profiles to `Xray`, so there is no behavior change for end users yet.
+
 Follow-up phases:
 
 1. Add `SingBoxEngine` bootstrap and runtime lifecycle.


### PR DESCRIPTION
## Summary
- add the Android sing-box runtime bootstrap path, packaged binaries, and HEV bridge wiring needed to start through the existing service chain
- bridge imported AnyTLS and Clash YAML nodes into `[sing-box]` `CUSTOM` profiles backed by raw sing-box runtime JSON
- keep native `VMESS` / `VLESS` / `TROJAN` profiles on the existing Xray path instead of regressing single-core behavior
- fix foreground UI state resync and implement real sing-box line testing through the local mixed inbound
- refresh the RFC so the document matches the branch's current implementation and validation status

## Validation
- sing-box path: scanned/imported `[sing-box]` `CUSTOM` profile starts through `CoreVpnService`
- sing-box path: runtime config is written under `no_backup/core-sing-box/runtime/config.json`
- sing-box path: line test returns a real latency result
- sing-box path: Google is reachable in Chrome after VPN is enabled
- xray path: native `VMESS` node starts with `Xray 26.5.3 started` in logs
- xray path: line test returns a real latency result
- xray path: Google is reachable in Chrome after VPN is enabled

## Notes
- current core selection is explicit: `[sing-box]` `CUSTOM` profiles run on `SingBoxEngine`; native `VMESS` / `VLESS` / `TROJAN` remain on `XrayCoreEngine`
- local-only environment files such as `gradle.properties`, SDK/JDK directories, and `tmp/` artifacts are intentionally excluded from this PR
