### PR TITLE
Add XMC (Minecraft FinalMask) settings to ServerActivity

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerActivity.kt
@@ -13,6 +13,7 @@ import android.widget.LinearLayout
 import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.SwitchCompat
 import androidx.lifecycle.lifecycleScope
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.DEFAULT_PORT
@@ -34,6 +35,7 @@ import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.Utils
+import com.v2ray.ang.util.XmcFinalMaskUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -144,6 +146,12 @@ class ServerActivity : BaseActivity() {
     private val et_extra: EditText? by lazy { findViewById(R.id.et_extra) }
     private val et_fm: EditText? by lazy { findViewById(R.id.et_fm) }
     private val layout_extra: LinearLayout? by lazy { findViewById(R.id.layout_extra) }
+    private val layout_xmc: LinearLayout? by lazy { findViewById(R.id.layout_xmc) }
+    private val sw_xmc: SwitchCompat? by lazy { findViewById(R.id.sw_xmc) }
+    private val layout_xmc_settings: LinearLayout? by lazy { findViewById(R.id.layout_xmc_settings) }
+    private val et_xmc_hostname: EditText? by lazy { findViewById(R.id.et_xmc_hostname) }
+    private val et_xmc_usernames: EditText? by lazy { findViewById(R.id.et_xmc_usernames) }
+    private val et_xmc_password: EditText? by lazy { findViewById(R.id.et_xmc_password) }
     private val et_ech_config_list: EditText? by lazy { findViewById(R.id.et_ech_config_list) }
     private val container_ech_config_list: LinearLayout? by lazy { findViewById(R.id.lay_ech_config_list) }
     private val et_verify_peer_cert_by_name: EditText? by lazy { findViewById(R.id.et_verify_peer_cert_by_name) }
@@ -269,6 +277,12 @@ class ServerActivity : BaseActivity() {
                         else -> View.GONE
                     }
 
+                layout_xmc?.visibility =
+                    when (networks[position]) {
+                        NetworkType.TCP.type -> View.VISIBLE
+                        else -> View.GONE
+                    }
+
                 layout_browser_dialer?.visibility =
                     when (networks[position]) {
                         NetworkType.WS.type -> View.VISIBLE
@@ -358,6 +372,9 @@ class ServerActivity : BaseActivity() {
         btn_pinned_ca256_action?.setOnClickListener {
             fetchPinnedCA256ForCurrentConfig()
         }
+        sw_xmc?.setOnCheckedChangeListener { _, isChecked ->
+            layout_xmc_settings?.visibility = if (isChecked) View.VISIBLE else View.GONE
+        }
         if (config != null) {
             bindingServer(config)
         } else {
@@ -445,6 +462,8 @@ class ServerActivity : BaseActivity() {
             sp_browser_dialer_mode?.setSelection(browserDialerMode)
         }
 
+        bindXmcSettings(config.finalMask)
+
         return true
     }
 
@@ -474,6 +493,7 @@ class ServerActivity : BaseActivity() {
             Utils.getEditable(WIREGUARD_LOCAL_ADDRESS_V4)
         et_local_mtu?.text = Utils.getEditable(WIREGUARD_LOCAL_MTU)
         sp_browser_dialer_mode?.setSelection(0)
+        bindXmcSettings(null)
         return true
     }
 
@@ -529,6 +549,14 @@ class ServerActivity : BaseActivity() {
                 toast(R.string.server_lab_final_mask)
                 return false
             }
+        }
+        val selectedNetwork = networks.getOrNull(sp_network?.selectedItemPosition ?: -1)
+        if (selectedNetwork == NetworkType.TCP.type
+            && sw_xmc?.isChecked == true
+            && et_xmc_password?.text?.toString().isNullOrEmpty()
+        ) {
+            toast(R.string.server_lab_xmc_password_required)
+            return false
         }
 
         saveCommon(config)
@@ -603,7 +631,20 @@ class ServerActivity : BaseActivity() {
         profileItem.authority = requestHost
         profileItem.xhttpMode = transportTypes(networks[network])[type]
         profileItem.xhttpExtra = et_extra?.text?.toString()?.trim().nullIfBlank()
-        profileItem.finalMask = et_fm?.text?.toString()?.trim()?.nullIfBlank()
+        val rawFinalMask = et_fm?.text?.toString()?.trim()?.nullIfBlank()
+        val xmcSettings = if (networks[network] == NetworkType.TCP.type && sw_xmc?.isChecked == true) {
+            XmcFinalMaskUtil.Settings(
+                hostname = et_xmc_hostname?.text?.toString()?.trim().orEmpty(),
+                usernames = et_xmc_usernames?.text?.toString().orEmpty()
+                    .split(',')
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() },
+                password = et_xmc_password?.text?.toString().orEmpty(),
+            )
+        } else {
+            null
+        }
+        profileItem.finalMask = XmcFinalMaskUtil.update(rawFinalMask, xmcSettings)?.nullIfBlank()
         profileItem.kcpMtu = et_kcp_mtu?.text?.toString()?.toIntOrNull()
         profileItem.kcpTti = et_kcp_tti?.text?.toString()?.toIntOrNull()
         if (networks[network] == NetworkType.WS.type || networks[network] == NetworkType.XHTTP.type) {
@@ -616,6 +657,14 @@ class ServerActivity : BaseActivity() {
         } else {
             profileItem.browserDialerMode = null
         }
+    }
+
+    private fun bindXmcSettings(finalMask: String?) {
+        val settings = XmcFinalMaskUtil.extract(finalMask)
+        sw_xmc?.isChecked = settings != null
+        et_xmc_hostname?.text = Utils.getEditable(settings?.hostname)
+        et_xmc_usernames?.text = Utils.getEditable(settings?.usernames?.joinToString(", "))
+        et_xmc_password?.text = Utils.getEditable(settings?.password)
     }
 
     private fun saveTls(config: ProfileItem) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/XmcFinalMaskUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/XmcFinalMaskUtil.kt
@@ -1,0 +1,125 @@
+package com.v2ray.ang.util
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+
+/** Helpers for editing an XMC TCP mask without discarding other FinalMask settings. */
+object XmcFinalMaskUtil {
+    private const val TYPE_XMC = "xmc"
+
+    data class Settings(
+        val hostname: String = "",
+        val usernames: List<String> = emptyList(),
+        val password: String = "",
+    )
+
+    fun extract(finalMask: String?): Settings? {
+        val root = parseObject(finalMask) ?: return null
+        val tcp = root.get("tcp")?.takeIf { it.isJsonArray }?.asJsonArray ?: return null
+
+        tcp.forEach { element ->
+            val mask = element.takeIf { it.isJsonObject }?.asJsonObject ?: return@forEach
+            if (mask.stringValue("type") != TYPE_XMC) return@forEach
+
+            val settings = mask.get("settings")?.takeIf { it.isJsonObject }?.asJsonObject
+            return Settings(
+                hostname = settings?.stringValue("hostname").orEmpty(),
+                usernames = settings?.usernameValues().orEmpty(),
+                password = settings?.stringValue("password").orEmpty(),
+            )
+        }
+
+        return null
+    }
+
+    /**
+     * Replaces all XMC entries while retaining every other FinalMask field and mask in order.
+     * Passing null removes XMC. Invalid input is returned unchanged so callers never lose raw data.
+     */
+    fun update(finalMask: String?, settings: Settings?): String? {
+        val root = if (finalMask.isNullOrBlank()) {
+            JsonObject()
+        } else {
+            parseObject(finalMask) ?: return finalMask
+        }
+
+        val currentTcp = root.get("tcp")?.takeIf { it.isJsonArray }?.asJsonArray
+        val updatedTcp = JsonArray()
+        var foundXmc = false
+
+        currentTcp?.forEach { element ->
+            val mask = element.takeIf { it.isJsonObject }?.asJsonObject
+            val isXmc = mask?.stringValue("type") == TYPE_XMC
+            if (!isXmc) {
+                updatedTcp.add(element)
+            } else if (!foundXmc) {
+                foundXmc = true
+                settings?.let { updatedTcp.add(createMask(it)) }
+            }
+        }
+
+        if (!foundXmc && settings != null) {
+            updatedTcp.add(createMask(settings))
+        }
+
+        if (updatedTcp.size() == 0) {
+            root.remove("tcp")
+        } else {
+            root.add("tcp", updatedTcp)
+        }
+
+        return root.takeUnless { it.size() == 0 }?.toString()
+    }
+
+    private fun createMask(settings: Settings): JsonObject {
+        val xmcSettings = JsonObject().apply {
+            settings.hostname.trim().takeIf { it.isNotEmpty() }?.let {
+                addProperty("hostname", it)
+            }
+
+            val normalizedUsernames = settings.usernames
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+            if (normalizedUsernames.isNotEmpty()) {
+                add("usernames", JsonArray().apply {
+                    normalizedUsernames.forEach(::add)
+                })
+            }
+
+            addProperty("password", settings.password)
+        }
+
+        return JsonObject().apply {
+            addProperty("type", TYPE_XMC)
+            add("settings", xmcSettings)
+        }
+    }
+
+    private fun parseObject(value: String?): JsonObject? {
+        if (value.isNullOrBlank()) return null
+        return runCatching {
+            JsonParser.parseString(value).takeIf { it.isJsonObject }?.asJsonObject
+        }.getOrNull()
+    }
+
+    private fun JsonObject.stringValue(key: String): String? {
+        return get(key)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+    }
+
+    private fun JsonObject.usernameValues(): List<String> {
+        val value = get("usernames") ?: return emptyList()
+        return when {
+            value.isJsonArray -> value.asJsonArray.mapNotNull { item ->
+                item.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+            }
+
+            value.isJsonPrimitive && value.asJsonPrimitive.isString -> value.asString
+                .split(',')
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+
+            else -> emptyList()
+        }
+    }
+}

--- a/V2rayNG/app/src/main/res/layout/layout_transport.xml
+++ b/V2rayNG/app/src/main/res/layout/layout_transport.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -159,6 +160,90 @@
             android:inputType="textMultiLine"
             android:maxLines="20"
             android:minLines="4" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_xmc"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/padding_spacing_dp16"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/server_lab_xmc_enable"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/sw_xmc"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/padding_spacing_dp16"
+                android:paddingEnd="@dimen/padding_spacing_dp16"
+                app:theme="@style/BrandedSwitch" />
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/padding_spacing_dp4"
+            android:text="@string/server_lab_xmc_tip"
+            android:textColor="@android:color/darker_gray"
+            android:textSize="12sp" />
+
+        <LinearLayout
+            android:id="@+id/layout_xmc_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:text="@string/server_lab_xmc_hostname" />
+
+            <EditText
+                android:id="@+id/et_xmc_hostname"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="mc.example.com"
+                android:inputType="textUri" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:text="@string/server_lab_xmc_usernames" />
+
+            <EditText
+                android:id="@+id/et_xmc_usernames"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Steve, Alex"
+                android:inputType="text" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_spacing_dp16"
+                android:text="@string/server_lab_xmc_password" />
+
+            <EditText
+                android:id="@+id/et_xmc_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword" />
+        </LinearLayout>
     </LinearLayout>
 
     <LinearLayout

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -116,6 +116,12 @@
     <string name="server_lab_xhttp_mode">XHTTP 模式</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra 原始 JSON，格式： { XHTTPObject }</string>
     <string name="server_lab_final_mask">FinalMask 原始 JSON 格式: { FinalMaskObject }</string>
+    <string name="server_lab_xmc_enable">启用 XMC（Minecraft FinalMask）</string>
+    <string name="server_lab_xmc_tip">仅支持 TCP。客户端密码必须与 Xray 服务端一致；hostname 和用户名可留空。</string>
+    <string name="server_lab_xmc_hostname">Minecraft hostname（可选）</string>
+    <string name="server_lab_xmc_usernames">Minecraft 用户名（逗号分隔，可选）</string>
+    <string name="server_lab_xmc_password">XMC 密码</string>
+    <string name="server_lab_xmc_password_required">必须填写 XMC 密码</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">证书指纹 (SHA-256)</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -116,6 +116,12 @@
     <string name="server_lab_xhttp_mode">XHTTP 模式</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra 原始 JSON，格式： { XHTTPObject }</string>
     <string name="server_lab_final_mask">FinalMask 原始 JSON 格式: { FinalMaskObject }</string>
+    <string name="server_lab_xmc_enable">啟用 XMC（Minecraft FinalMask）</string>
+    <string name="server_lab_xmc_tip">僅支援 TCP。用戶端密碼必須與 Xray 伺服器一致；hostname 和使用者名稱可留空。</string>
+    <string name="server_lab_xmc_hostname">Minecraft hostname（可選）</string>
+    <string name="server_lab_xmc_usernames">Minecraft 使用者名稱（逗號分隔，可選）</string>
+    <string name="server_lab_xmc_password">XMC 密碼</string>
+    <string name="server_lab_xmc_password_required">必須填寫 XMC 密碼</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">證書指紋 (SHA-256)</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -117,6 +117,12 @@
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
+    <string name="server_lab_xmc_enable">Enable XMC (Minecraft FinalMask)</string>
+    <string name="server_lab_xmc_tip">TCP only. The client password must match the Xray server; hostname and usernames are optional.</string>
+    <string name="server_lab_xmc_hostname">Minecraft hostname (optional)</string>
+    <string name="server_lab_xmc_usernames">Minecraft usernames (comma-separated, optional)</string>
+    <string name="server_lab_xmc_password">XMC password</string>
+    <string name="server_lab_xmc_password_required">XMC password is required</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/util/XmcFinalMaskUtilTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/util/XmcFinalMaskUtilTest.kt
@@ -1,0 +1,132 @@
+package com.v2ray.ang.util
+
+import com.google.gson.JsonParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class XmcFinalMaskUtilTest {
+
+    @Test
+    fun extractReadsXmcSettings() {
+        val finalMask = """
+            {
+              "tcp": [
+                {
+                  "type": "xmc",
+                  "settings": {
+                    "hostname": "mc.example.com",
+                    "usernames": ["Steve", "Alex"],
+                    "password": "secret"
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        assertEquals(
+            XmcFinalMaskUtil.Settings(
+                hostname = "mc.example.com",
+                usernames = listOf("Steve", "Alex"),
+                password = "secret",
+            ),
+            XmcFinalMaskUtil.extract(finalMask),
+        )
+    }
+
+    @Test
+    fun updateAddsXmcAndPreservesOtherMasks() {
+        val finalMask = """
+            {
+              "tcp": [{"type":"fragment","settings":{"packets":"tlshello"}}],
+              "quicParams": {"congestion":"bbr"}
+            }
+        """.trimIndent()
+
+        val updated = XmcFinalMaskUtil.update(
+            finalMask,
+            XmcFinalMaskUtil.Settings(
+                hostname = "mc.example.com",
+                usernames = listOf("Steve", "Alex"),
+                password = "secret",
+            ),
+        )
+        val root = JsonParser.parseString(updated).asJsonObject
+        val tcp = root.getAsJsonArray("tcp")
+
+        assertEquals(2, tcp.size())
+        assertEquals("fragment", tcp[0].asJsonObject.get("type").asString)
+        assertEquals("xmc", tcp[1].asJsonObject.get("type").asString)
+        assertEquals("bbr", root.getAsJsonObject("quicParams").get("congestion").asString)
+    }
+
+    @Test
+    fun updateReplacesDuplicateXmcMasksAtOriginalPosition() {
+        val finalMask = """
+            {
+              "tcp": [
+                {"type":"xmc","settings":{"password":"old-1"}},
+                {"type":"fragment","settings":{"packets":"tlshello"}},
+                {"type":"xmc","settings":{"password":"old-2"}}
+              ]
+            }
+        """.trimIndent()
+
+        val updated = XmcFinalMaskUtil.update(
+            finalMask,
+            XmcFinalMaskUtil.Settings(password = "new-password"),
+        )
+        val tcp = JsonParser.parseString(updated).asJsonObject.getAsJsonArray("tcp")
+
+        assertEquals(2, tcp.size())
+        assertEquals("xmc", tcp[0].asJsonObject.get("type").asString)
+        assertEquals(
+            "new-password",
+            tcp[0].asJsonObject.getAsJsonObject("settings").get("password").asString,
+        )
+        assertEquals("fragment", tcp[1].asJsonObject.get("type").asString)
+    }
+
+    @Test
+    fun updateRemovesOnlyXmc() {
+        val withOtherMask = """{"tcp":[{"type":"xmc","settings":{"password":"secret"}},{"type":"fragment"}]}"""
+        val withoutOtherMask = """{"tcp":[{"type":"xmc","settings":{"password":"secret"}}]}"""
+
+        val retained = JsonParser.parseString(XmcFinalMaskUtil.update(withOtherMask, null)).asJsonObject
+        assertEquals("fragment", retained.getAsJsonArray("tcp")[0].asJsonObject.get("type").asString)
+        assertFalse(retained.getAsJsonArray("tcp").any { it.asJsonObject.get("type").asString == "xmc" })
+        assertNull(XmcFinalMaskUtil.update(withoutOtherMask, null))
+    }
+
+    @Test
+    fun updateKeepsInvalidRawJsonUnchanged() {
+        val invalid = "{invalid"
+
+        assertEquals(
+            invalid,
+            XmcFinalMaskUtil.update(invalid, XmcFinalMaskUtil.Settings(password = "secret")),
+        )
+        assertNull(XmcFinalMaskUtil.extract(invalid))
+    }
+
+    @Test
+    fun updateOmitsBlankOptionalFields() {
+        val updated = XmcFinalMaskUtil.update(
+            null,
+            XmcFinalMaskUtil.Settings(
+                hostname = "  ",
+                usernames = listOf(" "),
+                password = "secret",
+            ),
+        )
+        val settings = JsonParser.parseString(updated).asJsonObject
+            .getAsJsonArray("tcp")[0].asJsonObject
+            .getAsJsonObject("settings")
+
+        assertFalse(settings.has("hostname"))
+        assertFalse(settings.has("usernames"))
+        assertTrue(settings.has("password"))
+    }
+}


### PR DESCRIPTION
- Introduced UI elements for XMC configuration in layout_transport.xml.
- Added logic to handle XMC settings visibility and validation in ServerActivity.kt.
- Updated strings.xml and localized files for new XMC-related strings.
- Ensured password validation for XMC when TCP is selected.