### PR TITLE
Add hysteria2 quic keepalive and idle timeout profile fields

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreOutboundBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreOutboundBuilder.kt
@@ -472,6 +472,8 @@ object CoreOutboundBuilder {
                     brutalDown = profileItem.bandwidthDown?.nullIfBlank(),
                 )
                 quicParams.congestion = if (quicParams.brutalUp != null || quicParams.brutalDown != null) "brutal" else null
+                quicParams.keepAlivePeriod = profileItem.keepAlivePeriod?.toIntOrNull()?.coerceIn(2, 60)
+                quicParams.maxIdleTimeout = profileItem.maxIdleTimeout?.toIntOrNull()?.coerceIn(4, 120)
                 if (profileItem.portHopping.isNotNullEmpty()) {
                     val rawInterval = profileItem.portHoppingInterval?.trim().nullIfBlank()
                     val interval = if (rawInterval == null) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -321,6 +321,8 @@ data class V2rayConfig(
                     var brutalUp: String? = null,
                     var brutalDown: String? = null,
                     var udpHop: UdpHopBean? = null,
+                    @SerializedName("keepAlivePeriod") var keepAlivePeriod: Int? = null,
+                    @SerializedName("maxIdleTimeout") var maxIdleTimeout: Int? = null,
                 ) {
                     // Nested data class for the udpHop JSON object
                     data class UdpHopBean(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ProfileItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ProfileItem.kt
@@ -59,6 +59,8 @@ data class ProfileItem(
     var obfsPassword: String? = null,
     var portHopping: String? = null,
     var portHoppingInterval: String? = null,
+    var keepAlivePeriod: String? = null,
+    var maxIdleTimeout: String? = null,
     var pinSHA256: String? = null,
     var bandwidthDown: String? = null,
     var bandwidthUp: String? = null,
@@ -124,6 +126,8 @@ data class ProfileItem(
                 && this.obfsPassword == obj.obfsPassword
                 && this.portHopping == obj.portHopping
                 && this.portHoppingInterval == obj.portHoppingInterval
+                && this.keepAlivePeriod == obj.keepAlivePeriod
+                && this.maxIdleTimeout == obj.maxIdleTimeout
                 && this.pinnedCA256 == obj.pinnedCA256
                 && this.proxyChainProfiles == obj.proxyChainProfiles
                 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/Hysteria2Fmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/Hysteria2Fmt.kt
@@ -41,6 +41,8 @@ object Hysteria2Fmt : FmtBase() {
                 config.portHoppingInterval = queryParam["mportHopInt"]
             }
             config.pinnedCA256 = queryParam["pinSHA256"]
+            config.keepAlivePeriod = queryParam["keepalive"]
+            config.maxIdleTimeout = queryParam["idle"]
 
         }
 
@@ -104,6 +106,8 @@ object Hysteria2Fmt : FmtBase() {
         if (config.pinnedCA256.isNotNullEmpty()) {
             dicQuery["pinSHA256"] = config.pinnedCA256.orEmpty()
         }
+        config.keepAlivePeriod?.nullIfBlank()?.let { dicQuery["keepalive"] = it }
+        config.maxIdleTimeout?.nullIfBlank()?.let { dicQuery["idle"] = it }
 
         return toUri(config, config.password, dicQuery)
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
@@ -128,6 +128,8 @@ class ServerActivity : BaseActivity() {
     private val et_local_address: EditText? by lazy { findViewById(R.id.et_local_address) }
     private val et_local_mtu: EditText? by lazy { findViewById(R.id.et_local_mtu) }
     private val et_obfs_password: EditText? by lazy { findViewById(R.id.et_obfs_password) }
+    private val et_keepalive: EditText? by lazy { findViewById(R.id.et_keepalive) }
+    private val et_idle: EditText? by lazy { findViewById(R.id.et_idle) }
     private val et_port_hop: EditText? by lazy { findViewById(R.id.et_port_hop) }
     private val et_port_hop_interval: EditText? by lazy { findViewById(R.id.et_port_hop_interval) }
     private val et_bandwidth_down: EditText? by lazy { findViewById(R.id.et_bandwidth_down) }
@@ -389,6 +391,8 @@ class ServerActivity : BaseActivity() {
             et_port_hop_interval?.text = Utils.getEditable(config.portHoppingInterval)
             et_bandwidth_down?.text = Utils.getEditable(config.bandwidthDown)
             et_bandwidth_up?.text = Utils.getEditable(config.bandwidthUp)
+            et_keepalive?.text = Utils.getEditable(config.keepAlivePeriod)
+            et_idle?.text = Utils.getEditable(config.maxIdleTimeout)
         }
         val securityEncryptions =
             if (config.configType == EConfigType.SHADOWSOCKS) shadowsocksSecuritys else securitys
@@ -571,6 +575,8 @@ class ServerActivity : BaseActivity() {
             config.portHoppingInterval = et_port_hop_interval?.text?.toString()?.trim()
             config.bandwidthDown = et_bandwidth_down?.text?.toString()
             config.bandwidthUp = et_bandwidth_up?.text?.toString()
+            config.keepAlivePeriod = et_keepalive?.text?.toString()?.trim()?.nullIfBlank()
+            config.maxIdleTimeout = et_idle?.text?.toString()?.trim()?.nullIfBlank()
         }
     }
 

--- a/V2rayNG/app/src/main/res/layout/activity_server_hysteria2.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_server_hysteria2.xml
@@ -127,6 +127,44 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_spacing_dp16"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/server_lab_keepalive" />
+
+            <EditText
+                android:id="@+id/et_keepalive"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_spacing_dp16"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/server_lab_idle" />
+
+            <EditText
+                android:id="@+id/et_idle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number" />
+
+        </LinearLayout>
+
         <include layout="@layout/layout_tls_hysteria2" />
 
         <LinearLayout

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -113,6 +113,8 @@
     <string name="server_lab_port_hop_interval">Интервал смены портов</string>
     <string name="server_lab_bandwidth_down">Входящая пропускная способность (допускаются: k/m/g/t)</string>
     <string name="server_lab_bandwidth_up">Исходящая пропускная способность (допускаются: k/m/g/t)</string>
+    <string name="server_lab_keepalive">QUIC keepAlivePeriod, секунды (2–60)</string>
+    <string name="server_lab_idle">QUIC idleTimeout, секунды (4–120)</string>
     <string name="server_lab_xhttp_mode">Режим XHTTP</string>
     <string name="server_lab_xhttp_extra">Необработанный JSON XHTTP Extra, формат: { XHTTPObject }</string>
     <string name="server_lab_final_mask">Необработанный JSON FinalMask, формат: { FinalMaskObject }</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -114,6 +114,8 @@
     <string name="server_lab_port_hop_interval">Port Hopping Interval</string>
     <string name="server_lab_bandwidth_down">Bandwidth down (Supported units: k/m/g/t)</string>
     <string name="server_lab_bandwidth_up">Bandwidth up (Supported units: k/m/g/t)</string>
+    <string name="server_lab_keepalive">QUIC keepAlivePeriod in seconds (2-60)</string>
+    <string name="server_lab_idle">QUIC idleTimeout in seconds (4-120)</string>
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>


### PR DESCRIPTION
## Why
After idle or sleep on Android, Hysteria2 reconnects slowly. xray defaults to 30s maxIdleTimeout with keepalive off.

## What
- Two optional fields on the Hysteria2 server screen
- Values go to finalmask.quicParams; clamped at build time (2-60 / 4-120)
- Share links: ?keepalive=3&idle=5

## Test
- [ ] assembleDebug
- [ ] profile with keepAlivePeriod=3 and maxIdleTimeout=5 survives save/reopen
- [ ] xray export shows quicParams entries; obfs/udpHop/brutal still there
- [ ] import ?keepalive=3&idle=5 fills the fields
- [ ] import idle=999 -> 120 in config, core starts