### PR TITLE
Add per-config dynamic shortcuts for external automation (Samsung Modes and Routines)

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -140,6 +140,12 @@
             android:exported="false"
             android:process=":RunSoLibV2RayDaemon"
             android:theme="@style/AppThemeDayNight.NoActionBar.Translucent" />
+        <activity
+            android:name=".ui.ScSelectServerActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:process=":RunSoLibV2RayDaemon"
+            android:theme="@style/AppThemeDayNight.NoActionBar.Translucent" />
 
         <activity
             android:name=".ui.UrlSchemeActivity"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ProfileItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ProfileItem.kt
@@ -69,6 +69,8 @@ data class ProfileItem(
 
     var browserDialerMode: String? = null,
 
+    var shortcutEnabled: Boolean = false,
+
     ) {
     companion object {
         fun create(configType: EConfigType): ProfileItem {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/ConfigShortcutManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/ConfigShortcutManager.kt
@@ -1,0 +1,35 @@
+package com.v2ray.ang.handler
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.v2ray.ang.R
+import com.v2ray.ang.ui.ScSelectServerActivity
+
+object ConfigShortcutManager {
+
+    private const val SHORTCUT_ID_PREFIX = "select_server_"
+
+    fun refresh(context: Context) {
+        val shortcuts = MmkvManager.decodeAllServerList()
+            .mapNotNull { guid ->
+                val profile = MmkvManager.decodeServerConfig(guid) ?: return@mapNotNull null
+                if (!profile.shortcutEnabled) return@mapNotNull null
+                val label = profile.remarks.ifBlank { guid }
+                val intent = Intent(context, ScSelectServerActivity::class.java).apply {
+                    action = Intent.ACTION_VIEW
+                    putExtra(ScSelectServerActivity.EXTRA_GUID, guid)
+                }
+                ShortcutInfoCompat.Builder(context, "$SHORTCUT_ID_PREFIX$guid")
+                    .setShortLabel(label)
+                    .setLongLabel(label)
+                    .setIcon(IconCompat.createWithResource(context, R.drawable.ic_qu_switch_24dp))
+                    .setIntent(intent)
+                    .build()
+            }
+
+        ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/MainActivity.kt
@@ -29,6 +29,7 @@ import com.v2ray.ang.enums.PermissionType
 import com.v2ray.ang.extension.toast
 import com.v2ray.ang.extension.toastError
 import com.v2ray.ang.handler.AngConfigManager
+import com.v2ray.ang.handler.ConfigShortcutManager
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
@@ -204,6 +205,7 @@ class MainActivity : HelperBaseActivity(), NavigationView.OnNavigationItemSelect
 
     override fun onResume() {
         super.onResume()
+        ConfigShortcutManager.refresh(this)
     }
 
     override fun onPause() {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ScSelectServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ScSelectServerActivity.kt
@@ -1,0 +1,27 @@
+package com.v2ray.ang.ui
+
+import android.os.Bundle
+import com.v2ray.ang.R
+import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.handler.MmkvManager
+
+class ScSelectServerActivity : BaseActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        moveTaskToBack(true)
+        setContentView(R.layout.activity_none)
+
+        val guid = intent.getStringExtra(EXTRA_GUID)
+        if (!guid.isNullOrBlank() && MmkvManager.decodeServerConfig(guid) != null) {
+            MmkvManager.setSelectServer(guid)
+            if (CoreServiceManager.isRunning()) {
+                CoreServiceManager.startVService(this, guid)
+            }
+        }
+        finish()
+    }
+
+    companion object {
+        const val EXTRA_GUID = "EXTRA_GUID"
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
@@ -94,6 +94,7 @@ class ServerActivity : BaseActivity() {
     // We don't use AndroidViewBinding because, it is better to share similar logics for different
     // protocols. Use findViewById manually ensures the xml are de-coupled with the activity logic.
     private val et_remarks: EditText by lazy { findViewById(R.id.et_remarks) }
+    private val sw_shortcut_enabled: androidx.appcompat.widget.SwitchCompat by lazy { findViewById(R.id.sw_shortcut_enabled) }
     private val et_address: EditText by lazy { findViewById(R.id.et_address) }
     private val et_port: EditText by lazy { findViewById(R.id.et_port) }
     private val et_id: EditText by lazy { findViewById(R.id.et_id) }
@@ -357,6 +358,7 @@ class ServerActivity : BaseActivity() {
     private fun bindingServer(config: ProfileItem): Boolean {
 
         et_remarks.text = Utils.getEditable(config.remarks)
+        sw_shortcut_enabled.isChecked = config.shortcutEnabled
         et_address.text = Utils.getEditable(config.server.orEmpty())
         et_port.text = Utils.getEditable(config.serverPort ?: DEFAULT_PORT.toString())
         et_id.text = Utils.getEditable(config.password.orEmpty())
@@ -537,6 +539,7 @@ class ServerActivity : BaseActivity() {
 
     private fun saveCommon(config: ProfileItem) {
         config.remarks = et_remarks.text.toString().trim()
+        config.shortcutEnabled = sw_shortcut_enabled.isChecked
         config.server = et_address.text.toString().trim()
         config.serverPort = et_port.text.toString().trim()
         config.password = et_id.text.toString().trim()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerCustomConfigActivity.kt
@@ -53,6 +53,7 @@ class ServerCustomConfigActivity : BaseActivity() {
      */
     private fun bindingServer(config: ProfileItem): Boolean {
         binding.etRemarks.text = Utils.getEditable(config.remarks)
+        binding.swShortcutEnabled.isChecked = config.shortcutEnabled
         val raw = MmkvManager.decodeServerRaw(editGuid)
         val configContent = raw.orEmpty()
 
@@ -89,6 +90,7 @@ class ServerCustomConfigActivity : BaseActivity() {
         binding.etRemarks.text.let {
             config.remarks = if (it.isNullOrEmpty()) profileItem?.remarks.orEmpty() else it.toString()
         }
+        config.shortcutEnabled = binding.swShortcutEnabled.isChecked
         config.server = profileItem?.server
         config.serverPort = profileItem?.serverPort
         config.description = AngConfigManager.generateDescription(config)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerProxyChainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerProxyChainActivity.kt
@@ -78,6 +78,7 @@ class ServerProxyChainActivity : BaseActivity() {
 
     private fun bindingServer(config: ProfileItem): Boolean {
         binding.etRemarks.text = Utils.getEditable(config.remarks)
+        binding.swShortcutEnabled.isChecked = config.shortcutEnabled
         val rows = parseChainMembers(config.proxyChainProfiles)
         memberAdapter.replaceAll(rows)
         if (rows.isEmpty()) {
@@ -119,6 +120,7 @@ class ServerProxyChainActivity : BaseActivity() {
 
         val config = MmkvManager.decodeServerConfig(editGuid) ?: ProfileItem.create(EConfigType.PROXYCHAIN)
         config.remarks = binding.etRemarks.text.toString().trim()
+        config.shortcutEnabled = binding.swShortcutEnabled.isChecked
         config.proxyChainProfiles = chainMembers.joinToString(",")
         config.description = chainMembers.joinToString(" -> ")
 

--- a/V2rayNG/app/src/main/res/layout/activity_server_custom_config.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_server_custom_config.xml
@@ -60,6 +60,26 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/padding_spacing_dp16"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/server_lab_shortcut_enabled" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/sw_shortcut_enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_spacing_dp16"
             android:orientation="vertical">
 
             <TextView

--- a/V2rayNG/app/src/main/res/layout/activity_server_proxy_chain.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_server_proxy_chain.xml
@@ -35,6 +35,27 @@
                     android:layout_marginTop="@dimen/padding_spacing_dp8"
                     android:hint="@string/server_lab_remarks"
                     android:inputType="text" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/padding_spacing_dp16"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/server_lab_shortcut_enabled" />
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/sw_shortcut_enabled"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                </LinearLayout>
+
             </LinearLayout>
 
             <LinearLayout

--- a/V2rayNG/app/src/main/res/layout/layout_address_port.xml
+++ b/V2rayNG/app/src/main/res/layout/layout_address_port.xml
@@ -39,6 +39,26 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/padding_spacing_dp16"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/server_lab_shortcut_enabled" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/sw_shortcut_enabled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/padding_spacing_dp16"
         android:orientation="vertical">
 
         <TextView

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="del_config_comfirm">Confirm delete ?</string>
     <string name="del_invalid_config_comfirm">Please test before deleting! Confirm delete ?</string>
     <string name="server_lab_remarks">remarks</string>
+    <string name="server_lab_shortcut_enabled">Show as shortcut</string>
     <string name="server_lab_address">address</string>
     <string name="server_lab_port">port</string>
     <string name="server_lab_id">id</string>


### PR DESCRIPTION
## Summary

This adds the ability to switch the active server config from outside the app using Android's App Shortcuts API — particularly useful with Samsung's Modes and Routines, but compatible with any launcher or automation tool that supports dynamic shortcuts.

### How it works

- Each server config has a new opt-in toggle: **"Show as shortcut"** in its edit screen
- When enabled, the config appears as a dynamic shortcut on the app's long-press menu
- Tapping the shortcut switches the active config; if the VPN is running, it reconnects immediately with the new config
- Shortcuts are refreshed whenever the user opens the main screen

### Why opt-in per config

Users with many configs would have an unmanageable shortcut list if all were included automatically. Android also enforces a hard cap on dynamic shortcuts. An explicit toggle lets users curate exactly which configs they want accessible externally.

### Changes

- `ProfileItem` — new `shortcutEnabled: Boolean = false` field (defaults off; existing configs unaffected)
- `ConfigShortcutManager` — new singleton that builds/refreshes dynamic shortcuts filtered by `shortcutEnabled`
- `ScSelectServerActivity` — new translucent activity (mirrors the existing `ScStart/Stop` pattern) that selects the config by GUID and restarts the VPN if running
- `layout_address_port.xml`, `activity_server_custom_config.xml`, `activity_server_proxy_chain.xml` — "Show as shortcut" switch added to all config edit screens
- `ServerActivity`, `ServerCustomConfigActivity`, `ServerProxyChainActivity` — bind/save the new toggle
- `MainActivity.onResume` — triggers shortcut refresh

## Test plan

- [ ] Open any config for editing — "Show as shortcut" toggle appears below the remarks field
- [ ] Enable toggle on a config, save, long-press app icon — config appears as a shortcut
- [ ] Tap the shortcut — active config changes (highlighted row in the list updates)
- [ ] With VPN running, tap a shortcut — VPN reconnects with the new config
- [ ] Disable the toggle, open the app — shortcut disappears
- [ ] Works for standard protocol types (VMESS, VLESS, etc.) and custom JSON configs