### PR TITLE
Add share log action

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/LogcatActivity.kt
@@ -1,6 +1,8 @@
 package com.v2ray.ang.ui
 
 import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -18,6 +20,11 @@ import com.v2ray.ang.viewmodel.LogcatViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.core.content.FileProvider
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class LogcatActivity : BaseActivity(), SwipeRefreshLayout.OnRefreshListener {
     private val binding by lazy { ActivityLogcatBinding.inflate(layoutInflater) }
@@ -43,6 +50,55 @@ class LogcatActivity : BaseActivity(), SwipeRefreshLayout.OnRefreshListener {
     private fun onLogLongClick(log: String): Boolean {
         Utils.setClipboard(this, log)
         return true
+    }
+
+    private fun shareLogcat() {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val logText = viewModel.getAll().joinToString("\n")
+
+            val result = try {
+                val shareDir = File(cacheDir, "shared_logs").apply {
+                    mkdirs()
+                }
+
+                shareDir.listFiles()?.forEach { it.delete() }
+
+                val timestamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US).format(Date())
+                val logFile = File(shareDir, "v2rayNG_logcat_$timestamp.txt")
+                logFile.writeText(logText, Charsets.UTF_8)
+
+                val uri = FileProvider.getUriForFile(
+                    this@LogcatActivity,
+                    "${packageName}.cache",
+                    logFile
+                )
+
+                uri to logFile.name
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    toast(e.localizedMessage ?: e.toString())
+                }
+                return@launch
+            }
+
+            withContext(Dispatchers.Main) {
+                val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_STREAM, result.first)
+                    putExtra(Intent.EXTRA_SUBJECT, result.second)
+                    putExtra(Intent.EXTRA_TITLE, result.second)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    clipData = ClipData.newUri(contentResolver, result.second, result.first)
+                }
+
+                startActivity(
+                    Intent.createChooser(
+                        shareIntent,
+                        getString(R.string.logcat_share)
+                    )
+                )
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -75,6 +131,11 @@ class LogcatActivity : BaseActivity(), SwipeRefreshLayout.OnRefreshListener {
             val all = viewModel.getAll().joinToString("\n")
             Utils.setClipboard(this, all)
             toastSuccess(R.string.toast_success)
+            true
+        }
+
+        R.id.share_all -> {
+            shareLogcat()
             true
         }
 

--- a/V2rayNG/app/src/main/res/menu/menu_logcat.xml
+++ b/V2rayNG/app/src/main/res/menu/menu_logcat.xml
@@ -17,4 +17,9 @@
         android:icon="@drawable/ic_copy"
         android:title="@string/logcat_copy"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/share_all"
+        android:icon="@drawable/ic_share_24dp"
+        android:title="@string/logcat_share"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -286,6 +286,7 @@
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">نسخ</string>
     <string name="logcat_clear">مسح</string>
+    <string name="logcat_share">مشاركة السجل</string>
     <string name="title_service_restart">إعادة تشغيل الخدمة</string>
     <string name="title_del_all_config">حذف جميع الإعدادات (قبل أول خطوة)</string>
     <string name="title_del_duplicate_config">حذف الإعدادات المكررة (2)</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -286,6 +286,7 @@
     <string name="title_logcat">লগক্যাট</string>
     <string name="logcat_copy">কপি করুন</string>
     <string name="logcat_clear">স্পষ্ট করুন</string>
+    <string name="logcat_share">লগ শেয়ার করুন</string>
     <string name="title_service_restart">সার্ভিস পুনরায় চালু করুন</string>
     <string name="title_del_all_config">সব কনফিগারেশন মুছে ফেলুন</string>
     <string name="title_del_duplicate_config">ডুপ্লিকেট কনফিগারেশন মুছে ফেলুন</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -286,6 +286,7 @@
     <string name="title_logcat">گوزارشا</string>
     <string name="logcat_copy">لف گیری</string>
     <string name="logcat_clear">روفتن</string>
+    <string name="logcat_share">Share log</string>
     <string name="title_service_restart">ره وندن دووارته خدمات</string>
     <string name="title_del_all_config">پاک کردن پوی کانفیگا بونکۊ سکویی</string>
     <string name="title_del_duplicate_config">پاک کردن کانفیگا تکراری بونکۊ سکویی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -283,6 +283,7 @@
     <string name="title_logcat">گزارشات</string>
     <string name="logcat_copy">کپی</string>
     <string name="logcat_clear">پاک کردن</string>
+    <string name="logcat_share">اشتراک‌گذاری گزارش</string>
     <string name="title_service_restart">راه‌اندازی مجدد خدمات</string>
     <string name="title_del_all_config">حذف تمام کانفیگ های گروه فعلی</string>
     <string name="title_del_duplicate_config">حذف کانفیگ های تکراری گروه فعلی</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -291,6 +291,7 @@
     <string name="title_logcat">Журнал</string>
     <string name="logcat_copy">Копировать</string>
     <string name="logcat_clear">Очистить</string>
+    <string name="logcat_share">Поделиться логом</string>
     <string name="title_service_restart">Перезапуск службы</string>
     <string name="title_del_all_config">Удалить профили</string>
     <string name="title_del_duplicate_config">Удалить дубликаты профилей</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -286,6 +286,7 @@
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">Sao chép</string>
     <string name="logcat_clear">Xoá</string>
+    <string name="logcat_share">Chia sẻ nhật ký</string>
     <string name="title_service_restart">Khởi động lại dịch vụ lõi</string>
     <string name="title_del_all_config">Xoá tất cả cấu hình</string>
     <string name="title_del_duplicate_config">Xoá cấu hình trùng lặp</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -286,6 +286,7 @@
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">复制</string>
     <string name="logcat_clear">清除</string>
+    <string name="logcat_share">分享日志</string>
     <string name="title_service_restart">服务重启</string>
     <string name="title_del_all_config">删除配置</string>
     <string name="title_del_duplicate_config">删除重复配置</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -285,6 +285,7 @@
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">複製</string>
     <string name="logcat_clear">清除</string>
+    <string name="logcat_share">分享日誌</string>
     <string name="title_service_restart">重啟服務</string>
     <string name="title_del_all_config">刪除設定</string>
     <string name="title_del_duplicate_config">刪除重複設定</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -293,6 +293,7 @@
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">Copy</string>
     <string name="logcat_clear">Clear</string>
+    <string name="logcat_share">Share log</string>
     <string name="title_service_restart">Service restart</string>
     <string name="title_del_all_config">Delete config</string>
     <string name="title_del_duplicate_config">Delete duplicate config</string>


### PR DESCRIPTION
## Summary

This PR adds a new `Share log` action to the Logcat screen.

The action creates a temporary `.txt` file from the current log output and opens the Android share sheet, so users can save or send logs to other apps.

This is useful when logs need to be shared for troubleshooting or saved for later analysis.

## Changes

- Added a `Share log` menu item to the Logcat screen
- Exported the current log output as a temporary `.txt` file
- Opened the Android share sheet with the generated log file
- Reused the existing FileProvider/cache file sharing mechanism
- Added translations for the new menu item

## Testing

Tested manually on an Android emulator:

- Opened the Logcat screen
- Refreshed log output
- Selected `Share log`
- Confirmed that Android shows the share sheet with one `.txt` file attached
- Confirmed that the generated file contains the current log output

Closes #5666