### PR TITLE
Add GPG verification file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -119,11 +122,34 @@ jobs:
         name: x86-apk
         path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/*/release/*x86*.apk
 
-    - name: Upload to release
-      uses: svenstaro/upload-release-action@v2
-      if: github.event.inputs.release_tag != ''
-      with:
-        file: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/*/release/*.apk
-        tag: ${{ github.event.inputs.release_tag }}
-        file_glob: true
-        prerelease: true
+  sign-and-release:
+    needs: build
+    runs-on: ubuntu-26.04
+    if: github.event_name == 'workflow_dispatch' && inputs.release_tag != ''
+
+    steps:
+      - name: Download APK artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: release
+
+      - name: Sign APK files
+        run: |
+          printf '%s' "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          KEY=$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')
+          mkdir -p release-files
+
+          find release -type f -name '*.apk' | while read apk; do
+            cp "$apk" release-files/
+            gpg --batch --yes --local-user "$KEY" --detach-sign --output "release-files/$(basename "$apk").sig" "$apk"
+          done
+
+          gpg --armor --export "$KEY" > release-files/v2rayNG-public-key.asc
+
+      - name: Upload APKs, signatures and public key to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: release-files/*
+          tag: ${{ inputs.release_tag }}
+          file_glob: true
+          prerelease: true


### PR DESCRIPTION
Google推行开发者认证计划，v2rayNG陆续有手机需要使用ADB安装，其他系统连手机执行adb install不能很好的确认文件来源，因此PR添加GPG验证文件

步骤：
> ### 内容
> 
> 此 PR 增加 GPG 签名文件，方便用户识别下载文件来源，预防镜像站、运营商、CDN劫持。 用户可使用 gpg --verify 命令校验文件
> 
> 效果如下： <img alt="2026-06-22 05 57 19" width="774" height="635" src="https://private-user-images.githubusercontent.com/221184582/610912865-5013feac-48cb-45c3-b9e7-bc9ffd404aaa.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODI0Mzk1NjEsIm5iZiI6MTc4MjQzOTI2MSwicGF0aCI6Ii8yMjExODQ1ODIvNjEwOTEyODY1LTUwMTNmZWFjLTQ4Y2ItNDVjMy1iOWU3LWJjOWZmZDQwNGFhYS5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwNjI2JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDYyNlQwMjAxMDFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0zMGRiNGIwNTM5YTBmMzRhMjE3NjNlOTM4YTQxZDE0NWJlMzQ5NjkwZDIwZWEwZWJjOTQ2NWZjNTlhZTY5NzllJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZyZXNwb25zZS1jb250ZW50LXR5cGU9aW1hZ2UlMkZwbmcifQ.bLJ0RXtbIE_AJ8AHLSATzAEfqVjzwoVeqiNl-1NIxzY">
> ### 合并前注意
> 
> 请在 Github Secret 上添加 GPG_PRIVATE_KEY 名称：GPG_PRIVATE_KEY 字段：生成的私钥(private.asc的完整内容)
> 
> 本PR不用Passphrase，运行gpg --quick-gen-key命令后弹出设置私钥密码选项直接为空即可，在Github Secret加上Passphrase意义不大，可能还会泄露日常信息，请考虑在Readme上公布指纹 ~在 GitHub Actions 自动签名场景下，私钥和 Passphrase 往往同时存在于 CI 环境，Passphrase在CI场景中意义有限~
> 
> 生成并查看私钥命令（Linux为例）
> 
> ```shell
> gpg --quick-gen-key "2dust <2dust-noreply@github.com>" ed448 sign 20y
> 
> gpg --armor --export-secret-keys "2dust <2dust-noreply@github.com>" > private.asc
> 
> cat private.asc
> ```
> 
> 查看指纹（Linux为例）
> 
> ```shell
> gpg --fingerprint "2dust <2dust-noreply@github.com>"
> ```
> 
> 私钥格式：
> 
> ```
> -----BEGIN PGP PRIVATE KEY BLOCK-----
> 
> XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
> XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
> 
> -----END PGP PRIVATE KEY BLOCK-----
> ```

