### PR TITLE
fix: migrate wsSettings host from deprecated headers.Host to independent host field

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreOutboundBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreOutboundBuilder.kt
@@ -410,7 +410,7 @@ object CoreOutboundBuilder {
 
             NetworkType.WS.type -> {
                 val wssetting = OutboundBean.StreamSettingsBean.WsSettingsBean()
-                wssetting.headers.Host = host.orEmpty()
+                wssetting.host = host.orEmpty()
                 sni = host
                 wssetting.path = path ?: "/"
                 streamSettings.wsSettings = wssetting

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -197,13 +197,12 @@ data class V2rayConfig(
 
             data class WsSettingsBean(
                 var path: String? = null,
-                var headers: HeadersBean = HeadersBean(),
+                var host: String? = null,
+                var headers: Map<String, String>? = null,
                 val maxEarlyData: Int? = null,
                 val useBrowserForwarding: Boolean? = null,
                 val acceptProxyProtocol: Boolean? = null
-            ) {
-                data class HeadersBean(var Host: String = "")
-            }
+            )
 
             data class HttpupgradeSettingsBean(
                 var path: String? = null,


### PR DESCRIPTION
Update WsSettings to use independent host field per Xray-core deprecation. wsSettings.headers.Host is deprecated, replaced by wsSettings.host.

- Add independent `host` field to WsSettingsBean
- Replace HeadersBean with Map<String, String>? to match Xray docs
- Update CoreOutboundBuilder to use wssetting.host instead of wssetting.headers.Host