### PR TITLE
Remove forced fragment packet override for TLS

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreOutboundBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreOutboundBuilder.kt
@@ -612,10 +612,6 @@ object CoreOutboundBuilder {
                 && packets == "tlshello"
             ) {
                 packets = "1-3"
-            } else if (streamSettings.security == AppConfig.TLS
-                && packets != "tlshello"
-            ) {
-                packets = "tlshello"
             }
 
             val fragmentMask = OutboundBean.StreamSettingsBean.FinalMaskBean.MaskBean(


### PR DESCRIPTION
## Summary

This PR removes the automatic override that forces the fragment packet type to `tlshello` when TLS is used.

Previously, if a user selected any packet type other than `tlshello`, the application would automatically replace it with `tlshello` whenever the transport security was set to TLS.

## Problem

The current logic prevents users from using other fragment packet types with TLS, even when those modes are supported by the underlying Xray core.

As a result, the packet type selected by the user in the UI is silently ignored and replaced during configuration generation.

## Changes

* Removed the TLS-specific packet override logic.
* Preserved the existing Reality-specific fallback behavior.
* User-selected fragment packet types are now respected and passed to Xray without modification.

## Motivation

The application UI allows users to choose a fragment packet type, so the selected value should be honored whenever possible instead of being automatically rewritten.

This change improves consistency between the UI and the generated configuration while allowing users to take advantage of packet modes already supported by Xray.
