### PR TITLE
Fix duplicate VPN startup on boot leading to disconnect

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -114,8 +114,14 @@ class CoreVpnService : VpnService(), ServiceControl {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received")
+        if (CoreServiceManager.isRunning()) {
+            LogUtil.i(AppConfig.TAG, "StartCore-VPN: Core already running, ignoring duplicate start")
+            return START_STICKY
+        }
         NotificationManager.showNotification(null)
-        setupVpnService()
+        if (!setupVpnService()) {
+            return START_NOT_STICKY
+        }
         startService()
         return START_STICKY
         //return super.onStartCommand(intent, flags, startId)
@@ -159,21 +165,22 @@ class CoreVpnService : VpnService(), ServiceControl {
      * Sets up the VPN service.
      * Prepares the VPN and configures it if preparation is successful.
      */
-    private fun setupVpnService() {
+    private fun setupVpnService(): Boolean {
         val prepare = prepare(this)
         if (prepare != null) {
             LogUtil.e(AppConfig.TAG, "StartCore-VPN: Permission not granted")
             stopSelf()
-            return
+            return false
         }
 
         if (configureVpnService() != true) {
             LogUtil.e(AppConfig.TAG, "StartCore-VPN: Configuration failed")
             stopSelf()
-            return
+            return false
         }
 
         runTun2socks()
+        return true
     }
 
     /**


### PR DESCRIPTION
When both connect-on-startup in the app and Always-on-VPN in Android are enabled, Android delivers a duplicate start command to CoreVpnService during boot. CoreVpnService previously rebuilt the VPN interface before checking whether the core was already running.

In native xray-tun mode this can disrupt the TUN file descriptor while Xray is already using it. Then startCoreLoop reports that the core is already running, CoreVpnService treats that as a startup failure, and the service disconnects shortly after boot.

This change makes CoreVpnService ignore duplicate start commands while the core is already running. It also stops startup early if VPN permission/configuration fails instead of continuing into startService.

Verified on an x86_64 emulator with:
- connect on startup and always-on vpn enabled
- local SOCKS5 proxy disabled
- HevTun disabled
- native xray-tun enabled

After reboot, adb shows CoreVpnService still running as a foreground service, VPN tun0 connected/validated, and no "Failed to start core loop" shutdown sequence.