### PR TITLE
Add configurable Observatory settings

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -335,4 +335,6 @@ object AppConfig {
         TAG_DIRECT,
         TAG_BLOCKED,
     )
+
+    val OBSERVATORY_DURATION_PATTERN = Regex("""[1-9]\d*(ms|s|m|h)""")
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -44,6 +44,11 @@ object AppConfig {
     const val PREF_FRAGMENT_LENGTH = "pref_fragment_length"
     const val PREF_FRAGMENT_INTERVAL = "pref_fragment_interval"
     const val PREF_FRAGMENT_MAXSPLIT = "pref_fragment_maxsplit"
+    const val PREF_OBSERVATORY_LEAST_PING_INTERVAL = "pref_observatory_least_ping_interval"
+    const val PREF_OBSERVATORY_LEAST_LOAD_INTERVAL = "pref_observatory_least_load_interval"
+    const val PREF_OBSERVATORY_LEAST_LOAD_METHOD = "pref_observatory_least_load_method"
+    const val PREF_OBSERVATORY_LEAST_LOAD_SAMPLING = "pref_observatory_least_load_sampling"
+    const val PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT = "pref_observatory_least_load_timeout"
     const val SUBSCRIPTION_UPDATE_TASK_NAME = "subscription_updater"
     const val SUBSCRIPTION_MIN_INTERVAL_MINUTES = 15L
     const val PREF_SPEED_ENABLED = "pref_speed_enabled"
@@ -128,6 +133,11 @@ object AppConfig {
     const val TG_CHANNEL_URL = "https://t.me/github_2dust"
     const val DELAY_TEST_URL = "https://www.gstatic.com/generate_204"
     const val DELAY_TEST_URL2 = "https://www.google.com/generate_204"
+    const val OBSERVATORY_LEAST_PING_INTERVAL = "3m"
+    const val OBSERVATORY_LEAST_LOAD_INTERVAL = "5m"
+    const val OBSERVATORY_LEAST_LOAD_METHOD = "HEAD"
+    const val OBSERVATORY_LEAST_LOAD_SAMPLING = "2"
+    const val OBSERVATORY_LEAST_LOAD_TIMEOUT = "30s"
 
     //    const val IP_API_URL = "https://speed.cloudflare.com/meta"
     const val IP_API_URL = "https://api.ip.sb/geoip"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -24,6 +24,7 @@ import com.v2ray.ang.util.Utils
 object CoreConfigManager {
     private var initConfigCache: String? = null
     private var initConfigCacheWithTun: String? = null
+    private val OBSERVATORY_DURATION_PATTERN = Regex("""[1-9]\d*(ms|s|m|h)""")
 
     //region get config function
 
@@ -1184,6 +1185,20 @@ object CoreConfigManager {
         balancerTag: String = AppConfig.TAG_BALANCER,
     ): BalancerStrategy {
         val probeUrl = MmkvManager.decodeSettingsString(AppConfig.PREF_DELAY_TEST_URL) ?: AppConfig.DELAY_TEST_URL
+        val leastPingInterval = decodeObservatoryDuration(
+            AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL,
+            AppConfig.OBSERVATORY_LEAST_PING_INTERVAL
+        )
+        val leastLoadInterval = decodeObservatoryDuration(
+            AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL,
+            AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL
+        )
+        val leastLoadMethod = decodeLeastLoadMethod()
+        val leastLoadSampling = decodeObservatorySampling()
+        val leastLoadTimeout = decodeObservatoryDuration(
+            AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT,
+            AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT
+        )
         val strategyType = BalancerStrategyType.from(policyGroupType)
         val balancer = V2rayConfig.RoutingBean.BalancerBean(
             tag = balancerTag,
@@ -1194,7 +1209,7 @@ object CoreConfigManager {
             V2rayConfig.ObservatoryObject(
                 subjectSelector = selector,
                 probeUrl = probeUrl,
-                probeInterval = "3m",
+                probeInterval = leastPingInterval,
                 enableConcurrency = true
             )
         } else null
@@ -1203,13 +1218,39 @@ object CoreConfigManager {
                 subjectSelector = selector,
                 pingConfig = V2rayConfig.BurstObservatoryObject.PingConfigObject(
                     destination = probeUrl,
-                    interval = "5m",
-                    sampling = 2,
-                    timeout = "30s"
+                    httpMethod = leastLoadMethod,
+                    interval = leastLoadInterval,
+                    sampling = leastLoadSampling,
+                    timeout = leastLoadTimeout
                 )
             )
         } else null
         return BalancerStrategy(balancer, observatory, burstObservatory)
+    }
+
+    private fun decodeObservatoryDuration(key: String, default: String): String {
+        val value = MmkvManager.decodeSettingsString(key)?.trim()
+        return if (!value.isNullOrEmpty() && OBSERVATORY_DURATION_PATTERN.matches(value)) {
+            value
+        } else {
+            default
+        }
+    }
+
+    private fun decodeLeastLoadMethod(): String {
+        val method = MmkvManager.decodeSettingsString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD)
+            ?.trim()
+            ?.uppercase()
+        return method?.takeIf { it == "HEAD" || it == "GET" }
+            ?: AppConfig.OBSERVATORY_LEAST_LOAD_METHOD
+    }
+
+    private fun decodeObservatorySampling(): Int {
+        return MmkvManager.decodeSettingsString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING)
+            ?.trim()
+            ?.toIntOrNull()
+            ?.takeIf { it > 0 }
+            ?: AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING.toInt()
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -24,7 +24,6 @@ import com.v2ray.ang.util.Utils
 object CoreConfigManager {
     private var initConfigCache: String? = null
     private var initConfigCacheWithTun: String? = null
-    private val OBSERVATORY_DURATION_PATTERN = Regex("""[1-9]\d*(ms|s|m|h)""")
 
     //region get config function
 
@@ -1185,20 +1184,11 @@ object CoreConfigManager {
         balancerTag: String = AppConfig.TAG_BALANCER,
     ): BalancerStrategy {
         val probeUrl = MmkvManager.decodeSettingsString(AppConfig.PREF_DELAY_TEST_URL) ?: AppConfig.DELAY_TEST_URL
-        val leastPingInterval = decodeObservatoryDuration(
-            AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL,
-            AppConfig.OBSERVATORY_LEAST_PING_INTERVAL
-        )
-        val leastLoadInterval = decodeObservatoryDuration(
-            AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL,
-            AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL
-        )
-        val leastLoadMethod = decodeLeastLoadMethod()
+        val leastPingInterval = decodeObservatoryDuration(AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL, AppConfig.OBSERVATORY_LEAST_PING_INTERVAL)
+        val leastLoadInterval = decodeObservatoryDuration(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL, AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL)
+        val leastLoadMethod = MmkvManager.decodeSettingsString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD, AppConfig.OBSERVATORY_LEAST_LOAD_METHOD)
         val leastLoadSampling = decodeObservatorySampling()
-        val leastLoadTimeout = decodeObservatoryDuration(
-            AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT,
-            AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT
-        )
+        val leastLoadTimeout = decodeObservatoryDuration(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT, AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT)
         val strategyType = BalancerStrategyType.from(policyGroupType)
         val balancer = V2rayConfig.RoutingBean.BalancerBean(
             tag = balancerTag,
@@ -1230,19 +1220,11 @@ object CoreConfigManager {
 
     private fun decodeObservatoryDuration(key: String, default: String): String {
         val value = MmkvManager.decodeSettingsString(key)?.trim()
-        return if (!value.isNullOrEmpty() && OBSERVATORY_DURATION_PATTERN.matches(value)) {
+        return if (!value.isNullOrEmpty() && AppConfig.OBSERVATORY_DURATION_PATTERN.matches(value)) {
             value
         } else {
             default
         }
-    }
-
-    private fun decodeLeastLoadMethod(): String {
-        val method = MmkvManager.decodeSettingsString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD)
-            ?.trim()
-            ?.uppercase()
-        return method?.takeIf { it == "HEAD" || it == "GET" }
-            ?: AppConfig.OBSERVATORY_LEAST_LOAD_METHOD
     }
 
     private fun decodeObservatorySampling(): Int {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -437,6 +437,7 @@ data class V2rayConfig(
         data class PingConfigObject(
             val destination: String,
             val connectivity: String? = null,
+            val httpMethod: String? = null,
             val interval: String,
             val sampling: Int,
             val timeout: String? = null

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -523,6 +523,11 @@ object SettingsManager {
         ensureDefaultValue(AppConfig.PREF_FRAGMENT_LENGTH, "50-100")
         ensureDefaultValue(AppConfig.PREF_FRAGMENT_INTERVAL, "10-20")
         ensureDefaultValue(AppConfig.PREF_FRAGMENT_MAXSPLIT, "10")
+        ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL, AppConfig.OBSERVATORY_LEAST_PING_INTERVAL)
+        ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL, AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL)
+        ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD, AppConfig.OBSERVATORY_LEAST_LOAD_METHOD)
+        ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING, AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING)
+        ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT, AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT)
     }
 
     private fun ensureDefaultValue(key: String, default: String) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -44,8 +44,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-private val OBSERVATORY_DURATION_PATTERN = Regex("""[1-9]\d*(ms|s|m|h)""")
-
 class SettingsActivity : BaseComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -97,26 +95,11 @@ fun SettingsScreen(
     var fragmentLength by rememberMmkvString(AppConfig.PREF_FRAGMENT_LENGTH, "50-100")
     var fragmentInterval by rememberMmkvString(AppConfig.PREF_FRAGMENT_INTERVAL, "10-20")
     var fragmentMaxSplit by rememberMmkvString(AppConfig.PREF_FRAGMENT_MAXSPLIT, "10")
-    var observatoryLeastPingInterval by rememberMmkvString(
-        AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL,
-        AppConfig.OBSERVATORY_LEAST_PING_INTERVAL
-    )
-    var observatoryLeastLoadInterval by rememberMmkvString(
-        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL,
-        AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL
-    )
-    var observatoryLeastLoadMethod by rememberMmkvString(
-        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD,
-        AppConfig.OBSERVATORY_LEAST_LOAD_METHOD
-    )
-    var observatoryLeastLoadSampling by rememberMmkvString(
-        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING,
-        AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING
-    )
-    var observatoryLeastLoadTimeout by rememberMmkvString(
-        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT,
-        AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT
-    )
+    var observatoryLeastPingInterval by rememberMmkvString(AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL, AppConfig.OBSERVATORY_LEAST_PING_INTERVAL)
+    var observatoryLeastLoadInterval by rememberMmkvString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL, AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL)
+    var observatoryLeastLoadMethod by rememberMmkvString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD, AppConfig.OBSERVATORY_LEAST_LOAD_METHOD)
+    var observatoryLeastLoadSampling by rememberMmkvString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING, AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING)
+    var observatoryLeastLoadTimeout by rememberMmkvString(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT, AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT)
 
     var mode by rememberMmkvString(AppConfig.PREF_MODE, VPN)
     var enableRootMode by rememberMmkvBool(AppConfig.PREF_ROOT_MODE_ENABLE, false)
@@ -184,13 +167,13 @@ fun SettingsScreen(
     val fragmentPacketsEntries = stringArrayResource(R.array.fragment_packets).toList()
     val fragmentPacketsValues = stringArrayResource(R.array.fragment_packets).toList()
     val observatoryLeastLoadMethodEntries = stringArrayResource(R.array.observatory_least_load_method).toList()
-    val observatoryLeastLoadMethodValues = stringArrayResource(R.array.observatory_least_load_method_value).toList()
+    val observatoryLeastLoadMethodValues = stringArrayResource(R.array.observatory_least_load_method).toList()
     val modeEntries = stringArrayResource(R.array.mode_entries).toList()
     val modeValues = stringArrayResource(R.array.mode_value).toList()
 
     fun updateObservatoryDuration(value: String, onValid: (String) -> Unit) {
         val duration = value.trim()
-        if (OBSERVATORY_DURATION_PATTERN.matches(duration)) {
+        if (AppConfig.OBSERVATORY_DURATION_PATTERN.matches(duration)) {
             onValid(duration)
         } else {
             context.toastError(R.string.toast_invalid_observatory_duration)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -44,6 +44,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+private val OBSERVATORY_DURATION_PATTERN = Regex("""[1-9]\d*(ms|s|m|h)""")
+
 class SettingsActivity : BaseComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -95,6 +97,26 @@ fun SettingsScreen(
     var fragmentLength by rememberMmkvString(AppConfig.PREF_FRAGMENT_LENGTH, "50-100")
     var fragmentInterval by rememberMmkvString(AppConfig.PREF_FRAGMENT_INTERVAL, "10-20")
     var fragmentMaxSplit by rememberMmkvString(AppConfig.PREF_FRAGMENT_MAXSPLIT, "10")
+    var observatoryLeastPingInterval by rememberMmkvString(
+        AppConfig.PREF_OBSERVATORY_LEAST_PING_INTERVAL,
+        AppConfig.OBSERVATORY_LEAST_PING_INTERVAL
+    )
+    var observatoryLeastLoadInterval by rememberMmkvString(
+        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_INTERVAL,
+        AppConfig.OBSERVATORY_LEAST_LOAD_INTERVAL
+    )
+    var observatoryLeastLoadMethod by rememberMmkvString(
+        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD,
+        AppConfig.OBSERVATORY_LEAST_LOAD_METHOD
+    )
+    var observatoryLeastLoadSampling by rememberMmkvString(
+        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING,
+        AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING
+    )
+    var observatoryLeastLoadTimeout by rememberMmkvString(
+        AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT,
+        AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT
+    )
 
     var mode by rememberMmkvString(AppConfig.PREF_MODE, VPN)
     var enableRootMode by rememberMmkvBool(AppConfig.PREF_ROOT_MODE_ENABLE, false)
@@ -161,8 +183,28 @@ fun SettingsScreen(
     val xudpQuicValues = stringArrayResource(R.array.mux_xudp_quic_value).toList()
     val fragmentPacketsEntries = stringArrayResource(R.array.fragment_packets).toList()
     val fragmentPacketsValues = stringArrayResource(R.array.fragment_packets).toList()
+    val observatoryLeastLoadMethodEntries = stringArrayResource(R.array.observatory_least_load_method).toList()
+    val observatoryLeastLoadMethodValues = stringArrayResource(R.array.observatory_least_load_method_value).toList()
     val modeEntries = stringArrayResource(R.array.mode_entries).toList()
     val modeValues = stringArrayResource(R.array.mode_value).toList()
+
+    fun updateObservatoryDuration(value: String, onValid: (String) -> Unit) {
+        val duration = value.trim()
+        if (OBSERVATORY_DURATION_PATTERN.matches(duration)) {
+            onValid(duration)
+        } else {
+            context.toastError(R.string.toast_invalid_observatory_duration)
+        }
+    }
+
+    fun updateObservatorySampling(value: String) {
+        val sampling = value.trim().toIntOrNull()?.takeIf { it > 0 }
+        if (sampling != null) {
+            observatoryLeastLoadSampling = sampling.toString()
+        } else {
+            context.toastError(R.string.toast_invalid_observatory_sampling)
+        }
+    }
 
     Scaffold(
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
@@ -488,6 +530,48 @@ fun SettingsScreen(
                 enabled = fragment,
                 keyboardNumber = true,
                 onValueChanged = { fragmentMaxSplit = it }
+            )
+
+            PreferenceGroupHeader(title = stringResource(R.string.title_observatory_settings))
+            SettingsEditItem(
+                title = stringResource(R.string.title_pref_observatory_least_ping_interval),
+                value = observatoryLeastPingInterval,
+                onValueChanged = {
+                    updateObservatoryDuration(it) { value ->
+                        observatoryLeastPingInterval = value
+                    }
+                }
+            )
+            SettingsEditItem(
+                title = stringResource(R.string.title_pref_observatory_least_load_interval),
+                value = observatoryLeastLoadInterval,
+                onValueChanged = {
+                    updateObservatoryDuration(it) { value ->
+                        observatoryLeastLoadInterval = value
+                    }
+                }
+            )
+            SettingsListItem(
+                title = stringResource(R.string.title_pref_observatory_least_load_method),
+                entries = observatoryLeastLoadMethodEntries,
+                values = observatoryLeastLoadMethodValues,
+                selectedValue = observatoryLeastLoadMethod,
+                onSelected = { observatoryLeastLoadMethod = it }
+            )
+            SettingsEditItem(
+                title = stringResource(R.string.title_pref_observatory_least_load_sampling),
+                value = observatoryLeastLoadSampling,
+                keyboardNumber = true,
+                onValueChanged = { updateObservatorySampling(it) }
+            )
+            SettingsEditItem(
+                title = stringResource(R.string.title_pref_observatory_least_load_timeout),
+                value = observatoryLeastLoadTimeout,
+                onValueChanged = {
+                    updateObservatoryDuration(it) { value ->
+                        observatoryLeastLoadTimeout = value
+                    }
+                }
             )
 
             PreferenceGroupHeader(title = stringResource(R.string.title_advanced))

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -370,6 +370,14 @@
     <string name="title_pref_fragment_interval">فاصل الجزء (الحد الأدنى - الحد الأقصى)</string>
     <string name="title_pref_fragment_enabled">تفعيل الجزء</string>
     <string name="title_pref_fragment_maxsplit">ماكس سبليت الجزء</string>
+    <string name="title_observatory_settings">إعدادات مراقبة الاتصال</string>
+    <string name="title_pref_observatory_least_ping_interval">فاصل leastPing</string>
+    <string name="title_pref_observatory_least_load_interval">فاصل leastLoad</string>
+    <string name="title_pref_observatory_least_load_method">طريقة HTTP لـ leastLoad</string>
+    <string name="title_pref_observatory_least_load_sampling">عينات leastLoad</string>
+    <string name="title_pref_observatory_least_load_timeout">مهلة leastLoad</string>
+    <string name="toast_invalid_observatory_duration">مدة غير صالحة. استخدم قيمة مثل 3m أو 30s.</string>
+    <string name="toast_invalid_observatory_sampling">عدد العينات غير صالح. استخدم رقمًا موجبًا.</string>
 
     <string name="update_check_for_update">Check for update</string>
     <string name="update_already_latest_version">Already on the latest version</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -369,6 +369,14 @@
     <string name="title_pref_fragment_interval">ফ্র্যাগমেন্ট ইন্টারভ্যাল (ন্যূনতম-সর্বাধিক)</string>
     <string name="title_pref_fragment_enabled">ফ্র্যাগমেন্ট সক্রিয় করুন</string>
     <string name="title_pref_fragment_maxsplit">ফ্র্যাগমেন্ট ম্যাক্স স্প্লিট</string>
+    <string name="title_observatory_settings">সংযোগ পর্যবেক্ষণ সেটিংস</string>
+    <string name="title_pref_observatory_least_ping_interval">leastPing ইন্টারভ্যাল</string>
+    <string name="title_pref_observatory_least_load_interval">leastLoad ইন্টারভ্যাল</string>
+    <string name="title_pref_observatory_least_load_method">leastLoad HTTP পদ্ধতি</string>
+    <string name="title_pref_observatory_least_load_sampling">leastLoad স্যাম্পলিং</string>
+    <string name="title_pref_observatory_least_load_timeout">leastLoad টাইমআউট</string>
+    <string name="toast_invalid_observatory_duration">অবৈধ সময়কাল। 3m বা 30s-এর মতো মান ব্যবহার করুন।</string>
+    <string name="toast_invalid_observatory_sampling">অবৈধ স্যাম্পলিং। একটি ধনাত্মক সংখ্যা ব্যবহার করুন।</string>
 
     <string name="update_check_for_update">Check for update</string>
     <string name="update_already_latest_version">Already on the latest version</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -375,6 +375,14 @@
     <string name="title_pref_fragment_interval">فاسله منجا کتنا فرگمنت (هدقل-هدکسر)</string>
     <string name="title_pref_fragment_enabled">ره وندن فرگمنت</string>
     <string name="title_pref_fragment_maxsplit">هدکسر تقسیم فرگمنت</string>
+    <string name="title_observatory_settings">سامووا واجۊری منپیز</string>
+    <string name="title_pref_observatory_least_ping_interval">فاسله leastPing</string>
+    <string name="title_pref_observatory_least_load_interval">فاسله leastLoad</string>
+    <string name="title_pref_observatory_least_load_method">روش HTTP سی leastLoad</string>
+    <string name="title_pref_observatory_least_load_sampling">نمونه گیری leastLoad</string>
+    <string name="title_pref_observatory_least_load_timeout">مهلت leastLoad</string>
+    <string name="toast_invalid_observatory_duration">زما نادروسته. یه ارزشی وری 3m یا 30s بکار ببرین.</string>
+    <string name="toast_invalid_observatory_sampling">نمونه گیری نادروسته. یه شماره مثبت بکار ببرین.</string>
 
     <string name="update_check_for_update">واجۊری سی ورۊ رسۊوی</string>
     <string name="update_already_latest_version">سکو نوسخه دیندایی پۊرنیڌه هڌ</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -366,6 +366,14 @@
     <string name="title_pref_fragment_interval">فاصله بین بسته های فرگمنت (حداقل-حداکثر)</string>
     <string name="title_pref_fragment_enabled">فعال کردن فرگمنت</string>
     <string name="title_pref_fragment_maxsplit">حداکثر تقسیم فرگمنت</string>
+    <string name="title_observatory_settings">تنظیمات پایش اتصال</string>
+    <string name="title_pref_observatory_least_ping_interval">فاصله leastPing</string>
+    <string name="title_pref_observatory_least_load_interval">فاصله leastLoad</string>
+    <string name="title_pref_observatory_least_load_method">روش HTTP برای leastLoad</string>
+    <string name="title_pref_observatory_least_load_sampling">نمونه‌برداری leastLoad</string>
+    <string name="title_pref_observatory_least_load_timeout">مهلت زمانی leastLoad</string>
+    <string name="toast_invalid_observatory_duration">مدت زمان نامعتبر است. از مقداری مانند 3m یا 30s استفاده کنید.</string>
+    <string name="toast_invalid_observatory_sampling">مقدار نمونه‌برداری نامعتبر است. از یک عدد مثبت استفاده کنید.</string>
 
     <string name="update_check_for_update">بررسی به روز رسانی</string>
     <string name="update_already_latest_version">در حال حاضر آخرین نسخه نصب شده است</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -381,6 +381,14 @@
     <string name="title_pref_fragment_interval">Интервал фрагментов (от — до)</string>
     <string name="title_pref_fragment_enabled">Использовать фрагментирование</string>
     <string name="title_pref_fragment_maxsplit">Максимальное число фрагментов</string>
+    <string name="title_observatory_settings">Настройки наблюдения соединений</string>
+    <string name="title_pref_observatory_least_ping_interval">Интервал leastPing</string>
+    <string name="title_pref_observatory_least_load_interval">Интервал leastLoad</string>
+    <string name="title_pref_observatory_least_load_method">HTTP-метод leastLoad</string>
+    <string name="title_pref_observatory_least_load_sampling">Выборка leastLoad</string>
+    <string name="title_pref_observatory_least_load_timeout">Тайм-аут leastLoad</string>
+    <string name="toast_invalid_observatory_duration">Недопустимая длительность. Используйте значение вроде 3m или 30s.</string>
+    <string name="toast_invalid_observatory_sampling">Недопустимая выборка. Используйте положительное число.</string>
 
     <string name="update_check_for_update">Проверить обновление</string>
     <string name="update_already_latest_version">Установлена последняя версия</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -371,6 +371,14 @@
     <string name="title_pref_fragment_interval">Fragment Interval (min-max)</string>
     <string name="title_pref_fragment_enabled">Enable Fragment</string>
     <string name="title_pref_fragment_maxsplit">Fragment Max Split</string>
+    <string name="title_observatory_settings">Cài đặt giám sát kết nối</string>
+    <string name="title_pref_observatory_least_ping_interval">Khoảng thời gian leastPing</string>
+    <string name="title_pref_observatory_least_load_interval">Khoảng thời gian leastLoad</string>
+    <string name="title_pref_observatory_least_load_method">Phương thức HTTP leastLoad</string>
+    <string name="title_pref_observatory_least_load_sampling">Lấy mẫu leastLoad</string>
+    <string name="title_pref_observatory_least_load_timeout">Thời gian chờ leastLoad</string>
+    <string name="toast_invalid_observatory_duration">Khoảng thời gian không hợp lệ. Dùng giá trị như 3m hoặc 30s.</string>
+    <string name="toast_invalid_observatory_sampling">Lấy mẫu không hợp lệ. Dùng một số dương.</string>
 
     <string name="update_check_for_update">Check for update</string>
     <string name="update_already_latest_version">Already on the latest version</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -380,6 +380,14 @@
     <string name="title_pref_fragment_interval">分片间隔（最小 - 最大）</string>
     <string name="title_pref_fragment_enabled">启用分片（Fragment）</string>
     <string name="title_pref_fragment_maxsplit">分片最大分割数</string>
+    <string name="title_observatory_settings">连接观测设置</string>
+    <string name="title_pref_observatory_least_ping_interval">leastPing 探测间隔</string>
+    <string name="title_pref_observatory_least_load_interval">leastLoad 探测间隔</string>
+    <string name="title_pref_observatory_least_load_method">leastLoad HTTP 方法</string>
+    <string name="title_pref_observatory_least_load_sampling">leastLoad 采样数量</string>
+    <string name="title_pref_observatory_least_load_timeout">leastLoad 探测超时</string>
+    <string name="toast_invalid_observatory_duration">时间格式无效。请使用类似 3m 或 30s 的值。</string>
+    <string name="toast_invalid_observatory_sampling">采样数量无效。请使用正数。</string>
 
     <string name="update_check_for_update">检查更新</string>
     <string name="update_already_latest_version">目前已是最新版本</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -378,6 +378,14 @@
     <string name="title_pref_fragment_interval">分片間隔（最小-最大）</string>
     <string name="title_pref_fragment_enabled">啟用分片（Fragment）</string>
     <string name="title_pref_fragment_maxsplit">分片最大分割數</string>
+    <string name="title_observatory_settings">連線觀測設定</string>
+    <string name="title_pref_observatory_least_ping_interval">leastPing 探測間隔</string>
+    <string name="title_pref_observatory_least_load_interval">leastLoad 探測間隔</string>
+    <string name="title_pref_observatory_least_load_method">leastLoad HTTP 方法</string>
+    <string name="title_pref_observatory_least_load_sampling">leastLoad 取樣數量</string>
+    <string name="title_pref_observatory_least_load_timeout">leastLoad 探測逾時</string>
+    <string name="toast_invalid_observatory_duration">時間格式無效。請使用類似 3m 或 30s 的值。</string>
+    <string name="toast_invalid_observatory_sampling">取樣數量無效。請使用正數。</string>
 
     <string name="update_check_for_update">檢查更新</string>
     <string name="update_already_latest_version">当前已是最新版本</string>

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -70,6 +70,16 @@
         <item>1-5</item>
     </string-array>
 
+    <string-array name="observatory_least_load_method" translatable="false">
+        <item>HEAD</item>
+        <item>GET</item>
+    </string-array>
+
+    <string-array name="observatory_least_load_method_value" translatable="false">
+        <item>HEAD</item>
+        <item>GET</item>
+    </string-array>
+
     <string-array name="streamsecurity_utls" translatable="false">
         <item />
         <item>chrome</item>

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -75,11 +75,6 @@
         <item>GET</item>
     </string-array>
 
-    <string-array name="observatory_least_load_method_value" translatable="false">
-        <item>HEAD</item>
-        <item>GET</item>
-    </string-array>
-
     <string-array name="streamsecurity_utls" translatable="false">
         <item />
         <item>chrome</item>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -384,6 +384,14 @@
     <string name="title_pref_fragment_interval">Fragment Interval (min-max)</string>
     <string name="title_pref_fragment_enabled">Enable Fragment</string>
     <string name="title_pref_fragment_maxsplit">Fragment Max Split</string>
+    <string name="title_observatory_settings">Observatory Settings</string>
+    <string name="title_pref_observatory_least_ping_interval">leastPing Interval</string>
+    <string name="title_pref_observatory_least_load_interval">leastLoad Interval</string>
+    <string name="title_pref_observatory_least_load_method">leastLoad Mode</string>
+    <string name="title_pref_observatory_least_load_sampling">leastLoad Sampling</string>
+    <string name="title_pref_observatory_least_load_timeout">leastLoad Timeout</string>
+    <string name="toast_invalid_observatory_duration">Invalid duration. Use a value like 3m or 30s.</string>
+    <string name="toast_invalid_observatory_sampling">Invalid sampling. Use a positive number.</string>
 
     <string name="update_check_for_update">Check for update</string>
     <string name="update_already_latest_version">Already on the latest version</string>


### PR DESCRIPTION
This adds UI settings for policy-group observatory behavior:

- `leastPing` probe interval
- `leastLoad` probe interval
- `leastLoad` HTTP method (`HEAD` / `GET`)
- `leastLoad` sampling count
- `leastLoad` timeout

The settings are added under a new "Observatory Settings" section in app settings, after Fragment Settings. Existing defaults are preserved:

- `leastPing` interval: `3m`
- `leastLoad` interval: `5m`
- `leastLoad` method: `HEAD`
- `leastLoad` sampling: `2`
- `leastLoad` timeout: `30s`

Configurable intervals and timeouts allow users to fine-tune the sensitivity of policy-group connection evaluation. Setting the interval lower improves the response to sudden availability changes during network switches.
The generated Xray config now passes `httpMethod` in `burstObservatory.pingConfig`, matching Xray's public config schema.
Using a URL like `https://httpbin.konghq.com/bytes/65535` with httpMethod set to GET can reliably discard the connections that respond to ping and HEAD, but drop after a small amount of data passes through - the issue Russian users have with some destinations.

Localized strings were added for all existing app locales. `leastPing`, `leastLoad`, `HEAD`, and `GET` are intentionally left untranslated.

This PR partially addresses #5885 concerns.
