### PR TITLE
feat: add certificate fetching utility with Android 7.0+ TLS 1.2 support

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -161,6 +161,9 @@ dependencies {
     implementation(libs.mmkv.static)
     implementation(libs.gson)
     implementation(libs.okhttp)
+    
+    // Security Libraries
+    implementation(libs.conscrypt.android)
 
     // Reactive and Utility Libraries
     implementation(libs.kotlinx.coroutines.android)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.DEFAULT_PORT
 import com.v2ray.ang.AppConfig.REALITY
@@ -29,8 +30,10 @@ import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
+import com.v2ray.ang.util.CertificateFetcher
 import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.Utils
+import kotlinx.coroutines.launch
 
 class ServerActivity : BaseActivity() {
 
@@ -143,6 +146,7 @@ class ServerActivity : BaseActivity() {
     private val et_verify_peer_cert_by_name: EditText? by lazy { findViewById(R.id.et_verify_peer_cert_by_name) }
     private val container_verify_peer_cert_by_name: LinearLayout? by lazy { findViewById(R.id.lay_verify_peer_cert_by_name) }
     private val et_pinned_ca256: EditText? by lazy { findViewById(R.id.et_pinned_ca256) }
+    private val btn_fetch_cert: com.google.android.material.button.MaterialButton? by lazy { findViewById(R.id.btn_fetch_cert) }
     private val container_pinned_ca256: LinearLayout? by lazy { findViewById(R.id.lay_pinned_ca256) }
     private val layout_browser_dialer: LinearLayout? by lazy { findViewById(R.id.layout_browser_dialer) }
     private val sp_browser_dialer_mode: Spinner? by lazy { findViewById(R.id.sp_browser_dialer_mode) }
@@ -348,10 +352,93 @@ class ServerActivity : BaseActivity() {
                 // do nothing
             }
         }
+        
+        // Setup fetch certificate button
+        btn_fetch_cert?.setOnClickListener {
+            fetchCertificateFingerprint()
+        }
+        
         if (config != null) {
             bindingServer(config)
         } else {
             clearServer()
+        }
+    }
+
+    /**
+     * Fetch certificate fingerprint from server
+     */
+    private fun fetchCertificateFingerprint() {
+        // Get current stream security setting
+        val streamSecurity = sp_stream_security?.selectedItemPosition ?: return
+        if (streamSecuritys[streamSecurity] != TLS) {
+            toast(R.string.server_lab_stream_security)
+            return
+        }
+
+        // Get domain and port
+        val address = et_address.text.toString().trim()
+        if (address.isEmpty()) {
+            toast(R.string.server_lab_address)
+            return
+        }
+
+        val port = et_port.text.toString().trim()
+        val domain = if (port.isNotEmpty() && Utils.parseInt(port) > 0) {
+            "$address:$port"
+        } else {
+            address
+        }
+
+        // Get SNI (Server Name Indication)
+        var serverName = et_sni?.text?.toString()?.trim()
+        
+        // If SNI is empty, try to get from request host (for specific network types)
+        if (serverName.isNullOrEmpty()) {
+            val network = sp_network?.selectedItemPosition ?: 0
+            when (networks[network]) {
+                NetworkType.WS.type,
+                NetworkType.HTTP_UPGRADE.type,
+                NetworkType.XHTTP.type,
+                NetworkType.H2.type -> {
+                    serverName = et_request_host?.text?.toString()?.trim()
+                }
+            }
+        }
+        
+        // If still empty, use address
+        if (serverName.isNullOrEmpty()) {
+            serverName = address
+        }
+
+        // Get allowInsecure setting
+        val allowInsecureField = sp_allow_insecure?.selectedItemPosition ?: 0
+        val allowInsecure = if (allowinsecures[allowInsecureField].isBlank()) {
+            false
+        } else {
+            allowinsecures[allowInsecureField].toBoolean()
+        }
+
+        // Show loading message
+        toast(R.string.fetching_certificate)
+
+        // Fetch certificate in coroutine
+        lifecycleScope.launch {
+            val result = CertificateFetcher.fetchCertificateFingerprints(
+                domain = domain,
+                serverName = serverName,
+                allowInsecure = allowInsecure
+            )
+
+            if (result.error != null) {
+                toast(getString(R.string.certificate_fetch_error, result.error))
+            } else if (result.fingerprints.isEmpty()) {
+                toast(getString(R.string.certificate_fetch_error, "No certificates found"))
+            } else {
+                val concatenated = CertificateFetcher.concatenateFingerprints(result.fingerprints)
+                et_pinned_ca256?.text = Utils.getEditable(concatenated)
+                toast(R.string.certificate_fetched)
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/CertificateFetcher.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/CertificateFetcher.kt
@@ -1,0 +1,167 @@
+package com.v2ray.ang.util
+
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.ConnectionSpec
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.TlsVersion
+import org.conscrypt.Conscrypt
+import java.security.MessageDigest
+import java.security.Security
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Utility for fetching and validating SSL/TLS certificates from remote servers.
+ * Supports TLS 1.2+ on all Android versions including Android 7.0 via Conscrypt.
+ */
+object CertificateFetcher {
+
+    data class CertificateResult(
+        val fingerprints: List<String>,
+        val error: String? = null
+    )
+
+    /**
+     * Fetches the certificate chain from a domain and returns SHA-256 fingerprints.
+     *
+     * @param domain The domain with optional port (e.g., "example.com" or "example.com:443")
+     * @param serverName The SNI hostname to use (defaults to domain without port)
+     * @param allowInsecure Whether to skip certificate validation
+     * @return CertificateResult containing fingerprints or error message
+     */
+    suspend fun fetchCertificateFingerprints(
+        domain: String,
+        serverName: String? = null,
+        allowInsecure: Boolean = false
+    ): CertificateResult = withContext(Dispatchers.IO) {
+        installConscryptIfNeeded()
+
+        var capturedCertificates: Array<X509Certificate>? = null
+
+        try {
+            val (host, port) = parseDomainAndPort(domain)
+            val sni = serverName?.takeIf { it.isNotBlank() }?.trimEnd('.') ?: host.trimEnd('.')
+
+            val capturingTrustManager = createCapturingTrustManager(allowInsecure) { chain ->
+                capturedCertificates = chain
+            }
+
+            val client = createOkHttpClient(capturingTrustManager, sni, host)
+            val request = Request.Builder().url("https://$host:$port/").build()
+
+            runCatching {
+                client.newCall(request).execute().close()
+            }.onFailure { exception ->
+                if (exception is javax.net.ssl.SSLHandshakeException && capturedCertificates.isNullOrEmpty()) {
+                    return@withContext CertificateResult(
+                        fingerprints = emptyList(),
+                        error = "SSL handshake failed: ${exception.message}"
+                    )
+                }
+            }
+
+            val certificates = capturedCertificates
+            if (certificates.isNullOrEmpty()) {
+                return@withContext CertificateResult(
+                    fingerprints = emptyList(),
+                    error = "Failed to capture certificates from $domain"
+                )
+            }
+
+            CertificateResult(fingerprints = certificates.map { calculateSha256Fingerprint(it) })
+        } catch (e: Exception) {
+            CertificateResult(
+                fingerprints = emptyList(),
+                error = "${e.javaClass.simpleName}: ${e.message}"
+            )
+        }
+    }
+
+    /**
+     * Concatenates multiple fingerprints into a comma-separated string.
+     */
+    fun concatenateFingerprints(fingerprints: List<String>): String =
+        fingerprints.joinToString(",")
+
+    private fun installConscryptIfNeeded() {
+        if (Build.VERSION.SDK_INT in Build.VERSION_CODES.N..Build.VERSION_CODES.N_MR1) {
+            runCatching {
+                Security.insertProviderAt(Conscrypt.newProvider(), 1)
+            }
+        }
+    }
+
+    private fun parseDomainAndPort(domain: String): Pair<String, Int> {
+        val parts = domain.split(":", limit = 2)
+        return if (parts.size == 2) {
+            Pair(parts[0], parts[1].toIntOrNull() ?: 443)
+        } else {
+            Pair(domain, 443)
+        }
+    }
+
+    private fun createCapturingTrustManager(
+        allowInsecure: Boolean,
+        onCertificatesCaptured: (Array<X509Certificate>) -> Unit
+    ): X509TrustManager {
+        val defaultTrustManager = runCatching { createDefaultTrustManager() }.getOrNull()
+
+        return object : X509TrustManager {
+            override fun checkClientTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                if (!allowInsecure) {
+                    defaultTrustManager?.checkClientTrusted(chain, authType)
+                }
+            }
+
+            override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?) {
+                chain?.let { onCertificatesCaptured(it.map { cert -> cert as X509Certificate }.toTypedArray()) }
+                if (!allowInsecure) {
+                    defaultTrustManager?.checkServerTrusted(chain, authType)
+                }
+            }
+
+            override fun getAcceptedIssuers(): Array<X509Certificate> =
+                defaultTrustManager?.acceptedIssuers ?: emptyArray()
+        }
+    }
+
+    private fun createDefaultTrustManager(): X509TrustManager {
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        trustManagerFactory.init(null as java.security.KeyStore?)
+        return trustManagerFactory.trustManagers
+            .firstOrNull { it is X509TrustManager } as? X509TrustManager
+            ?: throw IllegalStateException("No X509TrustManager found")
+    }
+
+    private fun createOkHttpClient(
+        trustManager: X509TrustManager,
+        sni: String,
+        host: String
+    ): OkHttpClient {
+        val sslContext = SSLContext.getInstance("TLS", Conscrypt.newProvider())
+        sslContext.init(null, arrayOf(trustManager), null)
+
+        val connectionSpec = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
+            .build()
+
+        return OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .connectionSpecs(listOf(connectionSpec, ConnectionSpec.COMPATIBLE_TLS))
+            .hostnameVerifier { hostname, _ -> hostname == sni || hostname == host }
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build()
+    }
+
+    private fun calculateSha256Fingerprint(cert: X509Certificate): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(cert.encoded)
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/CertificateFetcher.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/CertificateFetcher.kt
@@ -53,7 +53,12 @@ object CertificateFetcher {
             }
 
             val client = createOkHttpClient(capturingTrustManager, sni, host)
-            val request = Request.Builder().url("https://$host:$port/").build()
+            val url = okhttp3.HttpUrl.Builder()
+                .scheme("https")
+                .host(host)
+                .port(port)
+                .build()
+            val request = Request.Builder().url(url).build()
 
             runCatching {
                 client.newCall(request).execute().close()

--- a/V2rayNG/app/src/main/res/layout/layout_tls.xml
+++ b/V2rayNG/app/src/main/res/layout/layout_tls.xml
@@ -171,12 +171,28 @@
             android:layout_height="wrap_content"
             android:text="@string/server_lab_pinned_ca256" />
 
-        <EditText
-            android:id="@+id/et_pinned_ca256"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="text"
-            android:nextFocusDown="@+id/et_public_key" />
+            android:orientation="horizontal">
+
+            <EditText
+                android:id="@+id/et_pinned_ca256"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:inputType="text"
+                android:nextFocusDown="@+id/et_public_key" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_fetch_cert"
+                style="@style/Widget.Material3.Button.IconButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:contentDescription="@string/fetch_certificate"
+                android:text="@string/fetch_certificate_short" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/V2rayNG/app/src/main/res/layout/layout_tls_hysteria2.xml
+++ b/V2rayNG/app/src/main/res/layout/layout_tls_hysteria2.xml
@@ -82,11 +82,27 @@
                 android:layout_height="wrap_content"
                 android:text="@string/server_lab_pinned_ca256" />
 
-            <EditText
-                android:id="@+id/et_pinned_ca256"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:inputType="text" />
+                android:orientation="horizontal">
+
+                <EditText
+                    android:id="@+id/et_pinned_ca256"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:inputType="text" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btn_fetch_cert"
+                    style="@style/Widget.Material3.Button.IconButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/fetch_certificate"
+                    android:text="@string/fetch_certificate_short" />
+
+            </LinearLayout>
 
         </LinearLayout>
     </LinearLayout>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -120,6 +120,11 @@
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="fetch_certificate">Fetch Certificate</string>
+    <string name="fetch_certificate_short">Fetch</string>
+    <string name="fetching_certificate">Fetching certificate...</string>
+    <string name="certificate_fetched">Certificate fetched successfully</string>
+    <string name="certificate_fetch_error">Error fetching certificate: %s</string>
     <string name="server_lab_browser_dialer">Enable Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">Only supports xhttp (packet-up) and ws outbound; TLS-related settings may be ignored or conflict</string>
     <string name="toast_allow_insecure_deprecated">WARNING: Skipping certificate verification "allowInsecure" will be disabled in August 2026. Please use certificate fingerprints as soon as possible. This feature will not be available after its expiration.</string>

--- a/V2rayNG/gradle/libs.versions.toml
+++ b/V2rayNG/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "9.2.1"
+conscrypt = "2.5.2"
 desugarJdkLibs = "2.1.5"
 gradleLicensePlugin = "0.9.8"
 kotlin = "2.3.21"
@@ -33,6 +34,7 @@ fragment = "1.8.9"
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
+conscrypt-android = { module = "org.conscrypt:conscrypt-android", version.ref = "conscrypt" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 gradle-license-plugin = { module = "com.jaredsburrows:gradle-license-plugin", version.ref = "gradleLicensePlugin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
Add CertificateFetcher utility to fetch SSL/TLS certificates from remote servers and generate SHA-256 fingerprints for certificate pinning.

Key features:
- Fetch certificate chains from domains with optional port specification
- Generate SHA-256 fingerprints for certificate pinning
- Support custom SNI (Server Name Indication) configuration
- Optional insecure mode for testing/development
- Proper TLS 1.2+ support on Android 7.0-7.1 via Conscrypt
- Material3 button integration in TLS configuration UI

Technical implementation:
- Uses OkHttp with Conscrypt security provider for modern TLS support
- Implements custom X509TrustManager to capture certificates during handshake
- Supports TLS 1.2 and 1.3 with appropriate connection specs
- Coroutine-based async execution on IO dispatcher

Dependencies added:
- org.conscrypt:conscrypt-android:2.5.2