### PR TITLE
Added QUIC sniffig option in destOverride to default config

### DIFF
--- a/V2rayNG/app/src/main/assets/v2ray_config.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config.json
@@ -30,7 +30,8 @@
       "enabled": true,
       "destOverride": [
         "http",
-        "tls"
+        "tls",
+		"quic"
       ]
     }
   }

--- a/V2rayNG/app/src/main/assets/v2ray_config_with_tun.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config_with_tun.json
@@ -30,7 +30,8 @@
       "enabled": true,
       "destOverride": [
         "http",
-        "tls"
+        "tls",
+		"quic"
       ]
     }
   },
@@ -46,7 +47,8 @@
       "enabled": true,
       "destOverride": [
         "http",
-        "tls"
+        "tls",
+		"quic"
       ]
     }
   }


### PR DESCRIPTION
Changes in configs allows the system to properly handle QUIC traffic alongside HTTP and TLS