### PR TITLE
Improve network-switch recovery and warm policy-group routing

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="PackageVisibilityPolicy,QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -220,7 +220,7 @@
             android:name=".service.CoreTestService"
             android:exported="false"
             android:foregroundServiceType="specialUse"
-            android:process=":RunSoLibV2RayDaemon">
+            android:process=":OutboundProbe">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="test" />

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -174,6 +174,7 @@ object AppConfig {
     const val MSG_MEASURE_CONFIG_SUCCESS = 72
     const val MSG_MEASURE_CONFIG_NOTIFY = 73
     const val MSG_MEASURE_CONFIG_FINISH = 74
+    const val MSG_POLICY_ROUTE_OBSERVED = 75
 
     /** Notification channel IDs and names. */
     const val RAY_NG_CHANNEL_ID = "RAY_NG_M_CH_ID"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -44,6 +44,7 @@ object AppConfig {
     const val PREF_FRAGMENT_LENGTH = "pref_fragment_length"
     const val PREF_FRAGMENT_INTERVAL = "pref_fragment_interval"
     const val PREF_FRAGMENT_MAXSPLIT = "pref_fragment_maxsplit"
+    const val PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK = "pref_remember_routes_per_wifi_network"
     const val SUBSCRIPTION_UPDATE_TASK_NAME = "subscription_updater"
     const val SUBSCRIPTION_MIN_INTERVAL_MINUTES = 15L
     const val PREF_SPEED_ENABLED = "pref_speed_enabled"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -170,7 +170,6 @@ object AppConfig {
     const val MSG_MEASURE_DELAY = 6
     const val MSG_MEASURE_DELAY_SUCCESS = 61
     const val MSG_MEASURE_CONFIG_START = 7
-    const val MSG_MEASURE_CONFIG_CANCEL = 71
     const val MSG_MEASURE_CONFIG_SUCCESS = 72
     const val MSG_MEASURE_CONFIG_NOTIFY = 73
     const val MSG_MEASURE_CONFIG_FINISH = 74

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonArray
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.dto.ConfigResult
 import com.v2ray.ang.dto.CoreConfigContext
+import com.v2ray.ang.dto.OutboundProbePlan
 import com.v2ray.ang.dto.V2rayConfig
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.RulesetItem
@@ -72,6 +73,29 @@ object CoreConfigManager {
                 errorMessage = "Failed to get V2ray config for speedtest: ${e.message ?: e.javaClass.simpleName}"
             )
         }
+    }
+
+    /**
+     * Build one short-lived core configuration for a complete UI delay-test
+     * batch. Invalid profiles are retained as failed GUIDs so one malformed
+     * entry cannot prevent viable outbounds from being measured.
+     */
+    fun getV2rayConfig4BatchSpeedtest(context: Context, guids: List<String>): OutboundProbePlan {
+        val sources = mutableListOf<OutboundProbeConfigBuilder.Source>()
+        val failedGuids = mutableListOf<String>()
+        guids.distinct().forEach { guid ->
+            val result = getV2rayConfig4Speedtest(context, guid)
+            if (result.status && result.content.isNotBlank()) {
+                sources += OutboundProbeConfigBuilder.Source(guid, result.content)
+            } else {
+                failedGuids += guid
+            }
+        }
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = sources,
+            destination = SettingsManager.getDelayTestUrl(),
+        )
+        return plan.copy(failedGuids = (failedGuids + plan.failedGuids).distinct())
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -394,7 +394,18 @@ object CoreConfigManager {
     private fun postProcessForSpeedtest(v2rayConfig: V2rayConfig) {
         v2rayConfig.log.loglevel = MmkvManager.decodeSettingsString(AppConfig.PREF_LOGLEVEL) ?: "warning"
         v2rayConfig.inbounds.clear()
+        val usesPrimaryBalancer = v2rayConfig.routing.balancers
+            ?.any { it.tag == AppConfig.TAG_BALANCER }
+            ?: false
         v2rayConfig.routing.rules.clear()
+        if (usesPrimaryBalancer) {
+            v2rayConfig.routing.rules.add(
+                V2rayConfig.RoutingBean.RulesBean(
+                    network = "tcp,udp",
+                    balancerTag = AppConfig.TAG_BALANCER,
+                )
+            )
+        }
         v2rayConfig.dns = null
         v2rayConfig.fakedns = null
         v2rayConfig.stats = null

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -85,7 +85,9 @@ object CoreConfigManager {
         val failedGuids = mutableListOf<String>()
         guids.distinct().forEach { guid ->
             val result = getV2rayConfig4Speedtest(context, guid)
-            if (result.status && result.content.isNotBlank()) {
+            if (result.status && result.content.isNotBlank() &&
+                CoreNativeManager.validateOutboundProbeConfig(result.content)
+            ) {
                 sources += OutboundProbeConfigBuilder.Source(guid, result.content)
             } else {
                 failedGuids += guid

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
@@ -24,17 +24,11 @@ object CoreNativeManager {
         val outboundTag: String = "",
         val alive: Boolean = false,
         val delay: Long = -1L,
-        val lastError: String = "",
         val samples: Long = 0L,
-        val failedSamples: Long = 0L,
-        val deviation: Long = 0L,
     )
 
     data class OutboundProbeBatchResult(
-        val completed: Boolean = false,
         val cancelled: Boolean = false,
-        val networkUnavailable: Boolean = false,
-        val error: String = "",
         val results: List<OutboundProbeStatus> = emptyList(),
         val balancerTargets: Map<String, String> = emptyMap(),
     )
@@ -89,20 +83,12 @@ object CoreNativeManager {
         }
     }
 
-    /**
-     * Measure outbound connection delay.
-     *
-     * @param config The configuration JSON string
-     * @param testUrl The URL to test against
-     * @return Delay in milliseconds, or -1 if test failed
-     */
-    fun measureOutboundDelay(config: String, testUrl: String): Long {
-        return try {
-            Libv2ray.measureOutboundDelay(config, testUrl)
-        } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "Failed to measure outbound delay", e)
-            -1L
-        }
+    fun validateOutboundProbeConfig(config: String): Boolean = try {
+        Libv2ray.validateOutboundProbeConfig(config)
+        true
+    } catch (e: Exception) {
+        LogUtil.w(AppConfig.TAG, "Rejected invalid outbound probe source: ${e.message}")
+        false
     }
 
     fun newOutboundProbeController(): OutboundProbeController =
@@ -126,7 +112,7 @@ object CoreNativeManager {
             handler,
         )
         return JsonUtil.fromJsonSafe(payload, OutboundProbeBatchResult::class.java)
-            ?: OutboundProbeBatchResult(error = "Invalid outbound probe response")
+            ?: throw IllegalStateException("Invalid outbound probe response")
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
@@ -9,6 +9,8 @@ import go.Seq
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
 import libv2ray.Libv2ray
+import libv2ray.OutboundProbeController
+import libv2ray.OutboundProbeHandler
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -18,9 +20,23 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Provides initialization protection and unified API for V2Ray core operations.
  */
 object CoreNativeManager {
-    data class OutboundDelayResult(
-        val delay: Long = -1L,
+    data class OutboundProbeStatus(
         val outboundTag: String = "",
+        val alive: Boolean = false,
+        val delay: Long = -1L,
+        val lastError: String = "",
+        val samples: Long = 0L,
+        val failedSamples: Long = 0L,
+        val deviation: Long = 0L,
+    )
+
+    data class OutboundProbeBatchResult(
+        val completed: Boolean = false,
+        val cancelled: Boolean = false,
+        val networkUnavailable: Boolean = false,
+        val error: String = "",
+        val results: List<OutboundProbeStatus> = emptyList(),
+        val balancerTargets: Map<String, String> = emptyMap(),
     )
 
     private val initialized = AtomicBoolean(false)
@@ -89,18 +105,28 @@ object CoreNativeManager {
         }
     }
 
-    fun measureOutboundDelayWithWarmRoute(
+    fun newOutboundProbeController(): OutboundProbeController =
+        Libv2ray.newOutboundProbeController()
+
+    fun probeOutbounds(
+        controller: OutboundProbeController,
         config: String,
-        testUrl: String,
-        warmTarget: String,
-    ): OutboundDelayResult {
-        return try {
-            val payload = Libv2ray.measureOutboundDelayWithWarmRoute(config, testUrl, warmTarget)
-            JsonUtil.fromJsonSafe(payload, OutboundDelayResult::class.java) ?: OutboundDelayResult()
-        } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "Failed to measure outbound delay with warm route", e)
-            OutboundDelayResult()
-        }
+        outboundTagsJson: String,
+        balancerTagsJson: String,
+        maxConcurrency: Int,
+        samples: Int,
+        handler: OutboundProbeHandler,
+    ): OutboundProbeBatchResult {
+        val payload = controller.probeOutbounds(
+            config,
+            outboundTagsJson,
+            balancerTagsJson,
+            maxConcurrency,
+            samples,
+            handler,
+        )
+        return JsonUtil.fromJsonSafe(payload, OutboundProbeBatchResult::class.java)
+            ?: OutboundProbeBatchResult(error = "Invalid outbound probe response")
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.core
 import android.content.Context
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.util.LogUtil
+import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.Utils
 import go.Seq
 import libv2ray.CoreCallbackHandler
@@ -17,6 +18,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Provides initialization protection and unified API for V2Ray core operations.
  */
 object CoreNativeManager {
+    data class OutboundDelayResult(
+        val delay: Long = -1L,
+        val outboundTag: String = "",
+    )
+
     private val initialized = AtomicBoolean(false)
 
     /**
@@ -80,6 +86,20 @@ object CoreNativeManager {
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to measure outbound delay", e)
             -1L
+        }
+    }
+
+    fun measureOutboundDelayWithWarmRoute(
+        config: String,
+        testUrl: String,
+        warmTarget: String,
+    ): OutboundDelayResult {
+        return try {
+            val payload = Libv2ray.measureOutboundDelayWithWarmRoute(config, testUrl, warmTarget)
+            JsonUtil.fromJsonSafe(payload, OutboundDelayResult::class.java) ?: OutboundDelayResult()
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to measure outbound delay with warm route", e)
+            OutboundDelayResult()
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -34,12 +34,17 @@ import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
 import libv2ray.ProcessFinder
 import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 object CoreServiceManager {
 
@@ -48,6 +53,11 @@ object CoreServiceManager {
     private var currentConfig: ProfileItem? = null
     private var processFinder: XrayProcessFinder? = null
     private var browserDialer: IDialerService? = null
+    @Volatile private var runningProfileGuid = ""
+    private val networkResetMutex = Mutex()
+    private val coreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val networkTransitions = AtomicInteger(0)
+    private val policyRouteCallbacksEnabled = AtomicBoolean(false)
 
     var serviceControl: SoftReference<ServiceControl>? = null
         set(value) {
@@ -119,16 +129,69 @@ object CoreServiceManager {
      * Recreates the in-process Xray instance after Android changes the VPN's
      * underlying network. The VPN interface and service remain active.
      */
-    fun resetCoreNetworkState() {
-        if (!coreController.isRunning) return
+    fun resetCoreNetworkState(previousNetworkKey: String?, newNetworkKey: String) {
+        networkTransitions.incrementAndGet()
+        PolicyRouteCache.setCurrentNetwork(newNetworkKey)
+        if (!coreController.isRunning) {
+            networkTransitions.decrementAndGet()
+            return
+        }
 
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                coreController.resetNetworkState()
-                LogUtil.i(AppConfig.TAG, "StartCore-Manager: Core network state reset")
-            } catch (e: Exception) {
-                LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to reset core network state", e)
+        val profileGuid = runningProfileGuid
+        val cacheGeneration = PolicyRouteCache.snapshot().generation
+        coreScope.launch {
+            networkResetMutex.withLock {
+                try {
+                    val currentTarget = coreController.getBalancerPrincipleTarget(AppConfig.TAG_BALANCER)
+                    PolicyRouteCache.remember(
+                        previousNetworkKey,
+                        profileGuid,
+                        currentTarget,
+                        cacheGeneration,
+                    )
+                    val warmTarget = PolicyRouteCache.lookup(newNetworkKey, profileGuid).orEmpty()
+                    coreController.resetNetworkStateWithWarmRoute(AppConfig.TAG_BALANCER, warmTarget)
+                    LogUtil.i(
+                        AppConfig.TAG,
+                        "StartCore-Manager: Core network state reset" +
+                            if (warmTarget.isNotEmpty()) " with cached policy route" else "",
+                    )
+                } catch (e: Exception) {
+                    LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to reset core network state", e)
+                } finally {
+                    if (networkTransitions.decrementAndGet() == 0 && policyRouteCallbacksEnabled.get()) {
+                        refreshFreshPolicyRoute()
+                    }
+                }
             }
+        }
+    }
+
+    fun updateCoreNetworkIdentity(newNetworkKey: String) {
+        PolicyRouteCache.setCurrentNetwork(newNetworkKey)
+        if (coreController.isRunning && policyRouteCallbacksEnabled.get()) {
+            coreScope.launch { refreshFreshPolicyRoute() }
+        }
+    }
+
+    private fun refreshFreshPolicyRoute() {
+        val cacheSnapshot = PolicyRouteCache.snapshot()
+        val freshTarget = try {
+            coreController.getBalancerPrincipleTarget(AppConfig.TAG_BALANCER)
+        } catch (_: Exception) {
+            ""
+        }
+        rememberFreshPolicyRoute(freshTarget, cacheSnapshot)
+    }
+
+    private fun rememberFreshPolicyRoute(
+        target: String?,
+        cacheSnapshot: PolicyRouteCache.Snapshot = PolicyRouteCache.snapshot(),
+    ) {
+        if (!policyRouteCallbacksEnabled.get() || networkTransitions.get() != 0 || target.isNullOrBlank()) return
+        val profileGuid = runningProfileGuid
+        if (PolicyRouteCache.rememberCurrent(cacheSnapshot, profileGuid, target)) {
+            LogUtil.i(AppConfig.TAG, "Policy route cache updated from fresh observatory result")
         }
     }
 
@@ -283,11 +346,23 @@ object CoreServiceManager {
 
         NotificationManager.showNotification(currentConfig)
         CoreNativeManager.reconcileBrowserDialer(dialerAddr)
-        coreController.startLoop(result.content, tunFd)
+        runningProfileGuid = guid
+        policyRouteCallbacksEnabled.set(true)
+        try {
+            coreController.startLoop(result.content, tunFd)
+        } catch (e: Exception) {
+            policyRouteCallbacksEnabled.set(false)
+            runningProfileGuid = ""
+            throw e
+        }
 
         if (!coreController.isRunning) {
+            policyRouteCallbacksEnabled.set(false)
+            runningProfileGuid = ""
             error("Core failed to start")
         }
+
+        coreScope.launch { refreshFreshPolicyRoute() }
 
         if (browserDialer != null) {
             browserDialer!!.stop()
@@ -312,6 +387,9 @@ object CoreServiceManager {
      * @return True if the core was stopped successfully, false otherwise.
      */
     fun stopCoreLoop(): Boolean {
+        policyRouteCallbacksEnabled.set(false)
+        PolicyRouteCache.clear()
+        runningProfileGuid = ""
         val service = getService() ?: return false
 
         if (coreController.isRunning) {
@@ -461,6 +539,13 @@ object CoreServiceManager {
          * @return Always returns 0.
          */
         override fun onEmitStatus(l: Long, s: String?): Long {
+            return 0
+        }
+
+        override fun onBalancerTargetChanged(balancerTag: String?, target: String?): Long {
+            if (balancerTag == AppConfig.TAG_BALANCER) {
+                rememberFreshPolicyRoute(target)
+            }
             return 0
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -132,9 +132,9 @@ object CoreServiceManager {
      * Recreates the in-process Xray instance after Android changes the VPN's
      * underlying network. The VPN interface and service remain active.
      */
-    fun resetCoreNetworkState(previousNetworkKey: String?, newNetworkKey: String) {
+    fun resetCoreNetworkState(previousNetworkKey: String?, newNetworkKey: String, newNetworkHandle: Long) {
         networkTransitions.incrementAndGet()
-        PolicyRouteCache.setCurrentNetwork(newNetworkKey)
+        PolicyRouteCache.setCurrentNetwork(newNetworkKey, newNetworkHandle)
         if (!coreController.isRunning) {
             networkTransitions.decrementAndGet()
             return
@@ -180,8 +180,8 @@ object CoreServiceManager {
         }
     }
 
-    fun updateCoreNetworkIdentity(newNetworkKey: String) {
-        PolicyRouteCache.setCurrentNetwork(newNetworkKey)
+    fun updateCoreNetworkIdentity(newNetworkKey: String, newNetworkHandle: Long) {
+        PolicyRouteCache.setCurrentNetwork(newNetworkKey, newNetworkHandle)
         if (coreController.isRunning && policyRouteCallbacksEnabled.get()) {
             coreScope.launch { refreshFreshPolicyRoute() }
         }
@@ -212,8 +212,9 @@ object CoreServiceManager {
         if (!policyRouteCallbacksEnabled.get() || networkTransitions.get() != 0 ||
             update == null || update.profileGuid.isBlank() || update.outboundTag.isBlank()
         ) return
-        if (PolicyRouteCache.rememberCurrent(
-                PolicyRouteCache.snapshot(),
+        if (PolicyRouteCache.rememberObserved(
+                update.networkKey,
+                update.networkHandle,
                 update.profileGuid,
                 update.outboundTag,
             )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -14,8 +14,10 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.dto.OutboundTrafficStat
+import com.v2ray.ang.dto.PolicyRouteUpdate
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.extension.isComplexType
+import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.extension.toast
 import com.v2ray.ang.extension.toastError
 import com.v2ray.ang.handler.MmkvManager
@@ -50,6 +52,7 @@ object CoreServiceManager {
 
     private val coreController: CoreController = CoreNativeManager.newCoreController(CoreCallback())
     private val mMsgReceive = ReceiveMessageHandler()
+    private val mSystemEventReceive = SystemEventHandler()
     private var currentConfig: ProfileItem? = null
     private var processFinder: XrayProcessFinder? = null
     private var browserDialer: IDialerService? = null
@@ -205,6 +208,20 @@ object CoreServiceManager {
         }
     }
 
+    private fun rememberProbedPolicyRoute(update: PolicyRouteUpdate?) {
+        if (!policyRouteCallbacksEnabled.get() || networkTransitions.get() != 0 ||
+            update == null || update.profileGuid.isBlank() || update.outboundTag.isBlank()
+        ) return
+        if (PolicyRouteCache.rememberCurrent(
+                PolicyRouteCache.snapshot(),
+                update.profileGuid,
+                update.outboundTag,
+            )
+        ) {
+            LogUtil.i(AppConfig.TAG, "Policy route cache updated from batch observatory result")
+        }
+    }
+
     /**
      * Gets the name of the currently running server.
      * @return The name of the running server.
@@ -337,11 +354,21 @@ object CoreServiceManager {
             error(result.errorMessage.ifBlank { "Failed to get V2Ray config" })
         }
 
-        val mFilter = IntentFilter(AppConfig.BROADCAST_ACTION_SERVICE)
-        mFilter.addAction(Intent.ACTION_SCREEN_ON)
-        mFilter.addAction(Intent.ACTION_SCREEN_OFF)
-        mFilter.addAction(Intent.ACTION_USER_PRESENT)
-        ContextCompat.registerReceiver(service, mMsgReceive, mFilter, Utils.receiverFlags())
+        // Commands and probe results originate only from another process of
+        // this application. Keeping this receiver non-exported prevents other
+        // apps from forging control or policy-route cache messages.
+        ContextCompat.registerReceiver(
+            service,
+            mMsgReceive,
+            IntentFilter(AppConfig.BROADCAST_ACTION_SERVICE),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+        val systemFilter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_SCREEN_OFF)
+            addAction(Intent.ACTION_USER_PRESENT)
+        }
+        ContextCompat.registerReceiver(service, mSystemEventReceive, systemFilter, Utils.receiverFlags())
 
         currentConfig = config
         var tunFd = vpnInterface?.fd ?: 0
@@ -373,7 +400,6 @@ object CoreServiceManager {
         }
 
         coreScope.launch { refreshFreshPolicyRoute() }
-
         if (browserDialer != null) {
             browserDialer!!.stop()
             browserDialer = null
@@ -426,6 +452,11 @@ object CoreServiceManager {
             service.unregisterReceiver(mMsgReceive)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to unregister receiver", e)
+        }
+        try {
+            service.unregisterReceiver(mSystemEventReceive)
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to unregister system receiver", e)
         }
 
         return true
@@ -598,13 +629,12 @@ object CoreServiceManager {
     }
 
     /**
-     * Broadcast receiver for handling messages sent to the service.
-     * Handles registration, service control, and screen events.
+     * App-private receiver for control messages sent to the service.
      */
     private class ReceiveMessageHandler : BroadcastReceiver() {
         /**
          * Handles received broadcast messages.
-         * Processes service control messages and screen state changes.
+         * Processes service control messages from another app process.
          * @param ctx The context in which the receiver is running.
          * @param intent The intent being received.
          */
@@ -642,8 +672,17 @@ object CoreServiceManager {
                 AppConfig.MSG_MEASURE_DELAY -> {
                     measureV2rayDelay()
                 }
+
+                AppConfig.MSG_POLICY_ROUTE_OBSERVED -> {
+                    rememberProbedPolicyRoute(intent.serializable("content"))
+                }
             }
 
+        }
+    }
+
+    private class SystemEventHandler : BroadcastReceiver() {
+        override fun onReceive(ctx: Context?, intent: Intent?) {
             when (intent?.action) {
                 Intent.ACTION_SCREEN_OFF -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Screen off")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -116,6 +116,23 @@ object CoreServiceManager {
     fun isRunning() = coreController.isRunning
 
     /**
+     * Recreates the in-process Xray instance after Android changes the VPN's
+     * underlying network. The VPN interface and service remain active.
+     */
+    fun resetCoreNetworkState() {
+        if (!coreController.isRunning) return
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                coreController.resetNetworkState()
+                LogUtil.i(AppConfig.TAG, "StartCore-Manager: Core network state reset")
+            } catch (e: Exception) {
+                LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to reset core network state", e)
+            }
+        }
+    }
+
+    /**
      * Gets the name of the currently running server.
      * @return The name of the running server.
      */

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -157,7 +157,17 @@ object CoreServiceManager {
                             if (warmTarget.isNotEmpty()) " with cached policy route" else "",
                     )
                 } catch (e: Exception) {
-                    LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to reset core network state", e)
+                    policyRouteCallbacksEnabled.set(false)
+                    LogUtil.e(
+                        AppConfig.TAG,
+                        "StartCore-Manager: Core network reset and recovery failed; keeping VPN fail-closed",
+                        e,
+                    )
+                    getService()?.let { service ->
+                        val message = service.getString(R.string.notification_core_recovery_failed)
+                        MessageUtil.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+                        NotificationManager.showCoreFailure(message)
+                    }
                 } finally {
                     if (networkTransitions.decrementAndGet() == 0 && policyRouteCallbacksEnabled.get()) {
                         refreshFreshPolicyRoute()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/OutboundProbeConfigBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/OutboundProbeConfigBuilder.kt
@@ -1,0 +1,255 @@
+package com.v2ray.ang.core
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.v2ray.ang.dto.OutboundProbeCandidate
+import com.v2ray.ang.dto.OutboundProbePlan
+import com.v2ray.ang.dto.OutboundProbeProfilePlan
+import com.v2ray.ang.util.JsonUtil
+
+/**
+ * Combines independently generated speed-test configurations into one core.
+ *
+ * Every source gets a private tag namespace. Only outbound definitions and the
+ * primary policy-group balancer are retained: the one-shot observatory probes
+ * tagged outbound handlers directly, so unrelated routing and inbound state
+ * must not be allowed to affect another profile in the same batch.
+ */
+object OutboundProbeConfigBuilder {
+    data class Source(val guid: String, val content: String)
+
+    fun build(
+        sources: List<Source>,
+        destination: String,
+        timeout: String = DEFAULT_PROBE_TIMEOUT,
+        samples: Int = 1,
+    ): OutboundProbePlan {
+        require(destination.isNotBlank()) { "probe destination is empty" }
+        require(samples > 0) { "probe sample count must be positive" }
+
+        val mergedOutbounds = JsonArray()
+        val mergedBalancers = JsonArray()
+        val profiles = mutableListOf<OutboundProbeProfilePlan>()
+        val failedGuids = mutableListOf<String>()
+        var batchSamples = samples
+        var batchTimeout = timeout
+        var leastLoadHttpMethod: String? = null
+
+        sources.distinctBy { it.guid }.forEachIndexed { index, source ->
+            val root = JsonUtil.parseString(source.content)
+            val outbounds = root?.array("outbounds")
+            if (outbounds == null || outbounds.size() == 0) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+
+            val namespace = "probe-$index-"
+            val tagMap = linkedMapOf<String, String>()
+            val outboundObjects = outbounds.mapIndexedNotNull { outboundIndex, element ->
+                element.takeIf { it.isJsonObject }?.asJsonObject?.deepCopy()?.also { outbound ->
+                    val originalTag = outbound.string("tag") ?: "outbound-$outboundIndex"
+                    val probeTag = "$namespace$originalTag"
+                    tagMap[originalTag] = probeTag
+                    outbound.addProperty("tag", probeTag)
+                }
+            }
+            if (outboundObjects.isEmpty()) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+            outboundObjects.forEach { outbound ->
+                remapOutboundReferences(outbound, tagMap)
+                mergedOutbounds.add(outbound)
+            }
+
+            val routing = root.obj("routing")
+            val primaryBalancerTag = routing?.array("rules")
+                ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
+                ?.lastOrNull { it.isCatchAllRule() && it.string("balancerTag") != null }
+                ?.string("balancerTag")
+                ?: routing?.array("rules")
+                    ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
+                    ?.firstOrNull { it.string("balancerTag") != null }
+                    ?.string("balancerTag")
+
+            val originalBalancer = primaryBalancerTag?.let { wanted ->
+                routing?.array("balancers")
+                    ?.mapNotNull { it.takeIf { balancer -> balancer.isJsonObject }?.asJsonObject }
+                    ?.firstOrNull { it.string("tag") == wanted }
+            }
+
+            val profile = if (originalBalancer != null) {
+                if (originalBalancer.obj("strategy")?.string("type")
+                        ?.equals("leastLoad", ignoreCase = true) == true
+                ) {
+                    root.obj("burstObservatory")?.obj("pingConfig")?.let { pingConfig ->
+                        batchSamples = maxOf(batchSamples, pingConfig.positiveInt("sampling") ?: 1)
+                        batchTimeout = longerDuration(
+                            batchTimeout,
+                            pingConfig.string("timeout") ?: DEFAULT_PROBE_TIMEOUT,
+                        )
+                        val method = pingConfig.string("httpMethod")
+                            ?.uppercase()
+                            ?.takeIf { it == "GET" || it == "HEAD" }
+                            ?: "HEAD"
+                        leastLoadHttpMethod = when {
+                            leastLoadHttpMethod == null -> method
+                            leastLoadHttpMethod == "GET" || method == "GET" -> "GET"
+                            else -> "HEAD"
+                        }
+                    }
+                }
+                buildPolicyProfile(
+                    source.guid,
+                    namespace,
+                    originalBalancer,
+                    tagMap,
+                    mergedBalancers,
+                )
+            } else {
+                val routedTag = routing?.array("rules")
+                    ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
+                    ?.lastOrNull {
+                        it.isCatchAllRule() &&
+                            it.string("outboundTag")?.let(tagMap::containsKey) == true
+                    }
+                    ?.string("outboundTag")
+                val runtimeTag = routedTag ?: tagMap.keys.first()
+                OutboundProbeProfilePlan(
+                    guid = source.guid,
+                    candidates = listOf(
+                        OutboundProbeCandidate(
+                            probeTag = tagMap.getValue(runtimeTag),
+                            runtimeTag = runtimeTag,
+                        )
+                    ),
+                )
+            }
+
+            if (profile == null || profile.candidates.isEmpty()) {
+                failedGuids += source.guid
+            } else {
+                profiles += profile
+            }
+        }
+
+        val root = JsonObject().apply {
+            add("log", JsonObject().apply { addProperty("loglevel", "warning") })
+            add("outbounds", mergedOutbounds)
+            add("routing", JsonObject().apply {
+                addProperty("domainStrategy", "AsIs")
+                add("rules", JsonArray())
+                if (mergedBalancers.size() > 0) add("balancers", mergedBalancers)
+            })
+            add("burstObservatory", JsonObject().apply {
+                add("subjectSelector", JsonArray())
+                add("pingConfig", JsonObject().apply {
+                    addProperty("destination", destination)
+                    addProperty("httpMethod", leastLoadHttpMethod ?: DEFAULT_HTTP_METHOD)
+                    addProperty("interval", "1h")
+                    addProperty("sampling", batchSamples)
+                    addProperty("timeout", batchTimeout)
+                })
+            })
+        }
+
+        return OutboundProbePlan(
+            content = JsonUtil.toJsonPretty(root).orEmpty(),
+            profiles = profiles,
+            failedGuids = failedGuids,
+            samples = batchSamples,
+        )
+    }
+
+    private fun buildPolicyProfile(
+        guid: String,
+        namespace: String,
+        sourceBalancer: JsonObject,
+        tagMap: Map<String, String>,
+        mergedBalancers: JsonArray,
+    ): OutboundProbeProfilePlan? {
+        val selectors = sourceBalancer.array("selector")
+            ?.mapNotNull { it.takeIf { selector -> selector.isJsonPrimitive }?.asString }
+            .orEmpty()
+        val candidates = tagMap.entries
+            .filter { (runtimeTag, _) -> selectors.any(runtimeTag::startsWith) }
+            .map { (runtimeTag, probeTag) -> OutboundProbeCandidate(probeTag, runtimeTag) }
+        if (candidates.isEmpty()) return null
+
+        val balancer = sourceBalancer.deepCopy()
+        val probeBalancerTag = "$namespace${sourceBalancer.string("tag").orEmpty()}"
+        balancer.addProperty("tag", probeBalancerTag)
+        balancer.add("selector", JsonArray().apply {
+            selectors.forEach { add("$namespace$it") }
+        })
+        sourceBalancer.string("fallbackTag")?.let { fallback ->
+            tagMap[fallback]?.let { balancer.addProperty("fallbackTag", it) }
+                ?: balancer.remove("fallbackTag")
+        }
+        mergedBalancers.add(balancer)
+        return OutboundProbeProfilePlan(guid, candidates, probeBalancerTag)
+    }
+
+    private fun remapOutboundReferences(outbound: JsonObject, tagMap: Map<String, String>) {
+        outbound.obj("streamSettings")
+            ?.obj("sockopt")
+            ?.let { sockopt ->
+                sockopt.string("dialerProxy")?.let { old ->
+                    tagMap[old]?.let { sockopt.addProperty("dialerProxy", it) }
+                }
+            }
+        outbound.obj("proxySettings")?.let { proxySettings ->
+            proxySettings.string("tag")?.let { old ->
+                tagMap[old]?.let { proxySettings.addProperty("tag", it) }
+            }
+        }
+    }
+
+    private fun JsonObject.obj(name: String): JsonObject? =
+        get(name)?.takeIf { it.isJsonObject }?.asJsonObject
+
+    private fun JsonObject.array(name: String): JsonArray? =
+        get(name)?.takeIf { it.isJsonArray }?.asJsonArray
+
+    private fun JsonObject.string(name: String): String? =
+        get(name)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+
+    private fun JsonObject.positiveInt(name: String): Int? =
+        get(name)?.takeIf { it.isJsonPrimitive }
+            ?.runCatching { asInt }
+            ?.getOrNull()
+            ?.takeIf { it > 0 }
+
+    private fun longerDuration(first: String, second: String): String {
+        val firstMillis = durationMillis(first) ?: return second
+        val secondMillis = durationMillis(second) ?: return first
+        return if (secondMillis > firstMillis) second else first
+    }
+
+    private fun durationMillis(value: String): Long? {
+        val match = DURATION_PATTERN.matchEntire(value.trim()) ?: return null
+        val amount = match.groupValues[1].toLongOrNull() ?: return null
+        val multiplier = when (match.groupValues[2]) {
+            "ms" -> 1L
+            "s" -> 1_000L
+            "m" -> 60_000L
+            "h" -> 3_600_000L
+            else -> return null
+        }
+        return if (amount <= Long.MAX_VALUE / multiplier) amount * multiplier else Long.MAX_VALUE
+    }
+
+    private fun JsonObject.isCatchAllRule(): Boolean {
+        val constrainedFields = listOf(
+            "domain", "ip", "port", "sourcePort", "source", "user", "inboundTag",
+            "protocol", "attrs", "process",
+        )
+        if (constrainedFields.any(::has)) return false
+        val network = string("network")
+        return network == null || network == "tcp,udp" || network == "tcp, udp"
+    }
+
+    private val DURATION_PATTERN = Regex("""([1-9]\d*)(ms|s|m|h)""")
+    private const val DEFAULT_HTTP_METHOD = "GET"
+    private const val DEFAULT_PROBE_TIMEOUT = "5s"
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/OutboundProbeConfigBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/OutboundProbeConfigBuilder.kt
@@ -44,42 +44,92 @@ object OutboundProbeConfigBuilder {
             }
 
             val namespace = "probe-$index-"
-            val tagMap = linkedMapOf<String, String>()
-            val outboundObjects = outbounds.mapIndexedNotNull { outboundIndex, element ->
-                element.takeIf { it.isJsonObject }?.asJsonObject?.deepCopy()?.also { outbound ->
-                    val originalTag = outbound.string("tag") ?: "outbound-$outboundIndex"
-                    val probeTag = "$namespace$originalTag"
-                    tagMap[originalTag] = probeTag
-                    outbound.addProperty("tag", probeTag)
-                }
-            }
-            if (outboundObjects.isEmpty()) {
+            val outboundElements = outbounds.toList()
+            if (outboundElements.any { !it.isJsonObject }) {
                 failedGuids += source.guid
                 return@forEachIndexed
             }
-            outboundObjects.forEach { outbound ->
-                remapOutboundReferences(outbound, tagMap)
-                mergedOutbounds.add(outbound)
+            val outboundObjects = outboundElements.map { it.asJsonObject.deepCopy() }
+            val originalTags = outboundObjects.mapIndexed { outboundIndex, outbound ->
+                outbound.string("tag") ?: "outbound-$outboundIndex"
+            }
+            if (originalTags.toSet().size != originalTags.size) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+
+            val tagMap = linkedMapOf<String, String>()
+            outboundObjects.forEachIndexed { outboundIndex, outbound ->
+                val originalTag = originalTags[outboundIndex]
+                val probeTag = "$namespace$originalTag"
+                tagMap[originalTag] = probeTag
+                outbound.addProperty("tag", probeTag)
+            }
+            if (outboundObjects.any { !remapOutboundReferences(it, tagMap) }) {
+                failedGuids += source.guid
+                return@forEachIndexed
             }
 
             val routing = root.obj("routing")
-            val primaryBalancerTag = routing?.array("rules")
+            val routingRules = routing?.array("rules")
                 ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
-                ?.lastOrNull { it.isCatchAllRule() && it.string("balancerTag") != null }
+                .orEmpty()
+            val primaryBalancerTag = routingRules
+                .lastOrNull { it.isCatchAllRule() && it.string("balancerTag") != null }
                 ?.string("balancerTag")
-                ?: routing?.array("rules")
-                    ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
-                    ?.firstOrNull { it.string("balancerTag") != null }
-                    ?.string("balancerTag")
 
             val originalBalancer = primaryBalancerTag?.let { wanted ->
                 routing?.array("balancers")
                     ?.mapNotNull { it.takeIf { balancer -> balancer.isJsonObject }?.asJsonObject }
                     ?.firstOrNull { it.string("tag") == wanted }
             }
+            if ((primaryBalancerTag != null && originalBalancer == null) ||
+                (primaryBalancerTag == null && routingRules.any { it.string("balancerTag") != null })
+            ) {
+                // Direct batch probing cannot reproduce conditional routing.
+                // Accept only the catch-all policy-group form emitted by v2rayNG.
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
 
+            val localBalancers = JsonArray()
             val profile = if (originalBalancer != null) {
-                if (originalBalancer.obj("strategy")?.string("type")
+                buildPolicyProfile(
+                    source.guid,
+                    namespace,
+                    originalBalancer,
+                    tagMap,
+                    localBalancers,
+                )
+            } else {
+                val catchAllOutbound = routingRules.lastOrNull {
+                    it.isCatchAllRule() && it.string("outboundTag") != null
+                }?.string("outboundTag")
+                if (catchAllOutbound != null && catchAllOutbound !in tagMap) {
+                    failedGuids += source.guid
+                    return@forEachIndexed
+                }
+                if (catchAllOutbound == null && routingRules.isNotEmpty()) {
+                    failedGuids += source.guid
+                    return@forEachIndexed
+                }
+                val routedTag = catchAllOutbound
+                val runtimeTag = routedTag ?: tagMap.keys.first()
+                OutboundProbeProfilePlan(
+                    guid = source.guid,
+                    candidates = listOf(
+                        OutboundProbeCandidate(
+                            probeTag = tagMap.getValue(runtimeTag),
+                            runtimeTag = runtimeTag,
+                        )
+                    ),
+                )
+            }
+
+            if (profile == null || profile.candidates.isEmpty()) {
+                failedGuids += source.guid
+            } else {
+                if (originalBalancer?.obj("strategy")?.string("type")
                         ?.equals("leastLoad", ignoreCase = true) == true
                 ) {
                     root.obj("burstObservatory")?.obj("pingConfig")?.let { pingConfig ->
@@ -99,36 +149,8 @@ object OutboundProbeConfigBuilder {
                         }
                     }
                 }
-                buildPolicyProfile(
-                    source.guid,
-                    namespace,
-                    originalBalancer,
-                    tagMap,
-                    mergedBalancers,
-                )
-            } else {
-                val routedTag = routing?.array("rules")
-                    ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
-                    ?.lastOrNull {
-                        it.isCatchAllRule() &&
-                            it.string("outboundTag")?.let(tagMap::containsKey) == true
-                    }
-                    ?.string("outboundTag")
-                val runtimeTag = routedTag ?: tagMap.keys.first()
-                OutboundProbeProfilePlan(
-                    guid = source.guid,
-                    candidates = listOf(
-                        OutboundProbeCandidate(
-                            probeTag = tagMap.getValue(runtimeTag),
-                            runtimeTag = runtimeTag,
-                        )
-                    ),
-                )
-            }
-
-            if (profile == null || profile.candidates.isEmpty()) {
-                failedGuids += source.guid
-            } else {
+                outboundObjects.forEach { mergedOutbounds.add(it) }
+                localBalancers.forEach { mergedBalancers.add(it) }
                 profiles += profile
             }
         }
@@ -168,6 +190,17 @@ object OutboundProbeConfigBuilder {
         tagMap: Map<String, String>,
         mergedBalancers: JsonArray,
     ): OutboundProbeProfilePlan? {
+        val strategy = sourceBalancer.obj("strategy") ?: return null
+        val strategyType = strategy.string("type")
+        if (strategyType?.equals("leastPing", ignoreCase = true) != true &&
+            strategyType?.equals("leastLoad", ignoreCase = true) != true
+        ) return null
+        if ((strategy.obj("settings")?.array("costs")?.size() ?: 0) > 0) {
+            // Cost matchers refer to original outbound tags. Silently carrying
+            // them into a namespaced batch would change leastLoad semantics.
+            return null
+        }
+
         val selectors = sourceBalancer.array("selector")
             ?.mapNotNull { it.takeIf { selector -> selector.isJsonPrimitive }?.asString }
             .orEmpty()
@@ -183,26 +216,33 @@ object OutboundProbeConfigBuilder {
             selectors.forEach { add("$namespace$it") }
         })
         sourceBalancer.string("fallbackTag")?.let { fallback ->
-            tagMap[fallback]?.let { balancer.addProperty("fallbackTag", it) }
-                ?: balancer.remove("fallbackTag")
+            val mappedFallback = tagMap[fallback] ?: return null
+            balancer.addProperty("fallbackTag", mappedFallback)
         }
         mergedBalancers.add(balancer)
         return OutboundProbeProfilePlan(guid, candidates, probeBalancerTag)
     }
 
-    private fun remapOutboundReferences(outbound: JsonObject, tagMap: Map<String, String>) {
+    private fun remapOutboundReferences(outbound: JsonObject, tagMap: Map<String, String>): Boolean {
         outbound.obj("streamSettings")
             ?.obj("sockopt")
             ?.let { sockopt ->
                 sockopt.string("dialerProxy")?.let { old ->
-                    tagMap[old]?.let { sockopt.addProperty("dialerProxy", it) }
+                    if (old.isNotBlank()) {
+                        val mapped = tagMap[old] ?: return false
+                        sockopt.addProperty("dialerProxy", mapped)
+                    }
                 }
             }
         outbound.obj("proxySettings")?.let { proxySettings ->
             proxySettings.string("tag")?.let { old ->
-                tagMap[old]?.let { proxySettings.addProperty("tag", it) }
+                if (old.isNotBlank()) {
+                    val mapped = tagMap[old] ?: return false
+                    proxySettings.addProperty("tag", mapped)
+                }
             }
         }
+        return true
     }
 
     private fun JsonObject.obj(name: String): JsonObject? =

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyRouteCache.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyRouteCache.kt
@@ -6,18 +6,24 @@ package com.v2ray.ang.core
  * it, while an in-place core reset can carry it across a network transition.
  */
 object PolicyRouteCache {
-    data class Snapshot(val networkKey: String?, val generation: Long)
+    data class Snapshot(
+        val networkKey: String?,
+        val networkHandle: Long?,
+        val generation: Long,
+    )
 
     private val routes = mutableMapOf<String, MutableMap<String, String>>()
     private var currentNetworkKey: String? = null
+    private var currentNetworkHandle: Long? = null
     private var generation = 0L
 
     @Synchronized
-    fun snapshot(): Snapshot = Snapshot(currentNetworkKey, generation)
+    fun snapshot(): Snapshot = Snapshot(currentNetworkKey, currentNetworkHandle, generation)
 
     @Synchronized
-    fun setCurrentNetwork(networkKey: String) {
+    fun setCurrentNetwork(networkKey: String, networkHandle: Long) {
         currentNetworkKey = networkKey
+        currentNetworkHandle = networkHandle
     }
 
     @Synchronized
@@ -42,8 +48,24 @@ object PolicyRouteCache {
     @Synchronized
     fun rememberCurrent(snapshot: Snapshot, profileGuid: String, outboundTag: String): Boolean {
         if (snapshot.networkKey.isNullOrBlank() || profileGuid.isBlank() || outboundTag.isBlank()) return false
-        if (snapshot != Snapshot(currentNetworkKey, generation)) return false
+        if (snapshot != Snapshot(currentNetworkKey, currentNetworkHandle, generation)) return false
         val networkRoutes = routes.getOrPut(snapshot.networkKey) { mutableMapOf() }
+        if (networkRoutes[profileGuid] == outboundTag) return false
+        networkRoutes[profileGuid] = outboundTag
+        return true
+    }
+
+    /** Accepts a result from another process only for the exact underlay that measured it. */
+    @Synchronized
+    fun rememberObserved(
+        networkKey: String,
+        networkHandle: Long,
+        profileGuid: String,
+        outboundTag: String,
+    ): Boolean {
+        if (networkKey != currentNetworkKey || networkHandle != currentNetworkHandle) return false
+        if (profileGuid.isBlank() || outboundTag.isBlank()) return false
+        val networkRoutes = routes.getOrPut(networkKey) { mutableMapOf() }
         if (networkRoutes[profileGuid] == outboundTag) return false
         networkRoutes[profileGuid] = outboundTag
         return true
@@ -53,6 +75,7 @@ object PolicyRouteCache {
     fun clear() {
         routes.clear()
         currentNetworkKey = null
+        currentNetworkHandle = null
         generation++
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyRouteCache.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyRouteCache.kt
@@ -1,0 +1,58 @@
+package com.v2ray.ang.core
+
+/**
+ * Process-local memory of the last policy-group outbound that worked on each
+ * underlay. Nothing is persisted to disk: explicit service stop/restart clears
+ * it, while an in-place core reset can carry it across a network transition.
+ */
+object PolicyRouteCache {
+    data class Snapshot(val networkKey: String?, val generation: Long)
+
+    private val routes = mutableMapOf<String, MutableMap<String, String>>()
+    private var currentNetworkKey: String? = null
+    private var generation = 0L
+
+    @Synchronized
+    fun snapshot(): Snapshot = Snapshot(currentNetworkKey, generation)
+
+    @Synchronized
+    fun setCurrentNetwork(networkKey: String) {
+        currentNetworkKey = networkKey
+    }
+
+    @Synchronized
+    fun lookup(networkKey: String?, profileGuid: String): String? {
+        if (networkKey.isNullOrBlank() || profileGuid.isBlank()) return null
+        return routes[networkKey]?.get(profileGuid)
+    }
+
+    @Synchronized
+    fun remember(
+        networkKey: String?,
+        profileGuid: String,
+        outboundTag: String,
+        expectedGeneration: Long? = null,
+    ): Boolean {
+        if (networkKey.isNullOrBlank() || profileGuid.isBlank() || outboundTag.isBlank()) return false
+        if (expectedGeneration != null && expectedGeneration != generation) return false
+        routes.getOrPut(networkKey) { mutableMapOf() }[profileGuid] = outboundTag
+        return true
+    }
+
+    @Synchronized
+    fun rememberCurrent(snapshot: Snapshot, profileGuid: String, outboundTag: String): Boolean {
+        if (snapshot.networkKey.isNullOrBlank() || profileGuid.isBlank() || outboundTag.isBlank()) return false
+        if (snapshot != Snapshot(currentNetworkKey, generation)) return false
+        val networkRoutes = routes.getOrPut(snapshot.networkKey) { mutableMapOf() }
+        if (networkRoutes[profileGuid] == outboundTag) return false
+        networkRoutes[profileGuid] = outboundTag
+        return true
+    }
+
+    @Synchronized
+    fun clear() {
+        routes.clear()
+        currentNetworkKey = null
+        generation++
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/OutboundProbePlan.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/OutboundProbePlan.kt
@@ -1,0 +1,28 @@
+package com.v2ray.ang.dto
+
+/** One original runtime outbound represented by a uniquely tagged batch outbound. */
+data class OutboundProbeCandidate(
+    val probeTag: String,
+    val runtimeTag: String,
+)
+
+/** Mapping needed to turn native batch snapshots back into one UI result per profile. */
+data class OutboundProbeProfilePlan(
+    val guid: String,
+    val candidates: List<OutboundProbeCandidate>,
+    val balancerTag: String? = null,
+)
+
+/** One-core configuration and its profile/outbound mappings. */
+data class OutboundProbePlan(
+    val content: String,
+    val profiles: List<OutboundProbeProfilePlan>,
+    val failedGuids: List<String>,
+    val samples: Int,
+) {
+    val outboundTags: List<String>
+        get() = profiles.flatMap { it.candidates }.map { it.probeTag }.distinct()
+
+    val balancerTags: List<String>
+        get() = profiles.mapNotNull { it.balancerTag }.distinct()
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/PolicyRouteUpdate.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/PolicyRouteUpdate.kt
@@ -6,4 +6,6 @@ import java.io.Serializable
 data class PolicyRouteUpdate(
     val profileGuid: String,
     val outboundTag: String,
+    val networkKey: String,
+    val networkHandle: Long,
 ) : Serializable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/PolicyRouteUpdate.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/PolicyRouteUpdate.kt
@@ -1,0 +1,9 @@
+package com.v2ray.ang.dto
+
+import java.io.Serializable
+
+/** A viable policy-group route measured by the dedicated probe process. */
+data class PolicyRouteUpdate(
+    val profileGuid: String,
+    val outboundTag: String,
+) : Serializable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
@@ -6,7 +6,11 @@ sealed class RealPingEvent {
     data class Progress(val text: String) : RealPingEvent()
 
     /** A single server result is available. */
-    data class Result(val guid: String, val delayMillis: Long) : RealPingEvent()
+    data class Result(
+        val guid: String,
+        val delayMillis: Long,
+        val viableOutboundTag: String = "",
+    ) : RealPingEvent()
 
     /** The entire batch has finished or been cancelled. */
     data class Finish(val status: String) : RealPingEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
@@ -10,6 +10,8 @@ sealed class RealPingEvent {
         val guid: String,
         val delayMillis: Long,
         val viableOutboundTag: String = "",
+        val networkKey: String? = null,
+        val networkHandle: Long? = null,
     ) : RealPingEvent()
 
     /** The entire batch has finished or been cancelled. */

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/extension/_Ext.kt
@@ -63,6 +63,15 @@ fun Context.toastError(message: Int) {
 }
 
 /**
+ * Shows a long error toast message with the given resource ID.
+ *
+ * @param message The resource ID of the message to show.
+ */
+fun Context.toastErrorLong(message: Int) {
+    Toasty.error(this, message, Toast.LENGTH_LONG, true).show()
+}
+
+/**
  * Shows a toast message with the given text.
  *
  * @param message The text of the message to show.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -116,6 +116,29 @@ object NotificationManager {
     }
 
     /**
+     * Keeps the foreground VPN notification visible when Xray cannot be recovered.
+     * The VPN interface remains established so Android continues routing traffic into
+     * the nonfunctional tunnel instead of silently falling back to the physical network.
+     */
+    fun showCoreFailure(message: String) {
+        val service = getService() ?: return
+        speedNotificationJob?.cancel()
+        speedNotificationJob = null
+
+        val builder = mBuilder ?: run {
+            showNotification(null)
+            mBuilder
+        } ?: return
+
+        builder
+            .setSmallIcon(R.drawable.ic_stat_name)
+            .setContentTitle(service.getString(R.string.toast_services_failure))
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+        getNotificationManager()?.notify(NOTIFICATION_ID, builder.build())
+    }
+
+    /**
      * Cancels the notification.
      */
     fun cancelNotification() {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -24,7 +24,7 @@ class CoreTestService : Service() {
 
     @Volatile
     private var activeWorker: RealPingWorkerService? = null
-    private val batchStarted = AtomicBoolean(false)
+    private var batchStarted = false
     private val batchFinished = AtomicBoolean(false)
 
     /**
@@ -78,7 +78,6 @@ class CoreTestService : Service() {
 
         when (message.key) {
             AppConfig.MSG_MEASURE_CONFIG_START -> handleMeasureStart(message, startId)
-            AppConfig.MSG_MEASURE_CONFIG_CANCEL -> handleMeasureCancel()
             else -> {
                 NotificationHelper.stopForeground(this); stopSelf(startId)
             }
@@ -87,13 +86,14 @@ class CoreTestService : Service() {
     }
 
     private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
-        if (!batchStarted.compareAndSet(false, true)) {
+        if (batchStarted) {
             // This process is intentionally single-use. Even a request racing
             // with service teardown must wait for Android to create the next
             // :OutboundProbe process instead of starting a second native core.
             LogUtil.w(AppConfig.TAG, "CoreTestService ignored a second batch in its disposable process")
             return
         }
+        batchStarted = true
         LogUtil.i(AppConfig.TAG, "CoreTestService starting batch for subscription ${message.subscriptionId}")
 
         NotificationHelper.startForeground(
@@ -110,7 +110,6 @@ class CoreTestService : Service() {
         }
 
         if (guidsList.isNotEmpty()) {
-            batchFinished.set(false)
             activeWorker = RealPingWorkerService(
                 context = this,
                 guids = guidsList,
@@ -138,11 +137,18 @@ class CoreTestService : Service() {
 
             is RealPingEvent.Result -> {
                 MmkvManager.encodeServerTestDelayMillis(event.guid, event.delayMillis)
-                if (event.viableOutboundTag.isNotEmpty()) {
+                val networkKey = event.networkKey
+                val networkHandle = event.networkHandle
+                if (event.viableOutboundTag.isNotEmpty() && networkKey != null && networkHandle != null) {
                     MessageUtil.sendMsg2Service(
                         this,
                         AppConfig.MSG_POLICY_ROUTE_OBSERVED,
-                        PolicyRouteUpdate(event.guid, event.viableOutboundTag),
+                        PolicyRouteUpdate(
+                            event.guid,
+                            event.viableOutboundTag,
+                            networkKey,
+                            networkHandle,
+                        ),
                     )
                 }
                 MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, event.guid)
@@ -158,11 +164,4 @@ class CoreTestService : Service() {
         }
     }
 
-    private fun handleMeasureCancel() {
-        LogUtil.i(AppConfig.TAG, "CoreTestService received cancel message")
-        activeWorker?.cancel()
-        activeWorker = null
-        NotificationHelper.stopForeground(this)
-        stopSelf()
-    }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -24,6 +24,8 @@ class CoreTestService : Service() {
 
     @Volatile
     private var activeWorker: RealPingWorkerService? = null
+    @Volatile
+    private var replacementRequested = false
     private var batchStarted = false
     private val batchFinished = AtomicBoolean(false)
 
@@ -51,7 +53,7 @@ class CoreTestService : Service() {
         LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed")
         activeWorker?.cancel()
         activeWorker = null
-        if (batchFinished.compareAndSet(false, true)) {
+        if (!replacementRequested && batchFinished.compareAndSet(false, true)) {
             MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "-1")
         }
         NotificationHelper.stopForeground(this)
@@ -76,32 +78,34 @@ class CoreTestService : Service() {
             return START_NOT_STICKY
         }
 
-        when (message.key) {
+        return when (message.key) {
             AppConfig.MSG_MEASURE_CONFIG_START -> handleMeasureStart(message, startId)
             else -> {
-                NotificationHelper.stopForeground(this); stopSelf(startId)
+                NotificationHelper.stopForeground(this)
+                stopSelf(startId)
+                START_NOT_STICKY
             }
         }
-        return START_NOT_STICKY
     }
 
-    private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
+    private fun handleMeasureStart(message: TestServiceMessage, startId: Int): Int {
         if (batchStarted) {
-            // This process is intentionally single-use. Even a request racing
-            // with service teardown must wait for Android to create the next
-            // :OutboundProbe process instead of starting a second native core.
-            LogUtil.w(AppConfig.TAG, "CoreTestService ignored a second batch in its disposable process")
-            return
+            replacementRequested = true
+            startProbeForeground()
+            LogUtil.i(AppConfig.TAG, "CoreTestService handing the next batch to a fresh process")
+
+            // The latest start intent must remain start-requested while this
+            // single-use process exits. Returning REDELIVER before killing the
+            // process makes Android replay that exact request in a new process;
+            // stopService followed by startForegroundService can instead lose
+            // the replacement to a lifecycle race in the dying service.
+            Handler(Looper.getMainLooper()).post { Process.killProcess(Process.myPid()) }
+            return START_REDELIVER_INTENT
         }
         batchStarted = true
         LogUtil.i(AppConfig.TAG, "CoreTestService starting batch for subscription ${message.subscriptionId}")
 
-        NotificationHelper.startForeground(
-            this,
-            NotificationChannelType.CORE_TEST,
-            getString(R.string.app_name),
-            getString(R.string.title_real_ping_all_server)
-        )
+        startProbeForeground()
 
         val guidsList = when {
             message.serverGuids.isNotEmpty() -> message.serverGuids
@@ -122,9 +126,22 @@ class CoreTestService : Service() {
             MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "0")
             stopSelf(startId)
         }
+        return START_NOT_STICKY
+    }
+
+    private fun startProbeForeground() {
+        NotificationHelper.startForeground(
+            this,
+            NotificationChannelType.CORE_TEST,
+            getString(R.string.app_name),
+            getString(R.string.title_real_ping_all_server)
+        )
     }
 
     private fun handleWorkerEvent(event: RealPingEvent) {
+        // Once another start has claimed the service, the old process must not
+        // publish stale progress or results while waiting for its final kill.
+        if (replacementRequested) return
         when (event) {
             is RealPingEvent.Progress -> {
                 NotificationHelper.updateNotification(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -3,10 +3,14 @@ package com.v2ray.ang.service
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import android.os.Handler
+import android.os.Looper
+import android.os.Process
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreNativeManager
 import com.v2ray.ang.dto.RealPingEvent
+import com.v2ray.ang.dto.PolicyRouteUpdate
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.enums.NotificationChannelType
 import com.v2ray.ang.extension.serializable
@@ -14,12 +18,14 @@ import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.NotificationHelper
-import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
 
 class CoreTestService : Service() {
 
-    // manage active batch workers so each batch is independent and cancellable
-    private val activeWorkers = Collections.synchronizedList(mutableListOf<RealPingWorkerService>())
+    @Volatile
+    private var activeWorker: RealPingWorkerService? = null
+    private val batchStarted = AtomicBoolean(false)
+    private val batchFinished = AtomicBoolean(false)
 
     /**
      * Initializes the V2Ray environment.
@@ -42,13 +48,18 @@ class CoreTestService : Service() {
      * Cleans up resources when the service is destroyed.
      */
     override fun onDestroy() {
-        LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed, cancelling ${activeWorkers.size} active workers")
-        // cancel any active workers
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
+        LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed")
+        activeWorker?.cancel()
+        activeWorker = null
+        if (batchFinished.compareAndSet(false, true)) {
+            MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "-1")
+        }
         NotificationHelper.stopForeground(this)
         super.onDestroy()
+        // This process exists solely to own one batch core. Discarding it after
+        // the service stops makes the one-core-per-process boundary explicit
+        // and prevents native singleton state from leaking into a later batch.
+        Handler(Looper.getMainLooper()).post { Process.killProcess(Process.myPid()) }
     }
 
     /**
@@ -76,7 +87,14 @@ class CoreTestService : Service() {
     }
 
     private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
-        LogUtil.i(AppConfig.TAG, "CoreTestService starting worker   subscription ${message.subscriptionId}")
+        if (!batchStarted.compareAndSet(false, true)) {
+            // This process is intentionally single-use. Even a request racing
+            // with service teardown must wait for Android to create the next
+            // :OutboundProbe process instead of starting a second native core.
+            LogUtil.w(AppConfig.TAG, "CoreTestService ignored a second batch in its disposable process")
+            return
+        }
+        LogUtil.i(AppConfig.TAG, "CoreTestService starting batch for subscription ${message.subscriptionId}")
 
         NotificationHelper.startForeground(
             this,
@@ -92,21 +110,22 @@ class CoreTestService : Service() {
         }
 
         if (guidsList.isNotEmpty()) {
-            lateinit var worker: RealPingWorkerService
-            worker = RealPingWorkerService(
+            batchFinished.set(false)
+            activeWorker = RealPingWorkerService(
                 context = this,
                 guids = guidsList,
-                onEvent = { event -> handleWorkerEvent(event) { activeWorkers.remove(worker) } }
+                onEvent = ::handleWorkerEvent,
             )
-            activeWorkers.add(worker)
-            worker.start()
+            activeWorker?.start()
         } else {
             NotificationHelper.stopForeground(this)
+            batchFinished.set(true)
+            MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "0")
             stopSelf(startId)
         }
     }
 
-    private fun handleWorkerEvent(event: RealPingEvent, onWorkerDone: () -> Unit) {
+    private fun handleWorkerEvent(event: RealPingEvent) {
         when (event) {
             is RealPingEvent.Progress -> {
                 NotificationHelper.updateNotification(
@@ -119,25 +138,30 @@ class CoreTestService : Service() {
 
             is RealPingEvent.Result -> {
                 MmkvManager.encodeServerTestDelayMillis(event.guid, event.delayMillis)
+                if (event.viableOutboundTag.isNotEmpty()) {
+                    MessageUtil.sendMsg2Service(
+                        this,
+                        AppConfig.MSG_POLICY_ROUTE_OBSERVED,
+                        PolicyRouteUpdate(event.guid, event.viableOutboundTag),
+                    )
+                }
                 MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, event.guid)
             }
 
             is RealPingEvent.Finish -> {
+                if (!batchFinished.compareAndSet(false, true)) return
                 MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, event.status)
-                onWorkerDone()
-                if (activeWorkers.isEmpty()) {
-                    NotificationHelper.stopForeground(this)
-                    stopSelf()
-                }
+                activeWorker = null
+                NotificationHelper.stopForeground(this)
+                stopSelf()
             }
         }
     }
 
     private fun handleMeasureCancel() {
-        LogUtil.i(AppConfig.TAG, "CoreTestService received cancel message, cancelling ${activeWorkers.size} active workers")
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
+        LogUtil.i(AppConfig.TAG, "CoreTestService received cancel message")
+        activeWorker?.cancel()
+        activeWorker = null
         NotificationHelper.stopForeground(this)
         stopSelf()
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -35,6 +35,7 @@ class CoreVpnService : VpnService(), ServiceControl {
     private lateinit var mInterface: ParcelFileDescriptor
     private var isRunning = false
     private var tun2SocksService: Tun2SocksControl? = null
+    private val underlyingNetworkState = UnderlyingNetworkStateTracker<Network>()
 
     /**destroy
      * Unfortunately registerDefaultNetworkCallback is going to return our VPN interface: https://android.googlesource.com/platform/frameworks/base/+/dda156ab0c5d66ad82bdcf76cda07cbc0a9c8a2e
@@ -60,15 +61,23 @@ class CoreVpnService : VpnService(), ServiceControl {
         object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 setUnderlyingNetworks(arrayOf(network))
+                if (underlyingNetworkState.onAvailable(network)) {
+                    LogUtil.i(AppConfig.TAG, "StartCore-VPN: Underlying network changed to $network")
+                    CoreServiceManager.resetCoreNetworkState()
+                }
             }
 
             override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
                 // it's a good idea to refresh capabilities
-                setUnderlyingNetworks(arrayOf(network))
+                if (underlyingNetworkState.isCurrent(network)) {
+                    setUnderlyingNetworks(arrayOf(network))
+                }
             }
 
             override fun onLost(network: Network) {
-                setUnderlyingNetworks(null)
+                if (underlyingNetworkState.onLost(network)) {
+                    setUnderlyingNetworks(null)
+                }
             }
         }
     }
@@ -269,6 +278,7 @@ class CoreVpnService : VpnService(), ServiceControl {
     private fun configurePlatformFeatures(builder: Builder) {
         // Android P (API 28) and above: Configure network callbacks
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            underlyingNetworkState.reset()
             try {
                 connectivity.requestNetwork(defaultNetworkRequest, defaultNetworkCallback)
             } catch (e: Exception) {
@@ -361,6 +371,7 @@ class CoreVpnService : VpnService(), ServiceControl {
             } catch (e: Exception) {
                 LogUtil.w(AppConfig.TAG, "StartCore-VPN: Failed to unregister callback", e)
             }
+            underlyingNetworkState.reset()
         }
 
         tun2SocksService?.stopTun2Socks()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -108,9 +108,9 @@ class CoreVpnService : VpnService(), ServiceControl {
 
         if (pendingNetworkReset == network) {
             pendingNetworkReset = null
-            CoreServiceManager.resetCoreNetworkState(previousNetworkKey, newNetworkKey)
+            CoreServiceManager.resetCoreNetworkState(previousNetworkKey, newNetworkKey, network.networkHandle)
         } else if (previousNetworkKey != newNetworkKey) {
-            CoreServiceManager.updateCoreNetworkIdentity(newNetworkKey)
+            CoreServiceManager.updateCoreNetworkIdentity(newNetworkKey, network.networkHandle)
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -21,6 +21,7 @@ import com.v2ray.ang.BuildConfig
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.contracts.Tun2SocksControl
 import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.core.PolicyRouteCache
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
@@ -36,6 +37,7 @@ class CoreVpnService : VpnService(), ServiceControl {
     private var isRunning = false
     private var tun2SocksService: Tun2SocksControl? = null
     private val underlyingNetworkState = UnderlyingNetworkStateTracker<Network>()
+    private var pendingNetworkReset: Network? = null
 
     /**destroy
      * Unfortunately registerDefaultNetworkCallback is going to return our VPN interface: https://android.googlesource.com/platform/frameworks/base/+/dda156ab0c5d66ad82bdcf76cda07cbc0a9c8a2e
@@ -58,27 +60,63 @@ class CoreVpnService : VpnService(), ServiceControl {
 
     @delegate:RequiresApi(Build.VERSION_CODES.P)
     private val defaultNetworkCallback by lazy {
-        object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                setUnderlyingNetworks(arrayOf(network))
-                if (underlyingNetworkState.onAvailable(network)) {
-                    LogUtil.i(AppConfig.TAG, "StartCore-VPN: Underlying network changed to $network")
-                    CoreServiceManager.resetCoreNetworkState()
-                }
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            NetworkIdentityResolver.canReadWifiIdentity(applicationContext)
+        ) {
+            object : ConnectivityManager.NetworkCallback(
+                ConnectivityManager.NetworkCallback.FLAG_INCLUDE_LOCATION_INFO
+            ) {
+                override fun onAvailable(network: Network) = handleNetworkAvailable(network)
 
-            override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
-                // it's a good idea to refresh capabilities
-                if (underlyingNetworkState.isCurrent(network)) {
-                    setUnderlyingNetworks(arrayOf(network))
-                }
-            }
+                override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) =
+                    handleNetworkCapabilitiesChanged(network, capabilities)
 
-            override fun onLost(network: Network) {
-                if (underlyingNetworkState.onLost(network)) {
-                    setUnderlyingNetworks(null)
-                }
+                override fun onLost(network: Network) = handleNetworkLost(network)
             }
+        } else {
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) = handleNetworkAvailable(network)
+
+                override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) =
+                    handleNetworkCapabilitiesChanged(network, capabilities)
+
+                override fun onLost(network: Network) = handleNetworkLost(network)
+            }
+        }
+    }
+
+    private fun handleNetworkAvailable(network: Network) {
+        setUnderlyingNetworks(arrayOf(network))
+        if (underlyingNetworkState.onAvailable(network)) {
+            pendingNetworkReset = network
+            LogUtil.i(AppConfig.TAG, "StartCore-VPN: Underlying network changed to $network")
+        }
+    }
+
+    private fun handleNetworkCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+        if (!underlyingNetworkState.isCurrent(network)) return
+
+        setUnderlyingNetworks(arrayOf(network))
+        val newNetworkKey = NetworkIdentityResolver.resolve(applicationContext, capabilities)
+        val previousNetworkKey = PolicyRouteCache.snapshot().networkKey
+        if (previousNetworkKey != newNetworkKey) {
+            LogUtil.i(
+                AppConfig.TAG,
+                "StartCore-VPN: Underlay identity resolved as ${newNetworkKey.substringBefore(':')}",
+            )
+        }
+
+        if (pendingNetworkReset == network) {
+            pendingNetworkReset = null
+            CoreServiceManager.resetCoreNetworkState(previousNetworkKey, newNetworkKey)
+        } else if (previousNetworkKey != newNetworkKey) {
+            CoreServiceManager.updateCoreNetworkIdentity(newNetworkKey)
+        }
+    }
+
+    private fun handleNetworkLost(network: Network) {
+        if (underlyingNetworkState.onLost(network)) {
+            setUnderlyingNetworks(null)
         }
     }
 
@@ -279,6 +317,7 @@ class CoreVpnService : VpnService(), ServiceControl {
         // Android P (API 28) and above: Configure network callbacks
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             underlyingNetworkState.reset()
+            pendingNetworkReset = null
             try {
                 connectivity.requestNetwork(defaultNetworkRequest, defaultNetworkCallback)
             } catch (e: Exception) {
@@ -372,6 +411,7 @@ class CoreVpnService : VpnService(), ServiceControl {
                 LogUtil.w(AppConfig.TAG, "StartCore-VPN: Failed to unregister callback", e)
             }
             underlyingNetworkState.reset()
+            pendingNetworkReset = null
         }
 
         tun2SocksService?.stopTun2Socks()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.service
 import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
@@ -14,6 +15,16 @@ import com.v2ray.ang.handler.MmkvManager
 
 /** Resolves reconnect-stable underlay identities without phone-state access. */
 object NetworkIdentityResolver {
+    data class Identity(val key: String, val networkHandle: Long)
+
+    /** Captures both the reconnect-stable cache key and this network instance. */
+    fun resolveCurrent(context: Context): Identity? {
+        val connectivity = context.getSystemService(ConnectivityManager::class.java) ?: return null
+        val network = connectivity.activeNetwork ?: return null
+        val capabilities = connectivity.getNetworkCapabilities(network) ?: return null
+        return Identity(resolve(context, capabilities), network.networkHandle)
+    }
+
     fun resolve(context: Context, capabilities: NetworkCapabilities): String = when {
         capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> {
             val rememberPerNetwork = canReadWifiIdentity(context)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
@@ -1,0 +1,88 @@
+package com.v2ray.ang.service
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.NetworkCapabilities
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.handler.MmkvManager
+
+/** Resolves reconnect-stable underlay identities without phone-state access. */
+object NetworkIdentityResolver {
+    fun resolve(context: Context, capabilities: NetworkCapabilities): String = when {
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> {
+            val rememberPerNetwork = canReadWifiIdentity(context)
+            wifiKey(
+                ssid = if (rememberPerNetwork) readSsid(context, capabilities) else null,
+                rememberPerNetwork = rememberPerNetwork,
+            )
+        }
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
+            val (networkOperator, simOperator) = readCellularOperators(context)
+            cellularKey(networkOperator, simOperator)
+        }
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ethernet"
+        else -> "other"
+    }
+
+    fun canReadWifiIdentity(context: Context): Boolean =
+        MmkvManager.decodeSettingsBool(AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK, false) &&
+            context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+
+    internal fun wifiKey(ssid: String?, rememberPerNetwork: Boolean = true): String {
+        if (!rememberPerNetwork) return "wifi"
+        val normalized = ssid
+            ?.trim()
+            ?.removeSurrounding("\"")
+            ?.takeIf { it.isNotBlank() && it != WifiManager.UNKNOWN_SSID }
+        return normalized?.let { "wifi:$it" } ?: "wifi"
+    }
+
+    internal fun cellularKey(networkOperator: String?, simOperator: String?): String {
+        val mccMnc = sequenceOf(networkOperator, simOperator)
+            .mapNotNull { it?.trim()?.takeIf(::isMccMnc) }
+            .firstOrNull()
+        return mccMnc?.let { "cellular:$it" } ?: "cellular"
+    }
+
+    private fun isMccMnc(value: String): Boolean =
+        value.length in 5..6 && value.all(Char::isDigit)
+
+    @Suppress("DEPRECATION")
+    private fun readSsid(context: Context, capabilities: NetworkCapabilities): String? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val capabilitiesSsid = (capabilities.transportInfo as? WifiInfo)?.ssid
+            if (wifiKey(capabilitiesSsid) != "wifi") return capabilitiesSsid
+        }
+        return runCatching {
+            context.applicationContext
+                .getSystemService(WifiManager::class.java)
+                ?.connectionInfo
+                ?.ssid
+        }.getOrNull()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun readCellularOperators(context: Context): Pair<String?, String?> {
+        val base = context.getSystemService(TelephonyManager::class.java)
+            ?: return null to null
+        val subscriptionId = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> SubscriptionManager.getActiveDataSubscriptionId()
+            else -> SubscriptionManager.getDefaultDataSubscriptionId()
+        }
+        val telephony = if (SubscriptionManager.isValidSubscriptionId(subscriptionId)) {
+            base.createForSubscriptionId(subscriptionId)
+        } else {
+            base
+        }
+        return telephony.networkOperator to telephony.simOperator
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
@@ -32,10 +32,21 @@ object NetworkIdentityResolver {
         else -> "other"
     }
 
-    fun canReadWifiIdentity(context: Context): Boolean =
-        MmkvManager.decodeSettingsBool(AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK, false) &&
+    fun canReadWifiIdentity(context: Context): Boolean {
+        val enabled = MmkvManager.decodeSettingsBool(
+            AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK,
+            false,
+        )
+        if (!enabled) return false
+
+        val permissionGranted =
             context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
-            PackageManager.PERMISSION_GRANTED
+                PackageManager.PERMISSION_GRANTED
+        if (!permissionGranted) {
+            MmkvManager.encodeSettings(AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK, false)
+        }
+        return permissionGranted
+    }
 
     internal fun wifiKey(ssid: String?, rememberPerNetwork: Boolean = true): String {
         if (!rememberPerNetwork) return "wifi"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -4,122 +4,174 @@ import android.content.Context
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.core.CoreConfigManager
 import com.v2ray.ang.core.CoreNativeManager
-import com.v2ray.ang.core.PolicyRouteCache
+import com.v2ray.ang.dto.OutboundProbePlan
+import com.v2ray.ang.dto.OutboundProbeProfilePlan
 import com.v2ray.ang.dto.RealPingEvent
-import com.v2ray.ang.enums.EConfigType
-import com.v2ray.ang.extension.isComplexType
-import com.v2ray.ang.extension.isNotNullEmpty
-import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
-import com.v2ray.ang.handler.SpeedtestManager
+import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import libv2ray.OutboundProbeHandler
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Worker that runs a batch of real-ping tests independently.
- * Each batch owns its own CoroutineScope/dispatcher and can be cancelled separately.
+ * Runs one complete UI delay-test batch through one native Xray instance.
+ *
+ * CoreTestService hosts this worker in a dedicated process. The native batch
+ * observatory bounds concurrency internally and publishes coalesced snapshots,
+ * avoiding the former one-temporary-core-per-profile fan-out.
  */
 class RealPingWorkerService(
     private val context: Context,
     private val guids: List<String>,
-    private val onEvent: (RealPingEvent) -> Unit = {}
+    private val onEvent: (RealPingEvent) -> Unit = {},
 ) {
     private val job = SupervisorJob()
-    private val concurrency = SettingsManager.getRealPingConcurrency()
-    private val dispatcher = Executors.newFixedThreadPool(concurrency).asCoroutineDispatcher()
-    private val scope = CoroutineScope(job + dispatcher + CoroutineName("RealPingBatchWorker"))
-
-    private val runningCount = AtomicInteger(0)
-    private val totalCount = AtomicInteger(0)
+    private val scope = CoroutineScope(job + Dispatchers.IO + CoroutineName("OutboundProbeBatch"))
+    private val controller = CoreNativeManager.newOutboundProbeController()
+    private val finished = AtomicBoolean(false)
+    private val emittedDelays = mutableMapOf<String, Long>()
+    private val emittedRoutes = mutableMapOf<String, String>()
+    private val completedGuids = mutableSetOf<String>()
+    private var lastPayload = ""
+    private var totalProfiles = 0
 
     fun start() {
-        val jobs = guids.map { guid ->
-            totalCount.incrementAndGet()
-            scope.launch {
-                runningCount.incrementAndGet()
-                try {
-                    val result = startRealPing(guid)
-                    onEvent(RealPingEvent.Result(guid, result))
-                } catch (_: Throwable) {
-                    // ignore
-                } finally {
-                    val count = totalCount.decrementAndGet()
-                    val left = runningCount.decrementAndGet()
-                    onEvent(RealPingEvent.Progress("$left / $count"))
-                }
-            }
-        }
-
         scope.launch {
             try {
-                joinAll(*jobs.toTypedArray())
-                onEvent(RealPingEvent.Finish("0"))
+                val plan = CoreConfigManager.getV2rayConfig4BatchSpeedtest(context, guids)
+                totalProfiles = (plan.profiles.map { it.guid } + plan.failedGuids).distinct().size
+                plan.failedGuids.forEach { emitResult(it, -1L, completed = true) }
+
+                if (plan.outboundTags.isNotEmpty()) {
+                    val finalResult = CoreNativeManager.probeOutbounds(
+                        controller = controller,
+                        config = plan.content,
+                        outboundTagsJson = JsonUtil.toJson(plan.outboundTags),
+                        balancerTagsJson = JsonUtil.toJson(plan.balancerTags),
+                        maxConcurrency = SettingsManager.getRealPingConcurrency(),
+                        samples = plan.samples,
+                        handler = object : OutboundProbeHandler {
+                            override fun onOutboundProbeUpdate(payload: String?): Long {
+                                payload?.let { processPayload(plan, it) }
+                                return 0
+                            }
+                        },
+                    )
+                    if (finished.get()) return@launch
+                    processSnapshot(plan, finalResult)
+                    completeMissing(plan)
+                    finish(if (finalResult.cancelled) "-1" else "0")
+                } else {
+                    completeMissing(plan)
+                    finish("0")
+                }
             } catch (_: CancellationException) {
-                onEvent(RealPingEvent.Finish("-1"))
+                finish("-1")
+            } catch (error: Throwable) {
+                LogUtil.e(AppConfig.TAG, "Outbound probe batch failed", error)
+                finish("-1")
             } finally {
-                close()
+                scope.cancel()
             }
         }
     }
 
     fun cancel() {
+        controller.cancel()
         job.cancel()
+        finish("-1")
     }
 
-    private fun close() {
-        try {
-            dispatcher.close()
-        } catch (_: Throwable) {
-            // ignore
-        }
+    @Synchronized
+    private fun processPayload(plan: OutboundProbePlan, payload: String) {
+        if (finished.get()) return
+        if (payload == lastPayload) return
+        lastPayload = payload
+        val snapshot = JsonUtil.fromJsonSafe(payload, CoreNativeManager.OutboundProbeBatchResult::class.java)
+            ?: return
+        processSnapshot(plan, snapshot)
     }
 
-    private fun startRealPing(guid: String): Long {
-        val retFailure = -1L
+    @Synchronized
+    private fun processSnapshot(
+        plan: OutboundProbePlan,
+        snapshot: CoreNativeManager.OutboundProbeBatchResult,
+    ) {
+        if (finished.get()) return
+        val statuses = snapshot.results.associateBy { it.outboundTag }
+        plan.profiles.forEach { profile ->
+            val candidateStatuses = profile.candidates.mapNotNull { candidate ->
+                statuses[candidate.probeTag]?.let { candidate to it }
+            }
+            val allCandidatesCompleted = candidateStatuses.size == profile.candidates.size &&
+                candidateStatuses.all { (_, status) -> status.samples >= plan.samples }
 
-        val config = MmkvManager.decodeServerConfig(guid) ?: return retFailure
-        if (!config.configType.isComplexType()
-            && config.configType != EConfigType.HYSTERIA2
-            && config.configType != EConfigType.WIREGUARD
-            && config.alpn?.startsWith("h3") != true
-            && config.server.isNotNullEmpty()
-            && config.serverPort?.toIntOrNull() != null
-        ) {
-            val url = config.server.orEmpty()
-            val port = config.serverPort.orEmpty().toInt()
-            val tcpTime = SpeedtestManager.socketConnectTime(url, port, 1000)
-            if (tcpTime <= -1L) {
-                return retFailure
+            val selected = selectProfileResult(profile, snapshot, candidateStatuses)
+            if (selected != null) {
+                val (candidate, status) = selected
+                val viableRoute = candidate.runtimeTag.takeIf {
+                    status.alive && profile.balancerTag != null
+                }.orEmpty()
+                emitResult(
+                    profile.guid,
+                    if (status.alive) status.delay else -1L,
+                    viableRoute,
+                    allCandidatesCompleted,
+                )
+            } else if (allCandidatesCompleted) {
+                emitResult(profile.guid, -1L, completed = true)
             }
         }
+    }
 
-        val configResult = CoreConfigManager.getV2rayConfig4Speedtest(context, guid)
-        if (!configResult.status) {
-            return retFailure
+    private fun selectProfileResult(
+        profile: OutboundProbeProfilePlan,
+        snapshot: CoreNativeManager.OutboundProbeBatchResult,
+        statuses: List<Pair<com.v2ray.ang.dto.OutboundProbeCandidate, CoreNativeManager.OutboundProbeStatus>>,
+    ): Pair<com.v2ray.ang.dto.OutboundProbeCandidate, CoreNativeManager.OutboundProbeStatus>? {
+        if (profile.balancerTag == null) return statuses.firstOrNull()
+        val selectedTag = snapshot.balancerTargets[profile.balancerTag] ?: return null
+        return statuses.firstOrNull { (candidate, _) -> candidate.probeTag == selectedTag }
+    }
+
+    @Synchronized
+    private fun completeMissing(plan: OutboundProbePlan) {
+        (plan.profiles.map { it.guid } + plan.failedGuids).distinct().forEach { guid ->
+            if (guid !in completedGuids) emitResult(guid, emittedDelays[guid] ?: -1L, completed = true)
         }
-        val cacheSnapshot = PolicyRouteCache.snapshot()
-        val warmTarget = PolicyRouteCache.lookup(cacheSnapshot.networkKey, guid).orEmpty()
-        LogUtil.i(
-            AppConfig.TAG,
-            "Policy route cache ${if (warmTarget.isEmpty()) "miss" else "hit"} for delay test",
-        )
-        val result = CoreNativeManager.measureOutboundDelayWithWarmRoute(
-            configResult.content,
-            SettingsManager.getDelayTestUrl(),
-            warmTarget,
-        )
-        val remembered = PolicyRouteCache.rememberCurrent(cacheSnapshot, guid, result.outboundTag)
-        if (remembered) {
-            LogUtil.i(AppConfig.TAG, "Policy route cache updated from successful delay test")
+    }
+
+    @Synchronized
+    private fun emitResult(
+        guid: String,
+        delay: Long,
+        viableOutboundTag: String = "",
+        completed: Boolean,
+    ) {
+        if (emittedDelays[guid] != delay ||
+            (viableOutboundTag.isNotEmpty() && emittedRoutes[guid] != viableOutboundTag)
+        ) {
+            emittedDelays[guid] = delay
+            if (viableOutboundTag.isNotEmpty()) emittedRoutes[guid] = viableOutboundTag
+            onEvent(RealPingEvent.Result(guid, delay, viableOutboundTag))
         }
-        return result.delay
+        if (completed && completedGuids.add(guid)) {
+            val remaining = (totalProfiles - completedGuids.size).coerceAtLeast(0)
+            onEvent(RealPingEvent.Progress("$remaining / $totalProfiles"))
+        }
+    }
+
+    @Synchronized
+    private fun finish(status: String) {
+        if (finished.compareAndSet(false, true)) {
+            onEvent(RealPingEvent.Finish(status))
+        }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -1,8 +1,10 @@
 package com.v2ray.ang.service
 
 import android.content.Context
+import com.v2ray.ang.AppConfig
 import com.v2ray.ang.core.CoreConfigManager
 import com.v2ray.ang.core.CoreNativeManager
+import com.v2ray.ang.core.PolicyRouteCache
 import com.v2ray.ang.dto.RealPingEvent
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.extension.isComplexType
@@ -10,6 +12,7 @@ import com.v2ray.ang.extension.isNotNullEmpty
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.handler.SpeedtestManager
+import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -102,6 +105,21 @@ class RealPingWorkerService(
         if (!configResult.status) {
             return retFailure
         }
-        return CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+        val cacheSnapshot = PolicyRouteCache.snapshot()
+        val warmTarget = PolicyRouteCache.lookup(cacheSnapshot.networkKey, guid).orEmpty()
+        LogUtil.i(
+            AppConfig.TAG,
+            "Policy route cache ${if (warmTarget.isEmpty()) "miss" else "hit"} for delay test",
+        )
+        val result = CoreNativeManager.measureOutboundDelayWithWarmRoute(
+            configResult.content,
+            SettingsManager.getDelayTestUrl(),
+            warmTarget,
+        )
+        val remembered = PolicyRouteCache.rememberCurrent(cacheSnapshot, guid, result.outboundTag)
+        if (remembered) {
+            LogUtil.i(AppConfig.TAG, "Policy route cache updated from successful delay test")
+        }
+        return result.delay
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -14,8 +14,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import libv2ray.OutboundProbeHandler
 import java.util.concurrent.atomic.AtomicBoolean
@@ -32,9 +31,10 @@ class RealPingWorkerService(
     private val guids: List<String>,
     private val onEvent: (RealPingEvent) -> Unit = {},
 ) {
-    private val job = SupervisorJob()
+    private val job = Job()
     private val scope = CoroutineScope(job + Dispatchers.IO + CoroutineName("OutboundProbeBatch"))
     private val controller = CoreNativeManager.newOutboundProbeController()
+    private val networkIdentity = NetworkIdentityResolver.resolveCurrent(context)
     private val finished = AtomicBoolean(false)
     private val emittedDelays = mutableMapOf<String, Long>()
     private val emittedRoutes = mutableMapOf<String, String>()
@@ -77,8 +77,6 @@ class RealPingWorkerService(
             } catch (error: Throwable) {
                 LogUtil.e(AppConfig.TAG, "Outbound probe batch failed", error)
                 finish("-1")
-            } finally {
-                scope.cancel()
             }
         }
     }
@@ -160,7 +158,15 @@ class RealPingWorkerService(
         ) {
             emittedDelays[guid] = delay
             if (viableOutboundTag.isNotEmpty()) emittedRoutes[guid] = viableOutboundTag
-            onEvent(RealPingEvent.Result(guid, delay, viableOutboundTag))
+            onEvent(
+                RealPingEvent.Result(
+                    guid = guid,
+                    delayMillis = delay,
+                    viableOutboundTag = viableOutboundTag,
+                    networkKey = networkIdentity?.key,
+                    networkHandle = networkIdentity?.networkHandle,
+                )
+            )
         }
         if (completed && completedGuids.add(guid)) {
             val remaining = (totalProfiles - completedGuids.size).coerceAtLeast(0)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/UnderlyingNetworkStateTracker.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/UnderlyingNetworkStateTracker.kt
@@ -1,0 +1,38 @@
+package com.v2ray.ang.service
+
+/**
+ * Tracks Android's selected VPN underlay without treating the initial callback
+ * or repeated capability updates as a network transition.
+ */
+internal class UnderlyingNetworkStateTracker<T> {
+    private var current: T? = null
+    private var hasObservedNetwork = false
+    private var currentWasLost = false
+
+    @Synchronized
+    fun onAvailable(network: T): Boolean {
+        val changed = hasObservedNetwork && (current != network || currentWasLost)
+        current = network
+        hasObservedNetwork = true
+        currentWasLost = false
+        return changed
+    }
+
+    @Synchronized
+    fun onLost(network: T): Boolean {
+        if (current != network) return false
+        current = null
+        currentWasLost = true
+        return true
+    }
+
+    @Synchronized
+    fun isCurrent(network: T): Boolean = current == network
+
+    @Synchronized
+    fun reset() {
+        current = null
+        hasObservedNetwork = false
+        currentWasLost = false
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -15,6 +15,7 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.VPN
 import com.v2ray.ang.R
 import com.v2ray.ang.extension.toastError
+import com.v2ray.ang.extension.toastErrorLong
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.helper.MmkvPreferenceDataStore
 import com.v2ray.ang.root.RootManager
@@ -75,7 +76,7 @@ class SettingsActivity : BaseActivity() {
                     grants[Manifest.permission.ACCESS_FINE_LOCATION] == true || hasFineLocationPermission()
                 rememberRoutesPerWifiNetwork?.isChecked = fineLocationGranted
                 if (!fineLocationGranted) {
-                    context?.toastError(R.string.toast_precise_location_required_for_wifi_route_memory)
+                    context?.toastErrorLong(R.string.toast_precise_location_required_for_wifi_route_memory)
                 }
             }
 
@@ -243,6 +244,7 @@ class SettingsActivity : BaseActivity() {
 
         override fun onStart() {
             super.onStart()
+            disableWifiRouteMemoryWithoutPermission()
             updateHevTunSettings(MmkvManager.decodeSettingsBool(AppConfig.PREF_USE_HEV_TUNNEL, true))
 
             // Initialize mode-dependent UI states
@@ -258,6 +260,12 @@ class SettingsActivity : BaseActivity() {
             updateFragment(MmkvManager.decodeSettingsBool(AppConfig.PREF_FRAGMENT_ENABLED, false))
 
             updateDynamicSocksPort(MmkvManager.decodeSettingsBool(AppConfig.PREF_DYNAMIC_SOCKS_PORT, false))
+        }
+
+        private fun disableWifiRouteMemoryWithoutPermission() {
+            if (rememberRoutesPerWifiNetwork?.isChecked == true && !hasFineLocationPermission()) {
+                rememberRoutesPerWifiNetwork?.isChecked = false
+            }
         }
 
         private fun updateMode(value: String?) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -1,7 +1,11 @@
 package com.v2ray.ang.ui
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.CheckBoxPreference
 import androidx.preference.EditTextPreference
@@ -61,6 +65,19 @@ class SettingsActivity : BaseActivity() {
         private val socksPassword by lazy { findPreference<EditTextPreference>(AppConfig.PREF_SOCKS_PASSWORD) }
         private val socksEnableUdp by lazy { findPreference<CheckBoxPreference>(AppConfig.PREF_SOCKS_ENABLE_UDP) }
         private val proxySharing by lazy { findPreference<CheckBoxPreference>(AppConfig.PREF_PROXY_SHARING) }
+        private val rememberRoutesPerWifiNetwork by lazy {
+            findPreference<CheckBoxPreference>(AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK)
+        }
+
+        private val requestWifiIdentityPermission =
+            registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { grants ->
+                val fineLocationGranted =
+                    grants[Manifest.permission.ACCESS_FINE_LOCATION] == true || hasFineLocationPermission()
+                rememberRoutesPerWifiNetwork?.isChecked = fineLocationGranted
+                if (!fineLocationGranted) {
+                    context?.toastError(R.string.toast_precise_location_required_for_wifi_route_memory)
+                }
+            }
 
         override fun onCreatePreferences(bundle: Bundle?, s: String?) {
             // Use MMKV as the storage backend for all Preferences
@@ -92,6 +109,20 @@ class SettingsActivity : BaseActivity() {
             fragment?.setOnPreferenceChangeListener { _, newValue ->
                 updateFragment(newValue as Boolean)
                 true
+            }
+
+            rememberRoutesPerWifiNetwork?.setOnPreferenceChangeListener { _, newValue ->
+                if (newValue != true || hasFineLocationPermission()) {
+                    true
+                } else {
+                    requestWifiIdentityPermission.launch(
+                        arrayOf(
+                            Manifest.permission.ACCESS_COARSE_LOCATION,
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                        )
+                    )
+                    false
+                }
             }
 
             mode?.setOnPreferenceChangeListener { pref, newValue ->
@@ -203,6 +234,12 @@ class SettingsActivity : BaseActivity() {
             }
             return hasRoot
         }
+
+        private fun hasFineLocationPermission(): Boolean =
+            ContextCompat.checkSelfPermission(
+                requireContext(),
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
 
         override fun onStart() {
             super.onStart()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/MessageUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/MessageUtil.kt
@@ -55,11 +55,6 @@ object MessageUtil {
                     }
                 }
 
-                AppConfig.MSG_MEASURE_CONFIG_CANCEL -> {
-                    // Do not wake up service just to cancel; stop only if it is already running.
-                    ctx.stopService(intent)
-                }
-
                 else -> {
                     ctx.startService(intent)
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -175,10 +175,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
      * Tests the real ping for all servers.
      */
     fun testAllRealPing() {
-        MessageUtil.sendMsg2TestService(
-            getApplication(),
-            TestServiceMessage(key = AppConfig.MSG_MEASURE_CONFIG_CANCEL)
-        )
         MmkvManager.clearAllTestDelayResults(serversCache.map { it.guid }.toList())
         updateListAction.value = -1
 

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">إيقاف الخدمات</string>
     <string name="toast_services_success">نجاح بدء الخدمات</string>
     <string name="toast_services_failure">فشل بدء الخدمات</string>
+    <string name="notification_core_recovery_failed">فشل استرداد الاتصال. ستظل حركة المرور محظورة لمنع التسرب؛ أعد تشغيل v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">ملف التكوين</string>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -161,6 +161,9 @@
     <string name="summary_pref_per_app_proxy">عام: التطبيق المحدد هو وكيل، غير المحدد اتصال مباشر؛ \nوضع التجاوز: التطبيق المحدد متصل مباشرة، غير المحدد وكيل. \nخيار تحديد تطبيق الوكيل تلقائيًا في القائمة</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">تذكّر المسارات الصالحة لكل شبكة Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">يستخدم اسم شبكة Wi-Fi المتصلة للاحتفاظ بسجل مسارات منفصل. يتطلب إذن الموقع الدقيق لأن Android يحمي أسماء شبكات Wi-Fi باعتبارها معلومات موقع.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">يلزم إذن الموقع الدقيق لقراءة اسم شبكة Wi-Fi</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -159,6 +159,9 @@
     <string name="summary_pref_per_app_proxy">সাধারণ: চেকড অ্যাপ প্রক্সি, আনচেকড সরাসরি সংযোগ; \nবাইপাস মোড: চেকড অ্যাপ সরাসরি সংযুক্ত, আনচেকড প্রক্সি। \nমেনুতে প্রক্সি অ্যাপ্লিকেশন স্বয়ংক্রিয়ভাবে নির্বাচন করার বিকল্প</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">প্রতিটি Wi-Fi নেটওয়ার্কের জন্য কার্যকর রুট মনে রাখুন</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">আলাদা রুটের ইতিহাস রাখতে সংযুক্ত Wi-Fi নেটওয়ার্কের নাম ব্যবহার করে। সুনির্দিষ্ট লোকেশন অনুমতি প্রয়োজন, কারণ Android Wi-Fi নেটওয়ার্কের নামকে লোকেশন তথ্য হিসেবে সুরক্ষিত রাখে।</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Wi-Fi নেটওয়ার্কের নাম পড়তে সুনির্দিষ্ট লোকেশন অনুমতি প্রয়োজন</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">সার্ভিস বন্ধ করুন</string>
     <string name="toast_services_success">সার্ভিস সফলভাবে শুরু হয়েছে</string>
     <string name="toast_services_failure">সার্ভিস শুরু হতে ব্যর্থ হয়েছে</string>
+    <string name="notification_core_recovery_failed">সংযোগ পুনরুদ্ধার ব্যর্থ হয়েছে। ট্রাফিক লিক রোধে অবরুদ্ধ থাকবে; v2rayNG পুনরায় চালু করুন।</string>
 
     <!--ServerActivity-->
     <string name="title_server">কনফিগারেশন ফাইল</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">واڌاشتن سرویس</string>
     <string name="toast_services_success">ره وستن سرویس وا مووفقیت ٱنجوم وابی</string>
     <string name="toast_services_failure">ره وستن سرویس وا مووفقیت ٱنجوم نوابی</string>
+    <string name="notification_core_recovery_failed">بازیابی اتصال ناموفق بود. برای جلوگیری از نشت، ترافیک مسدود می‌ماند؛ v2rayNG را دوباره راه‌اندازی کنید.</string>
 
     <!--ServerActivity-->
     <string name="title_server">فایل کانفیگ</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -160,6 +160,9 @@
     <string name="summary_pref_per_app_proxy">پوی وولاتی: برنومه پسند وابیڌه وا ی پروکسی منپیز ابۊ، برنومه پسند نوابیڌه موستقیمن منپیز ابۊ.\nهالت دور زیڌن: برنومه پسند وابیڌه موستقیمن منپیز ابۊ، برنومه پسند نوابیڌه وا ی پروکسی منپیز ابۊ.\nپسند خوتکار برنومه یل پروکسی من نومگه امکووݩ پزیر هڌ.</string>
     <string name="title_pref_is_booted">منپیز خوتکار مجال ره ونی</string>
     <string name="summary_pref_is_booted">مجال ره وندن، خوساخوس و سرور پسند بیڌه منپیز ابۊ که گاشڌ نا مووفق بۊ.</string>
+    <string name="title_pref_remember_routes_per_wifi_network">تورا کارا سی هر شبکه وای‌فای ن و یاد ودارین</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">نوم شبکه وای‌فای منپیز وابیڌه ن سی نگهداشتن تاریخچه تور جۊری و کار اگره. چۊ ٱندروید نوم وای‌فای ن دووسمندی جایونی دونسته، دسرسی جای دقیق لازوم هڌ.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">دسرسی جای دقیق سی خوندن نوم شبکه وای‌فای لازوم هڌ</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">پاک کردن خوتکار کانفیگا نا موئتبر بئڌ پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتیجه یل پینگ گاشڌ دییق نبۊن؛ کانفیگا پاک وابیڌه ن نتری وورگنی.</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">توقف سرویس</string>
     <string name="toast_services_success">سرویس با موفقیت شروع شد</string>
     <string name="toast_services_failure">شروع سرویس با شکست مواجه شد</string>
+    <string name="notification_core_recovery_failed">بازیابی اتصال ناموفق بود. برای جلوگیری از نشت، ترافیک مسدود می‌ماند؛ v2rayNG را دوباره راه‌اندازی کنید.</string>
 
     <!--ServerActivity-->
     <string name="title_server">فایل کانفیگ</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -157,6 +157,9 @@
     <string name="summary_pref_per_app_proxy">عمومی: برنامه انتخاب شده از طریق یک پروکسی متصل می شود، برنامه انتخاب نشده مستقیماً متصل می شود. \nحالت دور زدن: برنامه انتخاب شده مستقیماً متصل می شود، برنامه انتخاب نشده از طریق یک پروکسی متصل می شود. \nانتخاب خودکار برنامه های پراکسی در منو امکان پذیر است.</string>
     <string name="title_pref_is_booted">اتصال خودکار هنگام راه اندازی</string>
     <string name="summary_pref_is_booted">هنگام راه اندازی به طور خودکار به سرور انتخابی متصل می شود که ممکن است ناموفق باشد.</string>
+    <string name="title_pref_remember_routes_per_wifi_network">به‌خاطر سپردن مسیرهای قابل استفاده برای هر شبکه Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">برای نگه‌داری سابقه مسیر جداگانه، از نام شبکه Wi-Fi متصل استفاده می‌کند. به مجوز مکان دقیق نیاز دارد، زیرا Android نام شبکه‌های Wi-Fi را به‌عنوان اطلاعات مکانی محافظت می‌کند.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">برای خواندن نام شبکه Wi-Fi، مجوز مکان دقیق لازم است</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">حذف خودکار کانفیگ‌های نامعتبر بعد از پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتایج پینگ ممکن است همیشه دقیق نباشند؛ کانفیگ‌های حذف‌شده قابل بازیابی نیستند.</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">Остановка служб</string>
     <string name="toast_services_success">Службы успешно запущены</string>
     <string name="toast_services_failure">Сбой при запуске служб</string>
+    <string name="notification_core_recovery_failed">Не удалось восстановить подключение. Трафик заблокирован для предотвращения утечки; перезапустите v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">Профиль</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -163,6 +163,9 @@
     <string name="summary_pref_per_app_proxy">Основной: выбранное приложение соединяется через прокси, не выбранное — напрямую;\nРежим обхода: выбранное приложение соединяется напрямую, не выбранное — через прокси.\nЕсть возможность автоматического выбора проксируемых приложений в меню.</string>
     <string name="title_pref_is_booted">Автоподключение при запуске</string>
     <string name="summary_pref_is_booted">Автоматически подключаться к выбранному серверу при запуске приложения (может оказаться неудачным)</string>
+    <string name="title_pref_remember_routes_per_wifi_network">Запоминать рабочие маршруты для каждой сети Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">Использует имя подключённой сети Wi-Fi, чтобы хранить отдельную историю маршрутов. Требуется доступ к точному местоположению, поскольку Android защищает имена сетей Wi-Fi как данные о местоположении.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Для чтения имени сети Wi-Fi требуется доступ к точному местоположению</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Автоудаление нерабочих профилей</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Автоматическое удаление нерабочих профилей после проверки (результаты проверки могут быть неточными; восстановить удалённые профили невозможно)</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -158,6 +158,9 @@
     <string name="summary_pref_per_app_proxy">- Bình thường: Ứng dụng đã chọn sẽ kết nối thông qua Proxy, chưa chọn sẽ kết nối trực tiếp. \n- Chế độ Bypass: Ứng dụng đã chọn sẽ kết nối trực tiếp, chưa chọn sẽ kết nối qua Proxy. \n- Nếu bạn đang ở Trung Quốc thì vào Menu, chọn Tự động chọn ứng dụng Proxy.</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">Ghi nhớ tuyến khả dụng cho từng mạng Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">Dùng tên mạng Wi-Fi đang kết nối để lưu lịch sử tuyến riêng. Cần quyền vị trí chính xác vì Android bảo vệ tên mạng Wi-Fi như thông tin vị trí.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Cần quyền vị trí chính xác để đọc tên mạng Wi-Fi</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">Đã dừng v2rayNG!</string>
     <string name="toast_services_success">Đã khởi động v2rayNG!</string>
     <string name="toast_services_failure">Không thể khởi động v2rayNG, kiểm tra lại cấu hình!</string>
+    <string name="notification_core_recovery_failed">Không thể khôi phục kết nối. Lưu lượng vẫn bị chặn để tránh rò rỉ; hãy khởi động lại v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">v2rayNG</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">关闭服务</string>
     <string name="toast_services_success">启动服务成功</string>
     <string name="toast_services_failure">启动服务失败</string>
+    <string name="notification_core_recovery_failed">连接恢复失败。流量将保持阻断以防泄漏；请重启 v2rayNG。</string>
 
     <!--ServerActivity-->
     <string name="title_server">配置项</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -160,6 +160,9 @@
     <string name="summary_pref_per_app_proxy">常规: 勾选的 App 被代理, 未勾选的直连;\n绕行模式: 勾选的 App 直连, 未勾选的被代理.\n不明白者在菜单中选择自动选中需代理应用</string>
     <string name="title_pref_is_booted">开机时自动连接</string>
     <string name="summary_pref_is_booted">开机时自动连接选择的服务器，可能会不成功</string>
+    <string name="title_pref_remember_routes_per_wifi_network">按 Wi-Fi 网络记住可用路由</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">使用当前连接的 Wi-Fi 名称分别保存路由历史。由于 Android 将 Wi-Fi 名称作为位置信息加以保护，因此需要精确位置权限。</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">读取 Wi-Fi 网络名称需要精确位置权限</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">测试后自动删除无效配置</string>
     <string name="summary_pref_auto_remove_invalid_after_test">测试结果可能不准确且已删除的配置无法恢复</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">停止服務</string>
     <string name="toast_services_success">啟動服務成功</string>
     <string name="toast_services_failure">啟動服務失敗</string>
+    <string name="notification_core_recovery_failed">連線復原失敗。流量將保持封鎖以防洩漏；請重新啟動 v2rayNG。</string>
 
     <!-- ServerActivity -->
     <string name="title_server">設定檔</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -159,6 +159,9 @@
     <string name="summary_pref_per_app_proxy">常規：勾選的 App 啟用 Proxy，未勾選的直接連線；\n繞行模式：勾選的 App 直接連線，未勾選的啟用 Proxy。\n可在選單中選擇自動選中需 Proxy 應用</string>
     <string name="title_pref_is_booted">開機時自動連線</string>
     <string name="summary_pref_is_booted">開機時自動連線選擇的伺服器，可能會不成功</string>
+    <string name="title_pref_remember_routes_per_wifi_network">依 Wi-Fi 網路記住可用路由</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">使用目前連線的 Wi-Fi 名稱分別儲存路由記錄。由於 Android 將 Wi-Fi 名稱視為位置資訊加以保護，因此需要精確位置權限。</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">讀取 Wi-Fi 網路名稱需要精確位置權限</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">測試後自動刪除無效配置</string>
     <string name="summary_pref_auto_remove_invalid_after_test">測試結果可能不準確且已刪除的配置無法復原</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -164,6 +164,9 @@
     <string name="summary_pref_per_app_proxy">General: Checked apps use proxy, unchecked apps connect directly; \nBypass mode: checked apps connect directly, unchecked apps use proxy. \nThe option to automatically select proxy applications is in the menu</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">Remember viable routes per Wi-Fi network</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">Uses the connected Wi-Fi name to keep separate route histories. Requires precise location permission because Android protects Wi-Fi names as location information.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Precise location permission is required to read the Wi-Fi network name</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="toast_services_stop">Stop Services</string>
     <string name="toast_services_success">Start Services Success</string>
     <string name="toast_services_failure">Start Services Failure</string>
+    <string name="notification_core_recovery_failed">Connection recovery failed. Traffic remains blocked to prevent leaks; restart v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">Config</string>

--- a/V2rayNG/app/src/main/res/xml/pref_settings.xml
+++ b/V2rayNG/app/src/main/res/xml/pref_settings.xml
@@ -282,6 +282,12 @@
     <PreferenceCategory android:title="@string/title_advanced">
 
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="pref_remember_routes_per_wifi_network"
+            android:summary="@string/summary_pref_remember_routes_per_wifi_network"
+            android:title="@string/title_pref_remember_routes_per_wifi_network" />
+
+        <CheckBoxPreference
             android:key="pref_is_booted"
             android:summary="@string/summary_pref_is_booted"
             android:title="@string/title_pref_is_booted" />

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/OutboundProbeConfigBuilderTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/OutboundProbeConfigBuilderTest.kt
@@ -138,6 +138,80 @@ class OutboundProbeConfigBuilderTest {
     }
 
     @Test
+    fun rejectsPolicyStrategiesWithoutOneStableViableTarget() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "random-policy",
+                    """
+                    {
+                      "outbounds": [
+                        {"tag":"proxy-a","protocol":"freedom"},
+                        {"tag":"proxy-b","protocol":"freedom"}
+                      ],
+                      "routing": {
+                        "rules": [{"type":"field","balancerTag":"balancer-main"}],
+                        "balancers": [{
+                          "tag":"balancer-main",
+                          "selector":["proxy-"],
+                          "strategy":{"type":"random"}
+                        }]
+                      }
+                    }
+                    """.trimIndent(),
+                )
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(listOf("random-policy"), plan.failedGuids)
+        assertTrue(plan.profiles.isEmpty())
+        assertEquals(0, JsonParser.parseString(plan.content).asJsonObject.getAsJsonArray("outbounds").size())
+    }
+
+    @Test
+    fun rejectsAmbiguousOrBrokenSourceReferencesBeforeMerge() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "duplicate-tags",
+                    """{"outbounds":[
+                      {"tag":"proxy","protocol":"freedom"},
+                      {"tag":"proxy","protocol":"freedom"}
+                    ]}""",
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "missing-dialer",
+                    """{"outbounds":[{
+                      "tag":"proxy",
+                      "protocol":"freedom",
+                      "streamSettings":{"sockopt":{"dialerProxy":"missing"}}
+                    }]}""",
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "conditional-route",
+                    """{
+                      "outbounds":[{"tag":"proxy","protocol":"freedom"}],
+                      "routing":{"rules":[{
+                        "type":"field",
+                        "domain":["example.com"],
+                        "outboundTag":"proxy"
+                      }]}
+                    }""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(
+            listOf("duplicate-tags", "missing-dialer", "conditional-route"),
+            plan.failedGuids,
+        )
+        assertTrue(plan.profiles.isEmpty())
+        assertEquals(0, JsonParser.parseString(plan.content).asJsonObject.getAsJsonArray("outbounds").size())
+    }
+
+    @Test
     fun isolatesMalformedProfilesFromTheViableBatch() {
         val plan = OutboundProbeConfigBuilder.build(
             sources = listOf(

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/OutboundProbeConfigBuilderTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/OutboundProbeConfigBuilderTest.kt
@@ -1,0 +1,157 @@
+package com.v2ray.ang.core
+
+import com.google.gson.JsonParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OutboundProbeConfigBuilderTest {
+    @Test
+    fun namespacesOutboundsAndRemapsDialerChains() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "normal-a",
+                    """
+                    {
+                      "outbounds": [
+                        {
+                          "tag": "proxy",
+                          "protocol": "freedom",
+                          "streamSettings": {"sockopt": {"dialerProxy": "hop"}}
+                        },
+                        {"tag": "hop", "protocol": "freedom"}
+                      ],
+                      "routing": {"rules": []}
+                    }
+                    """.trimIndent(),
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "normal-b",
+                    """{"outbounds":[{"tag":"proxy","protocol":"freedom"}]}""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(listOf("probe-0-proxy", "probe-1-proxy"), plan.outboundTags)
+        val root = JsonParser.parseString(plan.content).asJsonObject
+        val outbounds = root.getAsJsonArray("outbounds")
+        assertEquals(3, outbounds.size())
+        val firstSockopt = outbounds[0].asJsonObject
+            .getAsJsonObject("streamSettings")
+            .getAsJsonObject("sockopt")
+        assertEquals("probe-0-hop", firstSockopt.get("dialerProxy").asString)
+        assertEquals(0, root.getAsJsonObject("burstObservatory").getAsJsonArray("subjectSelector").size())
+    }
+
+    @Test
+    fun retainsPrimaryPolicyBalancerAndMapsItsMembers() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "policy-guid",
+                    """
+                    {
+                      "outbounds": [
+                        {"tag":"proxy-proxy-1-a","protocol":"freedom"},
+                        {"tag":"proxy-proxy-2-b","protocol":"freedom"},
+                        {"tag":"direct","protocol":"freedom"}
+                      ],
+                      "routing": {
+                        "rules": [{"type":"field","network":"tcp,udp","balancerTag":"balancer-main"}],
+                        "balancers": [{
+                          "tag":"balancer-main",
+                          "selector":["proxy-proxy-"],
+                          "strategy":{"type":"leastPing"}
+                        }]
+                      }
+                    }
+                    """.trimIndent(),
+                )
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertTrue(plan.failedGuids.isEmpty())
+        assertEquals("probe-0-balancer-main", plan.profiles.single().balancerTag)
+        assertEquals(
+            listOf("proxy-proxy-1-a", "proxy-proxy-2-b"),
+            plan.profiles.single().candidates.map { it.runtimeTag },
+        )
+        val balancer = JsonParser.parseString(plan.content).asJsonObject
+            .getAsJsonObject("routing")
+            .getAsJsonArray("balancers")[0].asJsonObject
+        assertEquals("probe-0-proxy-proxy-", balancer.getAsJsonArray("selector")[0].asString)
+    }
+
+    @Test
+    fun preservesLeastLoadProbeRequirementsForTheWholeBatch() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "policy-guid",
+                    """
+                    {
+                      "outbounds": [
+                        {"tag":"proxy-a","protocol":"freedom"},
+                        {"tag":"proxy-b","protocol":"freedom"}
+                      ],
+                      "routing": {
+                        "rules": [{"type":"field","balancerTag":"balancer-main"}],
+                        "balancers": [{
+                          "tag":"balancer-main",
+                          "selector":["proxy-"],
+                          "strategy":{"type":"leastLoad"}
+                        }]
+                      },
+                      "burstObservatory": {
+                        "subjectSelector":["proxy-"],
+                        "pingConfig": {
+                          "destination":"https://ignored.example",
+                          "httpMethod":"HEAD",
+                          "interval":"5m",
+                          "sampling":3,
+                          "timeout":"30s"
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "normal-guid",
+                    """{"outbounds":[{"tag":"proxy","protocol":"freedom"}]}""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(3, plan.samples)
+        val pingConfig = JsonParser.parseString(plan.content).asJsonObject
+            .getAsJsonObject("burstObservatory")
+            .getAsJsonObject("pingConfig")
+        assertEquals("HEAD", pingConfig.get("httpMethod").asString)
+        assertEquals("30s", pingConfig.get("timeout").asString)
+        assertEquals(3, pingConfig.get("sampling").asInt)
+        assertEquals("https://example.com/generate_204", pingConfig.get("destination").asString)
+    }
+
+    @Test
+    fun isolatesMalformedProfilesFromTheViableBatch() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source("broken", "{}"),
+                OutboundProbeConfigBuilder.Source(
+                    "valid",
+                    """{"outbounds":[{"tag":"proxy","protocol":"freedom"}]}""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(listOf("broken"), plan.failedGuids)
+        assertEquals(listOf("valid"), plan.profiles.map { it.guid })
+        assertFalse(plan.content.isBlank())
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyRouteCacheTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyRouteCacheTest.kt
@@ -24,7 +24,7 @@ class PolicyRouteCacheTest {
 
     @Test
     fun clearInvalidatesInFlightWrites() {
-        PolicyRouteCache.setCurrentNetwork("wifi:home")
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
         val snapshot = PolicyRouteCache.snapshot()
 
         PolicyRouteCache.clear()
@@ -44,12 +44,22 @@ class PolicyRouteCacheTest {
 
     @Test
     fun networkSwitchInvalidatesInFlightCurrentRouteWrite() {
-        PolicyRouteCache.setCurrentNetwork("wifi:home")
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
         val snapshot = PolicyRouteCache.snapshot()
 
-        PolicyRouteCache.setCurrentNetwork("cellular:310260")
+        PolicyRouteCache.setCurrentNetwork("cellular:310260", 200L)
 
         assertFalse(PolicyRouteCache.rememberCurrent(snapshot, "group-a", "proxy-a"))
         assertNull(PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun batchResultMustMatchExactNetworkInstance() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
+
+        assertFalse(PolicyRouteCache.rememberObserved("wifi:home", 99L, "group-a", "proxy-old"))
+        assertFalse(PolicyRouteCache.rememberObserved("cellular:310260", 100L, "group-a", "proxy-old"))
+        assertTrue(PolicyRouteCache.rememberObserved("wifi:home", 100L, "group-a", "proxy-current"))
+        assertEquals("proxy-current", PolicyRouteCache.lookup("wifi:home", "group-a"))
     }
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyRouteCacheTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyRouteCacheTest.kt
@@ -1,0 +1,55 @@
+package com.v2ray.ang.core
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolicyRouteCacheTest {
+    @After
+    fun tearDown() = PolicyRouteCache.clear()
+
+    @Test
+    fun keepsRoutesSeparateByNetworkAndProfile() {
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-a"))
+        assertTrue(PolicyRouteCache.remember("cellular:310260", "group-a", "proxy-b"))
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-b", "proxy-c"))
+
+        assertEquals("proxy-a", PolicyRouteCache.lookup("wifi:home", "group-a"))
+        assertEquals("proxy-b", PolicyRouteCache.lookup("cellular:310260", "group-a"))
+        assertEquals("proxy-c", PolicyRouteCache.lookup("wifi:home", "group-b"))
+    }
+
+    @Test
+    fun clearInvalidatesInFlightWrites() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home")
+        val snapshot = PolicyRouteCache.snapshot()
+
+        PolicyRouteCache.clear()
+
+        assertFalse(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-a", snapshot.generation))
+        assertNull(PolicyRouteCache.snapshot().networkKey)
+        assertNull(PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun freshObservatoryTargetReplacesPreviousRoute() {
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-old"))
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-fresh"))
+
+        assertEquals("proxy-fresh", PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun networkSwitchInvalidatesInFlightCurrentRouteWrite() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home")
+        val snapshot = PolicyRouteCache.snapshot()
+
+        PolicyRouteCache.setCurrentNetwork("cellular:310260")
+
+        assertFalse(PolicyRouteCache.rememberCurrent(snapshot, "group-a", "proxy-a"))
+        assertNull(PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/service/NetworkIdentityResolverTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/service/NetworkIdentityResolverTest.kt
@@ -1,0 +1,21 @@
+package com.v2ray.ang.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NetworkIdentityResolverTest {
+    @Test
+    fun normalizesWifiSsidWithoutSplittingMeshAccessPoints() {
+        assertEquals("wifi:Home Mesh", NetworkIdentityResolver.wifiKey("\"Home Mesh\""))
+        assertEquals("wifi", NetworkIdentityResolver.wifiKey("<unknown ssid>"))
+        assertEquals("wifi", NetworkIdentityResolver.wifiKey(null))
+        assertEquals("wifi", NetworkIdentityResolver.wifiKey("\"Home Mesh\"", rememberPerNetwork = false))
+    }
+
+    @Test
+    fun prefersCurrentCellularOperatorAndFallsBackToSimOperator() {
+        assertEquals("cellular:310260", NetworkIdentityResolver.cellularKey("310260", "23415"))
+        assertEquals("cellular:23415", NetworkIdentityResolver.cellularKey("", "23415"))
+        assertEquals("cellular", NetworkIdentityResolver.cellularKey("invalid", null))
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/service/UnderlyingNetworkStateTrackerTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/service/UnderlyingNetworkStateTrackerTest.kt
@@ -1,0 +1,49 @@
+package com.v2ray.ang.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnderlyingNetworkStateTrackerTest {
+    private val tracker = UnderlyingNetworkStateTracker<String>()
+
+    @Test
+    fun initialAndRepeatedAvailabilityAreNotTransitions() {
+        assertFalse(tracker.onAvailable("wifi"))
+        assertFalse(tracker.onAvailable("wifi"))
+        assertTrue(tracker.isCurrent("wifi"))
+    }
+
+    @Test
+    fun changingNetworksIsATransition() {
+        tracker.onAvailable("wifi")
+
+        assertTrue(tracker.onAvailable("cellular"))
+        assertTrue(tracker.isCurrent("cellular"))
+    }
+
+    @Test
+    fun losingAndReacquiringAnUnderlayIsATransition() {
+        tracker.onAvailable("wifi")
+
+        assertTrue(tracker.onLost("wifi"))
+        assertTrue(tracker.onAvailable("wifi"))
+    }
+
+    @Test
+    fun losingAStaleNetworkDoesNotClearTheCurrentUnderlay() {
+        tracker.onAvailable("wifi")
+        tracker.onAvailable("cellular")
+
+        assertFalse(tracker.onLost("wifi"))
+        assertTrue(tracker.isCurrent("cellular"))
+    }
+
+    @Test
+    fun resetMakesTheNextNetworkInitialAgain() {
+        tracker.onAvailable("wifi")
+        tracker.reset()
+
+        assertFalse(tracker.onAvailable("cellular"))
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves v2rayNG behavior across Android network changes and replaces the existing multi-core policy-group delay testing approach with one disposable batch-probing process.

The main VPN can restore the last viable policy-group route associated with the active network while its Observatory gathers fresh results. Real-delay tests now probe multiple outbounds concurrently through one Xray instance in a dedicated Android process, avoiding multiple simultaneous cores in the application process.

## Motivation

With Xray native TUN, switching between Wi-Fi and cellular can leave instance-owned network state associated with the previous underlay. The VPN may remain shown as connected while some or all traffic stops working until the service is restarted.

Policy-group delay testing had a separate problem: running several Xray instances in the same process could interact with process-wide Xray state. This could produce intermittent failures, especially when delay tests were started repeatedly.

**Additionally, it was pointed out that the way v2rayNG performs probing is unsupported by xray-core as only one core instance should be running inside one process:** https://github.com/XTLS/Xray-core/pull/6483#issuecomment-4954335868

## Changes

### Network-switch recovery

- Track changes to the underlying Android network, including its exact network handle.
- Reset the Xray instance when the VPN underlay changes while keeping the VPN service and TUN interface alive.
- Keep traffic fail-closed while the core is being replaced or recovered.
- Fall back to a complete VPN service restart if in-process core recovery cannot restore a live core.
- Surface recovery failures instead of leaving the VPN apparently connected without a running core.

### Per-network policy-route memory

- Remember the last viable policy-group target for each network and profile.
- Identify cellular connections using the active subscription's MCC/MNC information.
- Treat Wi-Fi as one shared identity by default.
- Provide an optional **Remember viable routes per Wi-Fi AP** setting, using the SSID when enabled.
- Do not request location permission by default.
- Require precise location only when the per-SSID option is enabled.
- Automatically disable the option if precise location permission is subsequently revoked or downgraded.
- Clear the in-memory route history only as part of an explicit connection/service lifecycle restart.

When a known network is encountered again, its cached route is installed as a temporary warm-start override. The override is released when the running Observatory reports its first fresh viable target, and the cache is updated directly from subsequent target-change callbacks.

### Disposable batch delay testing

- Build all supported selected profiles into one isolated probing configuration.
- Run that configuration in a focused `:OutboundProbe` Android process.
- Use one Xray instance to probe multiple outbounds concurrently.
- Discard the process after the batch completes or is cancelled.
- Namespace profile, outbound, routing, balancer, and Observatory tags to prevent collisions.
- Deliver progressive delay updates as individual probe samples become available.
- Evaluate policy groups using their actual `leastPing` or `leastLoad` selection rather than an unrelated outbound.
- Return successful route selections to the main process and update the route cache only when the network identity and handle still match.
- Preserve repeated test requests through disposable-process restarts and suppress stale callbacks from older batches.

The disposable test core is intentionally not warm-started from the cache. Its results are an output used to update the main process's route memory; they are not input inherited from a previous test process.

Unsupported or ambiguous configurations fail individually without invalidating otherwise probeable profiles. This includes conditional policy-group routing, unresolved outbound references, duplicate tags, and unsupported `leastLoad` cost configurations.

## Privacy and permissions

The default behavior requires no location permission. Users who explicitly enable per-SSID route memory are informed that precise location is required by Android to obtain the Wi-Fi SSID.

## Dependencies

This PR depends on:

- [2dust/AndroidLibXrayLite#200](https://github.com/2dust/AndroidLibXrayLite/pull/200)
- [XTLS/Xray-core#6492](https://github.com/XTLS/Xray-core/pull/6492)

It no longer depends on [XTLS/Xray-core#6483](https://github.com/XTLS/Xray-core/pull/6483).

The AndroidLibXrayLite submodule pointer is deliberately not changed in this application PR. The dependency should be updated normally after the prerequisite AndroidLibXrayLite work is accepted.

## Testing

- Focused route-cache, network-identity, underlay-tracking, and outbound-probe configuration tests pass.
- `assemblePlaystoreDebug` succeeds.
- Tested on an Android 17 emulator with Xray native TUN.
- Verified Wi-Fi/cellular transitions and continued browser connectivity.
- Verified denied, approximate, precise, revoked, and downgraded location-permission workflows.
- Verified repeated real-delay tests, including starting a second batch three seconds after the first.
- Verified progressive policy-group results and disposable probing-process replacement.