### PR TITLE
fix(group): ignore invalid latency for lowest-latency policy

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigContextBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigContextBuilder.kt
@@ -139,18 +139,17 @@ object CoreConfigContextBuilder {
     private fun resolvePolicyGroupProfiles(config: ProfileItem): List<ProfileItem> {
         try {
             val serverList = MmkvManager.decodeAllServerList()
-            return serverList
+
+            val matchedProfiles = serverList
                 .asSequence()
-                .mapNotNull { id -> MmkvManager.decodeServerConfig(id) }
-                .filter { profile ->
-                    val subscriptionId = config.policyGroupSubscriptionId
-                    if (subscriptionId.isNullOrBlank()) {
-                        true
-                    } else {
-                        profile.subscriptionId == subscriptionId
-                    }
+                .mapNotNull { id ->
+                    MmkvManager.decodeServerConfig(id)?.let { profile -> id to profile }
                 }
-                .filter { profile ->
+                .filter { (_, profile) ->
+                    val subscriptionId = config.policyGroupSubscriptionId
+                    subscriptionId.isNullOrBlank() || profile.subscriptionId == subscriptionId
+                }
+                .filter { (_, profile) ->
                     val filter = config.policyGroupFilter
                     if (filter.isNullOrBlank()) {
                         true
@@ -162,14 +161,22 @@ object CoreConfigContextBuilder {
                         }
                     }
                 }
-                .filter { it.server.isNotNullEmpty() }
-                .filter { Utils.isPureIpAddress(it.server!!) || Utils.isValidUrl(it.server!!) }
-                .filter { !it.configType.isComplexType() }
+                .filter { (_, profile) -> profile.server.isNotNullEmpty() }
+                .filter { (_, profile) -> Utils.isPureIpAddress(profile.server!!) || Utils.isValidUrl(profile.server!!) }
+                .filter { (_, profile) -> !profile.configType.isComplexType() }
                 .toList()
+
+            return PolicyGroupLatencyFilter.filterForLowestLatency(
+                items = matchedProfiles,
+                policyGroupType = config.policyGroupType,
+            ) { (id, _) ->
+                MmkvManager.decodeServerAffiliationInfo(id)?.testDelayMillis
+            }.map { (_, profile) -> profile }
         } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "Failed to resolve policy group profiles for '${config.remarks}'", e)
-            return listOf(config)
+            Logs.e(e)
         }
+
+        return emptyList()
     }
 
     private fun resolveProxyChainProfiles(config: ProfileItem): List<ProfileItem> {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyGroupLatencyFilter.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyGroupLatencyFilter.kt
@@ -1,0 +1,61 @@
+package com.v2ray.ang.core
+
+/**
+ * Filters invalid latency values before building lowest-latency policy groups.
+ *
+ * Some failed delay tests are stored as negative values, such as -1ms. Without
+ * filtering, these values can be treated as better than valid latency values.
+ */
+object PolicyGroupLatencyFilter {
+    private val lowestLatencyPolicies = setOf(
+        "latency",
+        "lowestlatency",
+        "lowestping",
+        "leastlatency",
+        "leastdelay",
+        "leastping",
+        "urltest",
+        "leastload",
+    )
+
+    fun isLowestLatencyPolicy(policyGroupType: String?): Boolean {
+        val normalized = policyGroupType
+            .orEmpty()
+            .lowercase()
+            .replace("_", "")
+            .replace("-", "")
+            .replace(" ", "")
+
+        return normalized in lowestLatencyPolicies
+    }
+
+    fun isValidMeasuredDelay(delayMillis: Long?): Boolean {
+        return delayMillis != null && delayMillis > 0L
+    }
+
+    fun isNotDeadDelay(delayMillis: Long?): Boolean {
+        return delayMillis == null || delayMillis >= 0L
+    }
+
+    fun <T> filterForLowestLatency(
+        items: List<T>,
+        policyGroupType: String?,
+        delayOf: (T) -> Long?,
+    ): List<T> {
+        if (!isLowestLatencyPolicy(policyGroupType)) {
+            return items
+        }
+
+        val measured = items.filter { isValidMeasuredDelay(delayOf(it)) }
+        if (measured.isNotEmpty()) {
+            return measured
+        }
+
+        val notDead = items.filter { isNotDeadDelay(delayOf(it)) }
+        if (notDead.isNotEmpty()) {
+            return notDead
+        }
+
+        return items
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyGroupLatencyFilterTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyGroupLatencyFilterTest.kt
@@ -1,0 +1,67 @@
+package com.v2ray.ang.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolicyGroupLatencyFilterTest {
+    private data class Node(
+        val name: String,
+        val delayMillis: Long?,
+    )
+
+    @Test
+    fun filtersDeadNodesWhenValidMeasuredDelayExists() {
+        val nodes = listOf(
+            Node("dead", -1L),
+            Node("fast", 120L),
+            Node("slow", 320L),
+        )
+
+        val filtered = PolicyGroupLatencyFilter.filterForLowestLatency(
+            items = nodes,
+            policyGroupType = "leastPing",
+        ) { it.delayMillis }
+
+        assertEquals(listOf("fast", "slow"), filtered.map { it.name })
+    }
+
+    @Test
+    fun keepsUnmeasuredNodesWhenNoMeasuredDelayExists() {
+        val nodes = listOf(
+            Node("dead", -1L),
+            Node("unmeasured", 0L),
+        )
+
+        val filtered = PolicyGroupLatencyFilter.filterForLowestLatency(
+            items = nodes,
+            policyGroupType = "lowest_latency",
+        ) { it.delayMillis }
+
+        assertEquals(listOf("unmeasured"), filtered.map { it.name })
+    }
+
+    @Test
+    fun doesNotChangeNonLowestLatencyPolicies() {
+        val nodes = listOf(
+            Node("dead", -1L),
+            Node("normal", 150L),
+        )
+
+        val filtered = PolicyGroupLatencyFilter.filterForLowestLatency(
+            items = nodes,
+            policyGroupType = "random",
+        ) { it.delayMillis }
+
+        assertEquals(nodes, filtered)
+    }
+
+    @Test
+    fun recognizesLowestLatencyPolicyNames() {
+        assertTrue(PolicyGroupLatencyFilter.isLowestLatencyPolicy("leastPing"))
+        assertTrue(PolicyGroupLatencyFilter.isLowestLatencyPolicy("lowest_latency"))
+        assertTrue(PolicyGroupLatencyFilter.isLowestLatencyPolicy("url-test"))
+        assertFalse(PolicyGroupLatencyFilter.isLowestLatencyPolicy("random"))
+    }
+}


### PR DESCRIPTION
Refs #5817

## Summary
- Ignore invalid negative latency values when resolving lowest-latency policy groups.
- Prevent dead servers with values such as `-1ms` from being selected as the best candidate.
- Keep non-lowest-latency policies unchanged.
- Add unit coverage for invalid latency filtering.

## Behavior
When a lowest-latency policy group has valid measured nodes, only nodes with positive latency are considered.

If there are no positive measured values, unmeasured nodes are kept while dead negative-latency nodes are excluded where possible.

If every candidate is negative, the original list is preserved to avoid generating an empty policy group.

## Test
- Not completed locally: Android/Gradle test environment was not available or failed locally.
