### PR TITLE
Use 'restore' icon instead of 'delete' for "Restart Service" notification

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -105,7 +105,7 @@ object NotificationManager {
                 stopV2RayPendingIntent
             )
             .addAction(
-                R.drawable.ic_delete_24dp,
+                R.drawable.ic_restore_24dp,
                 service.getString(R.string.title_service_restart),
                 restartV2RayPendingIntent
             )


### PR DESCRIPTION
I believe it's not used (are these icons even shown anywhere?) but the intent was to use restore icon all along?