### PR TITLE
Add Fragment Packet 1-1 option to Fragment settings UI

### DIFF
--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -64,6 +64,7 @@
 
     <string-array name="fragment_packets" translatable="false">
         <item>tlshello</item>
+        <item>1-1</item>
         <item>1-2</item>
         <item>1-3</item>
         <item>1-5</item>


### PR DESCRIPTION
## Summary

Xray-core already supports the `Fragment Packet 1-1` mode, but this option is currently not exposed in the v2rayNG UI.

As a result, users who want to use this fragment type must manually create or edit a full JSON configuration instead of being able to select it directly from the application's Fragment settings.

This PR adds the `Fragment Packet 1-1` option to the Fragment UI, making the feature accessible through the normal application workflow.

## Motivation

`Fragment Packet 1-1` is a useful fragmentation mode for some users, particularly in Iran where fragmentation techniques are commonly used to improve connectivity and bypass network restrictions.

Since the underlying Xray core already supports this mode, exposing it in the UI improves usability and allows users to take advantage of the feature without manually editing configuration files.

## Changes

* Added `Fragment Packet 1-1` to the Fragment settings UI.
* No core functionality changes.
* No behavior changes for existing configurations.

This PR only exposes an already-supported Xray feature through the UI for easier access.
