### PR TITLE
Fix https://github.com/2dust/v2rayNG/issues/5619

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -311,6 +311,16 @@ object AngConfigManager {
     private fun findMatchedProfileKey(keyToProfile: Map<String, ProfileItem>, target: ProfileItem?): String? {
         if (keyToProfile.isEmpty() || target == null) return null
 
+        // Level 0: Full match (remarks + server + port + password)
+        if (target.remarks.isNotBlank()) {
+            keyToProfile.entries.firstOrNull { (_, saved) ->
+                isSameText(saved.remarks, target.remarks) &&
+                        isSameText(saved.server, target.server) &&
+                        isSameText(saved.serverPort, target.serverPort) &&
+                        isSameText(saved.password, target.password)
+            }?.key?.let { return it }
+        }
+
         // Level 1: Match by remarks
         if (target.remarks.isNotBlank()) {
             keyToProfile.entries.firstOrNull { (_, saved) ->


### PR DESCRIPTION
Fixed an issue where the incorrect configuration was selected after a subscription update when the subscription contained two or more different configurations with the same remarks: in findMatchedProfileKey added "Level 0" matching to perform a full check of remarks, server, port, and password before falling back to partial matches. 