### PR TITLE
feat: promote frequently-used actions to toolbar for quick access

### DIFF
--- a/V2rayNG/app/src/main/res/drawable/ic_add_20dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_add_20dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+</vector>

--- a/V2rayNG/app/src/main/res/drawable/ic_outline_filter_alt_20.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_outline_filter_alt_20.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7,6h10l-5.01,6.3L7,6zM4.25,5.61C6.27,8.2 10,13 10,13v6c0,0.55 0.45,1 1,1h2c0.55,0 1,-0.45 1,-1v-6c0,0 3.72,-4.8 5.74,-7.39C20.25,4.95 19.78,4 18.95,4H5.04C4.21,4 3.74,4.95 4.25,5.61z" />
+</vector>

--- a/V2rayNG/app/src/main/res/drawable/ic_sort_24dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_sort_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3,18h6v-2H3v2zM3,6v2h18V6H3zM3,13h12v-2H3v2z" />
+</vector>

--- a/V2rayNG/app/src/main/res/drawable/ic_sync_24dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_sync_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,4V1L8,5l4,4V6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zM12,18c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z" />
+</vector>

--- a/V2rayNG/app/src/main/res/drawable/ic_timer_24dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_timer_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M15,1H9v2h6V1zM11,14h2V8h-2v6zM19.03,7.39l1.42,-1.42c-0.43,-0.51 -0.9,-0.99 -1.41,-1.41l-1.42,1.42C16.07,4.74 14.12,4 12,4c-4.97,0 -9,4.03 -9,9s4.03,9 9,9 9,-4.03 9,-9c0,-2.12 -0.74,-4.07 -1.97,-5.61zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z" />
+</vector>

--- a/V2rayNG/app/src/main/res/menu/menu_main.xml
+++ b/V2rayNG/app/src/main/res/menu/menu_main.xml
@@ -3,14 +3,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/search_view"
-        android:icon="@drawable/ic_outline_filter_alt_24"
+        android:icon="@drawable/ic_outline_filter_alt_20"
         android:title="@string/menu_item_search"
         app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:showAsAction="always|collapseActionView" />
     <item
-        android:icon="@drawable/ic_add_24dp"
+        android:icon="@drawable/ic_add_20dp"
         android:title="@string/menu_item_add_config"
-        app:showAsAction="ifRoom">
+        app:showAsAction="always">
         <menu>
             <item
                 android:id="@+id/import_qrcode"
@@ -67,6 +67,21 @@
         </menu>
     </item>
     <item
+        android:id="@+id/sub_update"
+        android:icon="@drawable/ic_sync_24dp"
+        android:title="@string/title_sub_update"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/sort_by_test_results"
+        android:icon="@drawable/ic_sort_24dp"
+        android:title="@string/title_sort_by_test_results"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/real_ping_all"
+        android:icon="@drawable/ic_timer_24dp"
+        android:title="@string/title_real_ping_all_server"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/service_restart"
         android:title="@string/title_service_restart"
         app:showAsAction="never" />
@@ -91,19 +106,7 @@
         android:title="@string/title_export_all"
         app:showAsAction="never" />
     <item
-        android:id="@+id/real_ping_all"
-        android:title="@string/title_real_ping_all_server"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/sort_by_test_results"
-        android:title="@string/title_sort_by_test_results"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/locate_selected_config"
         android:title="@string/title_locate_selected_config"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/sub_update"
-        android:title="@string/title_sub_update"
         app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
## What this does

Moves **Update subscription**, **Sort by test results**, and **Real delay test** from the overflow menu (three-dot) to the main toolbar as icon buttons. Also shrinks the existing filter and add-config icons from 24dp to 20dp for a more compact toolbar.

## Before / After

| Before | After |
|--------|-------|
| Tap overflow menu → scroll → find action | One-tap directly from toolbar |

Users had to open the overflow menu, scroll past 10+ items, and find these three actions buried at the bottom. Now they're always visible as toolbar icons.

## Changes

- **5 new vector drawables**: `ic_sync_24dp`, `ic_sort_24dp`, `ic_timer_24dp` (new actions) + `ic_add_20dp`, `ic_outline_filter_alt_20` (smaller variants)
- **`menu_main.xml`**: promoted 3 items from overflow to toolbar (`showAsAction="ifRoom"`), reduced icon sizes for consistency, pinned add-config to always show
- **No Kotlin changes needed** — existing `onOptionsItemSelected` handlers already covered all 3 action IDs (`sub_update`, `sort_by_test_results`, `real_ping_all`)

## Why

These three actions are the most commonly performed daily operations. Having them in the overflow menu adds unnecessary friction, especially for users who update subscriptions and test latency multiple times a day. The smaller icons also give the toolbar a cleaner, more balanced look.