### PR TITLE
Refine subscriptions selection of active server

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -279,11 +279,12 @@ object AngConfigManager {
      * @return Map of generated keys to their corresponding ProfileItem.
      */
     private fun batchSaveConfigs(configs: List<ProfileItem>, subid: String): Map<String, ProfileItem> {
+        var firstProfileKey: String? = null
         val keyToProfile = mutableMapOf<String, ProfileItem>()
 
         // Read serverList once
         val serverList = MmkvManager.decodeServerList(subid)
-        var needSetSelected = MmkvManager.getSelectServer().isNullOrBlank()
+        val needSetSelected = MmkvManager.getSelectServer().isNullOrBlank()
 
         configs.forEach { config ->
             val key = Utils.getUuid()
@@ -292,12 +293,13 @@ object AngConfigManager {
 
             if (!serverList.contains(key)) {
                 serverList.add(0, key)
-                if (needSetSelected) {
-                    MmkvManager.setSelectServer(key)
-                    needSetSelected = false
-                }
             }
             keyToProfile[key] = config
+            firstProfileKey = key
+        }
+
+        if (needSetSelected) {
+            firstProfileKey?.let { MmkvManager.setSelectServer(it) }
         }
 
         // Write serverList once
@@ -414,6 +416,8 @@ object AngConfigManager {
                         MmkvManager.removeServerViaSubid(subid)
                     }
 
+                    val needSetSelected = MmkvManager.getSelectServer().isNullOrBlank()
+                    var firstProfileKey: String? = null
                     val keyToProfile = mutableMapOf<String, ProfileItem>()
 
                     var count = 0
@@ -424,11 +428,18 @@ object AngConfigManager {
                         val key = MmkvManager.encodeServerConfig("", config)
                         MmkvManager.encodeServerRaw(key, JsonUtil.toJsonPretty(srv) ?: "")
                         keyToProfile[key] = config
+                        firstProfileKey = key
                         count += 1
                     }
 
+                    // Restore previous active profile or select the first profile on fresh import
                     val matchKey = findMatchedProfileKey(keyToProfile, activeSubProfile)
-                    matchKey?.let { MmkvManager.setSelectServer(it) }
+                    if (matchKey != null) {
+                        MmkvManager.setSelectServer(matchKey)
+                    } else if (needSetSelected) {
+                        firstProfileKey?.let { MmkvManager.setSelectServer(it) }
+                    }
+
                     return count
                 }
             } catch (e: Exception) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -234,15 +234,10 @@ object AngConfigManager {
             if (servers == null) {
                 return 0
             }
+
             //  Find the currently selected server that matches the subscription ID
-            val removedSelected = if (subid.isNotBlank() && !append) {
-                MmkvManager.getSelectServer()
-                    .takeIf { it?.isNotBlank() == true }
-                    ?.let { MmkvManager.decodeServerConfig(it) }
-                    ?.takeIf { it.subscriptionId == subid }
-            } else {
-                null
-            }
+            val activeSubProfile = if (!append) getActiveSubProfile(subid)
+            else null
 
             val subItem = MmkvManager.decodeSubscription(subid)
 
@@ -264,7 +259,7 @@ object AngConfigManager {
                     MmkvManager.removeServerViaSubid(subid)
                 }
                 val keyToProfile = batchSaveConfigs(configs, subid)
-                val matchKey = findMatchedProfileKey(keyToProfile, removedSelected)
+                val matchKey = findMatchedProfileKey(keyToProfile, activeSubProfile)
                 matchKey?.let { MmkvManager.setSelectServer(it) }
             }
 
@@ -308,6 +303,21 @@ object AngConfigManager {
         // Write serverList once
         MmkvManager.encodeServerList(serverList, subid)
         return keyToProfile
+    }
+
+    /**
+     * Gets the currently selected profile for the specified subscription.
+     *
+     * @param subid The subscription ID.
+     * @return The selected profile if it belongs to the subscription; otherwise null.
+     */
+    private fun getActiveSubProfile(subid: String): ProfileItem? {
+        if (subid.isBlank()) return null
+
+        return MmkvManager.getSelectServer()
+            .takeIf { it?.isNotBlank() == true }
+            ?.let { MmkvManager.decodeServerConfig(it) }
+            ?.takeIf { it.subscriptionId == subid }
     }
 
     /**
@@ -392,6 +402,10 @@ object AngConfigManager {
             && server.contains("routing")
         ) {
             try {
+                //  Find the currently selected server that matches the subscription ID
+                val activeSubProfile = if (!append) getActiveSubProfile(subid)
+                else null
+
                 val serverList: Array<Any> =
                     JsonUtil.fromJson(server, Array<Any>::class.java) ?: arrayOf()
 
@@ -399,6 +413,9 @@ object AngConfigManager {
                     if (!append) {
                         MmkvManager.removeServerViaSubid(subid)
                     }
+
+                    val keyToProfile = mutableMapOf<String, ProfileItem>()
+
                     var count = 0
                     for (srv in serverList.reversed()) {
                         val config = CustomFmt.parse(JsonUtil.toJson(srv)) ?: continue
@@ -406,8 +423,12 @@ object AngConfigManager {
                         config.description = generateDescription(config)
                         val key = MmkvManager.encodeServerConfig("", config)
                         MmkvManager.encodeServerRaw(key, JsonUtil.toJsonPretty(srv) ?: "")
+                        keyToProfile[key] = config
                         count += 1
                     }
+
+                    val matchKey = findMatchedProfileKey(keyToProfile, activeSubProfile)
+                    matchKey?.let { MmkvManager.setSelectServer(it) }
                     return count
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
This PR:
1) Preserves selection of active server config for JSON multiple subscription during update identical to behavior of regular links subscription.
2) Refines selection of active server for both regular links subscription and JSON multiple subscription to choose FIRST server from the list as active if no old server matches in the parsed list during update. Old behavior chooses LAST server as active if non match or on fresh import of subscription.

Built and tested multiple times.