### PR TITLE
Add custom HTTP headers for subscription updates

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/UrlContentRequest.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/UrlContentRequest.kt
@@ -6,5 +6,6 @@ data class UrlContentRequest(
     val httpPort: Int = 0,
     val proxyUsername: String? = null,
     val proxyPassword: String? = null,
-    val userAgent: String? = null
+    val userAgent: String? = null,
+    val requestHeaders: String? = null
 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/SubscriptionItem.kt
@@ -13,5 +13,6 @@ data class SubscriptionItem(
     var filter: String? = null,
     var allowInsecureUrl: Boolean = false,
     var userAgent: String? = null,
+    var requestHeaders: String? = null,
 )
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -550,6 +550,7 @@ object AngConfigManager {
             }
             LogUtil.i(AppConfig.TAG, url)
             val userAgent = it.subscription.userAgent
+            val requestHeaders = it.subscription.requestHeaders
             val proxyUsername = SettingsManager.getSocksUsername()
             val proxyPassword = SettingsManager.getSocksPassword()
 
@@ -559,6 +560,7 @@ object AngConfigManager {
                     UrlContentRequest(
                         url = url,
                         userAgent = userAgent,
+                        requestHeaders = requestHeaders,
                         timeout = 15000,
                         httpPort = httpPort,
                         proxyUsername = proxyUsername,
@@ -574,7 +576,8 @@ object AngConfigManager {
                     HttpUtil.getUrlContentWithUserAgent(
                         UrlContentRequest(
                             url = url,
-                            userAgent = userAgent
+                            userAgent = userAgent,
+                            requestHeaders = requestHeaders
                         )
                     )
                 } catch (e: Exception) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SubEditActivity.kt
@@ -21,6 +21,10 @@ import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.util.Utils
+import com.v2ray.ang.util.JsonUtil
+import android.util.JsonReader
+import android.util.JsonToken
+import java.io.StringReader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
@@ -54,6 +58,7 @@ class SubEditActivity : BaseActivity() {
         binding.etRemarks.text = Utils.getEditable(subItem.remarks)
         binding.etUrl.text = Utils.getEditable(subItem.url)
         binding.etUserAgent.text = Utils.getEditable(subItem.userAgent)
+        binding.etRequestHeaders.setText(subItem.requestHeaders)
         binding.etFilter.text = Utils.getEditable(subItem.filter)
         binding.chkEnable.isChecked = subItem.enabled
         binding.autoUpdateCheck.isChecked = subItem.autoUpdate
@@ -75,6 +80,8 @@ class SubEditActivity : BaseActivity() {
         binding.etUpdateInterval.text = null
         binding.etPreProfile.text = null
         binding.etNextProfile.text = null
+        binding.etRequestHeaders.setText(null)
+        binding.etRequestHeaders.error = null
         return true
     }
 
@@ -106,6 +113,51 @@ class SubEditActivity : BaseActivity() {
         }
         input.setOnClickListener {
             input.showDropDown()
+        }
+    }
+
+    /**
+     * validate custom request headers JSON
+     */
+    private fun isValidRequestHeadersJson(headersJson: String): Boolean {
+        return try {
+            JsonReader(StringReader(headersJson)).use { reader ->
+                reader.isLenient = false
+
+                reader.beginObject()
+
+                while (reader.hasNext()) {
+                    val name = reader.nextName().trim()
+
+                    if (name.isBlank()) {
+                        return false
+                    }
+
+                    if (name.contains(":") || name.any { it.code <= 32 || it.code >= 127 }) {
+                        return false
+                    }
+
+                    if (reader.peek() != JsonToken.STRING) {
+                        return false
+                    }
+
+                    val value = reader.nextString()
+
+                    if (value.isBlank()) {
+                        return false
+                    }
+
+                    if (value.contains('\r') || value.contains('\n')) {
+                        return false
+                    }
+                }
+
+                reader.endObject()
+
+                reader.peek() == JsonToken.END_DOCUMENT
+            }
+        } catch (_: Exception) {
+            false
         }
     }
 
@@ -145,6 +197,20 @@ class SubEditActivity : BaseActivity() {
         subItem.prevProfile = binding.etPreProfile.text.toString()
         subItem.nextProfile = binding.etNextProfile.text.toString()
         subItem.allowInsecureUrl = binding.allowInsecureUrl.isChecked
+
+        val requestHeaders = binding.etRequestHeaders.text.toString().trim()
+        if (requestHeaders.isNotEmpty()) {
+            if (!isValidRequestHeadersJson(requestHeaders)) {
+                binding.etRequestHeaders.error = getString(R.string.subscription_request_headers_invalid)
+                return false
+            }
+
+            binding.etRequestHeaders.error = null
+            subItem.requestHeaders = requestHeaders
+        } else {
+            binding.etRequestHeaders.error = null
+            subItem.requestHeaders = null
+        }
 
         if (TextUtils.isEmpty(subItem.remarks)) {
             toast(R.string.sub_setting_remarks)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -18,6 +18,7 @@ import java.net.Proxy
 import java.net.URI
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import org.json.JSONObject
 
 object HttpUtil {
 
@@ -163,6 +164,23 @@ object HttpUtil {
                 .header("Connection", "close")
 
             applyEmbeddedBasicAuthHeader(currentUrl, requestBuilder)
+
+            request.requestHeaders?.takeIf { it.isNotBlank() }?.let { headers ->
+                try {
+                    val jsonObject = JSONObject(headers)
+                    val keys = jsonObject.keys()
+
+                    while (keys.hasNext()) {
+                        val key = keys.next()
+                        val value = jsonObject.opt(key)
+
+                        if (value != null && value != JSONObject.NULL) {
+                            requestBuilder.header(key, value.toString())
+                        }
+                    }
+                } catch (_: Exception) {
+                }
+            }
 
             if (request.httpPort != 0 && !request.proxyUsername.isNullOrBlank() && !request.proxyPassword.isNullOrBlank()) {
                 requestBuilder.header("Proxy-Authorization", Credentials.basic(request.proxyUsername, request.proxyPassword))

--- a/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
+++ b/V2rayNG/app/src/main/res/layout/activity_sub_edit.xml
@@ -96,6 +96,27 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/subscription_request_headers" />
+
+                <EditText
+                    android:id="@+id/et_request_headers"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="monospace"
+                    android:gravity="top|start"
+                    android:inputType="textMultiLine"
+                    android:minLines="2" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/padding_spacing_dp16"
                 android:orientation="vertical">
 

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -413,6 +413,8 @@
     <string name="title_webdav_user">Username</string>
     <string name="title_webdav_pass">Password</string>
     <string name="title_webdav_remote_path">Remote directory (optional)</string>
+    <string name="subscription_request_headers_invalid">Invalid JSON format</string>
+    <string name="subscription_request_headers">Request Headers (JSON format)</string>
 
     <string-array name="share_method">
         <item>QRcode</item>


### PR DESCRIPTION
## Summary

This PR adds a new `HTTP Headers (JSON format)` field to the subscription settings.

It allows users to pass custom HTTP headers, such as `X-hwid`, `Authorization`, or any other provider-required headers, during subscription updates using a simple JSON dictionary.

This is a generic and scalable solution that addresses the issue discussed in #5847 without adding specific, single-purpose fields to the UI.

## Changes

* Added a `requestHeaders` property to the `SubscriptionItem` data class
* Added a `requestHeaders` field to the `UrlContentRequest` container
* Passed custom subscription headers through the subscription update flow
* Added a multiline JSON headers input field (`et_request_headers`) to the subscription edit layout (`activity_sub_edit.xml`)
* Added JSON object and HTTP header validation in `SubEditActivity.kt` using `android.util.JsonReader` before saving
* Cleared the input field and error state when resetting the server configuration (`clearServer`)
* Parsed the custom headers JSON safely using `JSONObject` in `HttpUtil.kt`
* Applied parsed custom headers directly to the OkHttp request builder
* Added translations for the new layout labels and validation error messages to `strings.xml` and `values-ru/strings.xml`

## Usage

Example custom headers JSON:

~~~json
{
  "X-hwid": "my_test_device",
  "Authorization": "Bearer test"
}
~~~

The value must be a JSON object with string header values.

### Subscription edit screen
<details><img width="1080" height="2186" alt="Screenshot_20260630_041133" src="https://github.com/user-attachments/assets/adebe24e-6262-4cc8-9316-61d5000f2c79" /></details>

## Testing

Tested manually on an Android emulator:

* Opened the subscription group setting screen
* Verified that the new `HTTP Headers (JSON format)` field is displayed correctly under the User Agent field
* Entered a valid JSON string, for example `{"X-hwid": "my_test_device", "Authorization": "Bearer test"}`, and saved successfully
* Attempted to save invalid JSON, such as missing values or invalid structure, and confirmed that saving is blocked with an `Invalid JSON format` error
* Confirmed that JSON arrays are rejected because the field expects a JSON object
* Updated the subscription and confirmed via `webhook.site` that the custom headers were included in the HTTP request
* Confirmed that existing subscriptions without custom headers continue to load, save, and update without any issues

Closes #5847