### PR TITLE
feat: add custom X-hwid header support for subscription updates

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionItem.kt
@@ -13,5 +13,6 @@ data class SubscriptionItem(
     var filter: String? = null,
     var allowInsecureUrl: Boolean = false,
     var userAgent: String? = null,
+    var hwid: String? = null,
 )
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -530,21 +530,22 @@ object AngConfigManager {
             }
             LogUtil.i(AppConfig.TAG, url)
             val userAgent = it.subscription.userAgent
+            val hwid = it.subscription.hwid
             val proxyUsername = SettingsManager.getSocksUsername()
             val proxyPassword = SettingsManager.getSocksPassword()
 
             var configText = try {
                 val httpPort = SettingsManager.getHttpPort()
-                HttpUtil.getUrlContentWithUserAgent(url, userAgent, 15000, httpPort, proxyUsername, proxyPassword)
+                HttpUtil.getUrlContentWithUserAgent(url, userAgent, hwid, 15000, httpPort, proxyUsername, proxyPassword)
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.ANG_PACKAGE, "Update subscription: proxy not ready or other error", e)
                 ""
             }
             if (configText.isEmpty()) {
                 configText = try {
-                    HttpUtil.getUrlContentWithUserAgent(url, userAgent)
+                    HttpUtil.getUrlContentWithUserAgent(url, userAgent, hwid)
                 } catch (e: Exception) {
-                    LogUtil.e(AppConfig.TAG, "Update subscription: Failed to get URL content with user agent", e)
+                    LogUtil.e(AppConfig.TAG, "Update subscription: Failed to get URL content with user agent / hwid", e)
                     ""
                 }
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -49,6 +49,7 @@ class SubEditActivity : BaseActivity() {
         binding.etRemarks.text = Utils.getEditable(subItem.remarks)
         binding.etUrl.text = Utils.getEditable(subItem.url)
         binding.etUserAgent.text = Utils.getEditable(subItem.userAgent)
+        binding.etHwid.text = Utils.getEditable(subItem.hwid)
         binding.etFilter.text = Utils.getEditable(subItem.filter)
         binding.chkEnable.isChecked = subItem.enabled
         binding.autoUpdateCheck.isChecked = subItem.autoUpdate
@@ -65,6 +66,7 @@ class SubEditActivity : BaseActivity() {
     private fun clearServer(): Boolean {
         binding.etRemarks.text = null
         binding.etUrl.text = null
+        binding.etHwid.text = null
         binding.etFilter.text = null
         binding.chkEnable.isChecked = true
         binding.etUpdateInterval.text = null
@@ -82,6 +84,7 @@ class SubEditActivity : BaseActivity() {
         subItem.remarks = binding.etRemarks.text.toString()
         subItem.url = binding.etUrl.text.toString()
         subItem.userAgent = binding.etUserAgent.text.toString()
+        subItem.hwid = binding.etHwid.text.toString()
         subItem.filter = binding.etFilter.text.toString()
         subItem.enabled = binding.chkEnable.isChecked
         subItem.autoUpdate = binding.autoUpdateCheck.isChecked

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -150,6 +150,7 @@ object HttpUtil {
     fun getUrlContentWithUserAgent(
         url: String?,
         userAgent: String?,
+        hwid: String? = null,
         timeout: Int = 15000,
         httpPort: Int = 0,
         proxyUsername: String? = null,
@@ -172,6 +173,10 @@ object HttpUtil {
                 .get()
                 .header("User-agent", finalUserAgent)
                 .header("Connection", "close")
+
+            if (!hwid.isNullOrBlank()) {
+                requestBuilder.header("X-hwid", hwid)
+            }
 
             applyEmbeddedBasicAuthHeader(currentUrl, requestBuilder)
 

--- a/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
@@ -102,6 +102,25 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:text="@string/sub_setting_x_hwid" />
+
+                <EditText
+                    android:id="@+id/et_hwid"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="text" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="@string/sub_setting_filter" />
 
                 <EditText

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -402,6 +402,7 @@
     <string name="title_webdav_user">Username</string>
     <string name="title_webdav_pass">Password</string>
     <string name="title_webdav_remote_path">Remote directory (optional)</string>
+    <string name="sub_setting_x_hwid" translatable="false">X-hwid</string>
 
     <string-array name="share_method">
         <item>QRcode</item>


### PR DESCRIPTION
### Description
This PR adds the ability to set a custom `X-hwid` HTTP header for each subscription, similar to the existing `User-Agent` functionality.

### Motivation
Subscription providers have started requiring an HWID (Hardware ID) for authentication or to limit the number of active devices. Sending a real device identifier can compromise user privacy and creates unnecessary restrictions.

By allowing a custom `X-hwid` field, users can:
1. Protect their privacy by sending a dummy identifier.
2. Comply with provider requirements without exposing real device data.

### Changes
- **UI**: Added a new text field "X-hwid" in the Subscription Edit/Settings screen.
- **Model**: Added `hwid` property to the `SubscriptionItem` data class.
- **Networking**: Updated `HttpUtil` and `AngConfigManager` to include the `X-hwid` header in HTTP requests when updating subscriptions.
- **Localization**: Added the non-translatable string resource for the new field.

### Screenshot

<details><summary>Dark theme</summary>
<img width="1080" height="2252" alt="Screenshot_20260506_164734" src="https://github.com/user-attachments/assets/8f6934df-05ce-41d8-9954-1df78d924509" />
</details> 

<details><summary>White theme</summary>
<img width="1080" height="2258" alt="Screenshot_20260506_164613" src="https://github.com/user-attachments/assets/97ae163c-c050-4d0c-98e8-79bf27af1913" />
</details> 

Inspired by the discussion in v2rayN: [2dust/v2rayN#9158](https://github.com/2dust/v2rayN/discussions/9158#discussion-9912243)