### PR TITLE
Recover policy routes across network switches and separate process real-delay probing

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -28,6 +28,9 @@
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="PackageVisibilityPolicy,QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -217,7 +220,7 @@
             android:name=".service.CoreTestService"
             android:exported="false"
             android:foregroundServiceType="specialUse"
-            android:process=":RunSoLibV2RayDaemon">
+            android:process=":OutboundProbe">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="test" />

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -44,6 +44,7 @@ object AppConfig {
     const val PREF_FRAGMENT_LENGTH = "pref_fragment_length"
     const val PREF_FRAGMENT_INTERVAL = "pref_fragment_interval"
     const val PREF_FRAGMENT_MAXSPLIT = "pref_fragment_maxsplit"
+    const val PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK = "pref_remember_routes_per_wifi_network"
     const val SUBSCRIPTION_UPDATE_TASK_NAME = "subscription_updater"
     const val SUBSCRIPTION_MIN_INTERVAL_MINUTES = 15L
     const val PREF_SPEED_ENABLED = "pref_speed_enabled"
@@ -173,6 +174,7 @@ object AppConfig {
     const val MSG_MEASURE_CONFIG_SUCCESS = 72
     const val MSG_MEASURE_CONFIG_NOTIFY = 73
     const val MSG_MEASURE_CONFIG_FINISH = 74
+    const val MSG_POLICY_ROUTE_OBSERVED = 75
 
     /** Notification channel IDs and names. */
     const val RAY_NG_CHANNEL_ID = "RAY_NG_M_CH_ID"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonArray
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.dto.ConfigResult
 import com.v2ray.ang.dto.CoreConfigContext
+import com.v2ray.ang.dto.OutboundProbePlan
 import com.v2ray.ang.dto.V2rayConfig
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.RulesetItem
@@ -72,6 +73,31 @@ object CoreConfigManager {
                 errorMessage = "Failed to get V2ray config for speedtest: ${e.message ?: e.javaClass.simpleName}"
             )
         }
+    }
+
+    /**
+     * Build one short-lived core configuration for a complete UI delay-test
+     * batch. Invalid profiles are retained as failed GUIDs so one malformed
+     * entry cannot prevent viable outbounds from being measured.
+     */
+    fun getV2rayConfig4BatchSpeedtest(context: Context, guids: List<String>): OutboundProbePlan {
+        val sources = mutableListOf<OutboundProbeConfigBuilder.Source>()
+        val failedGuids = mutableListOf<String>()
+        guids.distinct().forEach { guid ->
+            val result = getV2rayConfig4Speedtest(context, guid)
+            if (result.status && result.content.isNotBlank() &&
+                CoreNativeManager.validateOutboundProbeConfig(result.content)
+            ) {
+                sources += OutboundProbeConfigBuilder.Source(guid, result.content)
+            } else {
+                failedGuids += guid
+            }
+        }
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = sources,
+            destination = SettingsManager.getDelayTestUrl(),
+        )
+        return plan.copy(failedGuids = (failedGuids + plan.failedGuids).distinct())
     }
 
     /**
@@ -394,7 +420,18 @@ object CoreConfigManager {
     private fun postProcessForSpeedtest(v2rayConfig: V2rayConfig) {
         v2rayConfig.log.loglevel = MmkvManager.decodeSettingsString(AppConfig.PREF_LOGLEVEL) ?: "warning"
         v2rayConfig.inbounds.clear()
+        val usesPrimaryBalancer = v2rayConfig.routing.balancers
+            ?.any { it.tag == AppConfig.TAG_BALANCER }
+            ?: false
         v2rayConfig.routing.rules.clear()
+        if (usesPrimaryBalancer) {
+            v2rayConfig.routing.rules.add(
+                V2rayConfig.RoutingBean.RulesBean(
+                    network = "tcp,udp",
+                    balancerTag = AppConfig.TAG_BALANCER,
+                )
+            )
+        }
         v2rayConfig.dns = null
         v2rayConfig.fakedns = null
         v2rayConfig.stats = null

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreNativeManager.kt
@@ -3,11 +3,14 @@ package com.v2ray.ang.core
 import android.content.Context
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.util.LogUtil
+import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.Utils
 import go.Seq
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
 import libv2ray.Libv2ray
+import libv2ray.OutboundProbeController
+import libv2ray.OutboundProbeHandler
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -17,6 +20,19 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Provides initialization protection and unified API for V2Ray core operations.
  */
 object CoreNativeManager {
+    data class OutboundProbeStatus(
+        val outboundTag: String = "",
+        val alive: Boolean = false,
+        val delay: Long = -1L,
+        val samples: Long = 0L,
+    )
+
+    data class OutboundProbeBatchResult(
+        val cancelled: Boolean = false,
+        val results: List<OutboundProbeStatus> = emptyList(),
+        val balancerTargets: Map<String, String> = emptyMap(),
+    )
+
     private val initialized = AtomicBoolean(false)
 
     /**
@@ -67,20 +83,42 @@ object CoreNativeManager {
         }
     }
 
+    fun validateOutboundProbeConfig(config: String): Boolean = try {
+        Libv2ray.validateOutboundProbeConfig(config)
+        true
+    } catch (e: Exception) {
+        LogUtil.w(AppConfig.TAG, "Rejected invalid outbound probe source: ${e.message}")
+        false
+    }
+
+    fun newOutboundProbeController(): OutboundProbeController =
+        Libv2ray.newOutboundProbeController()
+
     /**
-     * Measure outbound connection delay.
-     *
-     * @param config The configuration JSON string
-     * @param testUrl The URL to test against
-     * @return Delay in milliseconds, or -1 if test failed
+     * Runs the AndroidLib compatibility adapter around upstream Xray's existing
+     * BurstObservatory.Check and GetObservation APIs. Each nested tag list is
+     * one UI configuration, so maxConcurrency keeps its settings-level meaning.
+     * The dedicated service process remains the hard isolation boundary.
      */
-    fun measureOutboundDelay(config: String, testUrl: String): Long {
-        return try {
-            Libv2ray.measureOutboundDelay(config, testUrl)
-        } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "Failed to measure outbound delay", e)
-            -1L
-        }
+    fun probeOutboundGroups(
+        controller: OutboundProbeController,
+        config: String,
+        outboundGroupsJson: String,
+        balancerTagsJson: String,
+        maxConcurrency: Int,
+        samples: Int,
+        handler: OutboundProbeHandler,
+    ): OutboundProbeBatchResult {
+        val payload = controller.probeOutboundGroups(
+            config,
+            outboundGroupsJson,
+            balancerTagsJson,
+            maxConcurrency,
+            samples,
+            handler,
+        )
+        return JsonUtil.fromJsonSafe(payload, OutboundProbeBatchResult::class.java)
+            ?: throw IllegalStateException("Invalid outbound probe response")
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -14,8 +14,10 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.dto.OutboundTrafficStat
+import com.v2ray.ang.dto.PolicyRouteUpdate
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.extension.isComplexType
+import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.extension.toast
 import com.v2ray.ang.extension.toastError
 import com.v2ray.ang.handler.MmkvManager
@@ -34,20 +36,31 @@ import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
 import libv2ray.ProcessFinder
 import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 object CoreServiceManager {
 
     private val coreController: CoreController = CoreNativeManager.newCoreController(CoreCallback())
     private val mMsgReceive = ReceiveMessageHandler()
+    private val mSystemEventReceive = SystemEventHandler()
     private var currentConfig: ProfileItem? = null
     private var processFinder: XrayProcessFinder? = null
     private var browserDialer: IDialerService? = null
+    @Volatile private var runningProfileGuid = ""
+    private val networkResetMutex = Mutex()
+    private val coreScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val networkTransitions = AtomicInteger(0)
+    private val policyRouteCallbacksEnabled = AtomicBoolean(false)
 
     var serviceControl: SoftReference<ServiceControl>? = null
         set(value) {
@@ -114,6 +127,105 @@ object CoreServiceManager {
      * @return True if the service is running, false otherwise.
      */
     fun isRunning() = coreController.isRunning
+
+    /**
+     * Sequentially closes and recreates the only Xray instance in this process
+     * after Android changes the VPN's underlying network. The VPN interface and
+     * service remain active, and unchanged upstream process-global state never
+     * overlaps two live instances.
+     */
+    fun resetCoreNetworkState(previousNetworkKey: String?, newNetworkKey: String, newNetworkHandle: Long) {
+        networkTransitions.incrementAndGet()
+        PolicyRouteCache.setCurrentNetwork(newNetworkKey, newNetworkHandle)
+        if (!coreController.isRunning) {
+            networkTransitions.decrementAndGet()
+            return
+        }
+
+        val profileGuid = runningProfileGuid
+        val cacheGeneration = PolicyRouteCache.snapshot().generation
+        coreScope.launch {
+            networkResetMutex.withLock {
+                try {
+                    val currentTarget = coreController.getBalancerPrincipleTarget(AppConfig.TAG_BALANCER)
+                    PolicyRouteCache.remember(
+                        previousNetworkKey,
+                        profileGuid,
+                        currentTarget,
+                        cacheGeneration,
+                    )
+                    val warmTarget = PolicyRouteCache.lookup(newNetworkKey, profileGuid).orEmpty()
+                    coreController.resetNetworkStateWithWarmRoute(AppConfig.TAG_BALANCER, warmTarget)
+                    LogUtil.i(
+                        AppConfig.TAG,
+                        "StartCore-Manager: Core network state reset" +
+                            if (warmTarget.isNotEmpty()) " with cached policy route" else "",
+                    )
+                } catch (e: Exception) {
+                    policyRouteCallbacksEnabled.set(false)
+                    LogUtil.e(
+                        AppConfig.TAG,
+                        "StartCore-Manager: Core network reset and recovery failed; keeping VPN fail-closed",
+                        e,
+                    )
+                    getService()?.let { service ->
+                        val message = service.getString(R.string.notification_core_recovery_failed)
+                        MessageUtil.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+                        NotificationManager.showCoreFailure(message)
+                    }
+                } finally {
+                    if (networkTransitions.decrementAndGet() == 0 && policyRouteCallbacksEnabled.get()) {
+                        refreshFreshPolicyRoute()
+                    }
+                }
+            }
+        }
+    }
+
+    fun updateCoreNetworkIdentity(newNetworkKey: String, newNetworkHandle: Long) {
+        PolicyRouteCache.setCurrentNetwork(newNetworkKey, newNetworkHandle)
+        if (coreController.isRunning && policyRouteCallbacksEnabled.get()) {
+            coreScope.launch { refreshFreshPolicyRoute() }
+        }
+    }
+
+    private fun refreshFreshPolicyRoute() {
+        val cacheSnapshot = PolicyRouteCache.snapshot()
+        val freshTarget = try {
+            coreController.getBalancerPrincipleTarget(AppConfig.TAG_BALANCER)
+        } catch (_: Exception) {
+            ""
+        }
+        rememberFreshPolicyRoute(freshTarget, cacheSnapshot)
+    }
+
+    private fun rememberFreshPolicyRoute(
+        target: String?,
+        cacheSnapshot: PolicyRouteCache.Snapshot = PolicyRouteCache.snapshot(),
+    ): Boolean {
+        if (!policyRouteCallbacksEnabled.get() || networkTransitions.get() != 0 || target.isNullOrBlank()) return false
+        val profileGuid = runningProfileGuid
+        if (PolicyRouteCache.rememberCurrent(cacheSnapshot, profileGuid, target)) {
+            LogUtil.i(AppConfig.TAG, "Policy route cache accepted fresh observatory target")
+            return true
+        }
+        return false
+    }
+
+    private fun rememberProbedPolicyRoute(update: PolicyRouteUpdate?) {
+        if (!policyRouteCallbacksEnabled.get() || networkTransitions.get() != 0 ||
+            update == null || update.profileGuid.isBlank() || update.outboundTag.isBlank()
+        ) return
+        if (PolicyRouteCache.rememberObserved(
+                update.networkKey,
+                update.networkHandle,
+                update.profileGuid,
+                update.outboundTag,
+            )
+        ) {
+            LogUtil.i(AppConfig.TAG, "Policy route cache updated from batch observatory result")
+        }
+    }
 
     /**
      * Gets the name of the currently running server.
@@ -247,11 +359,21 @@ object CoreServiceManager {
             error(result.errorMessage.ifBlank { "Failed to get V2Ray config" })
         }
 
-        val mFilter = IntentFilter(AppConfig.BROADCAST_ACTION_SERVICE)
-        mFilter.addAction(Intent.ACTION_SCREEN_ON)
-        mFilter.addAction(Intent.ACTION_SCREEN_OFF)
-        mFilter.addAction(Intent.ACTION_USER_PRESENT)
-        ContextCompat.registerReceiver(service, mMsgReceive, mFilter, Utils.receiverFlags())
+        // Commands and probe results originate only from another process of
+        // this application. Keeping this receiver non-exported prevents other
+        // apps from forging control or policy-route cache messages.
+        ContextCompat.registerReceiver(
+            service,
+            mMsgReceive,
+            IntentFilter(AppConfig.BROADCAST_ACTION_SERVICE),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+        val systemFilter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_ON)
+            addAction(Intent.ACTION_SCREEN_OFF)
+            addAction(Intent.ACTION_USER_PRESENT)
+        }
+        ContextCompat.registerReceiver(service, mSystemEventReceive, systemFilter, Utils.receiverFlags())
 
         currentConfig = config
         var tunFd = vpnInterface?.fd ?: 0
@@ -266,12 +388,23 @@ object CoreServiceManager {
 
         NotificationManager.showNotification(currentConfig)
         CoreNativeManager.reconcileBrowserDialer(dialerAddr)
-        coreController.startLoop(result.content, tunFd)
+        runningProfileGuid = guid
+        policyRouteCallbacksEnabled.set(true)
+        try {
+            coreController.startLoop(result.content, tunFd)
+        } catch (e: Exception) {
+            policyRouteCallbacksEnabled.set(false)
+            runningProfileGuid = ""
+            throw e
+        }
 
         if (!coreController.isRunning) {
+            policyRouteCallbacksEnabled.set(false)
+            runningProfileGuid = ""
             error("Core failed to start")
         }
 
+        coreScope.launch { refreshFreshPolicyRoute() }
         if (browserDialer != null) {
             browserDialer!!.stop()
             browserDialer = null
@@ -295,6 +428,9 @@ object CoreServiceManager {
      * @return True if the core was stopped successfully, false otherwise.
      */
     fun stopCoreLoop(): Boolean {
+        policyRouteCallbacksEnabled.set(false)
+        PolicyRouteCache.clear()
+        runningProfileGuid = ""
         val service = getService() ?: return false
 
         if (coreController.isRunning) {
@@ -321,6 +457,11 @@ object CoreServiceManager {
             service.unregisterReceiver(mMsgReceive)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to unregister receiver", e)
+        }
+        try {
+            service.unregisterReceiver(mSystemEventReceive)
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to unregister system receiver", e)
         }
 
         return true
@@ -446,6 +587,13 @@ object CoreServiceManager {
         override fun onEmitStatus(l: Long, s: String?): Long {
             return 0
         }
+
+        override fun onBalancerTargetChanged(balancerTag: String?, target: String?): Long {
+            if (balancerTag == AppConfig.TAG_BALANCER) {
+                return if (rememberFreshPolicyRoute(target)) 0 else 1
+            }
+            return 0
+        }
     }
 
     /**
@@ -486,13 +634,12 @@ object CoreServiceManager {
     }
 
     /**
-     * Broadcast receiver for handling messages sent to the service.
-     * Handles registration, service control, and screen events.
+     * App-private receiver for control messages sent to the service.
      */
     private class ReceiveMessageHandler : BroadcastReceiver() {
         /**
          * Handles received broadcast messages.
-         * Processes service control messages and screen state changes.
+         * Processes service control messages from another app process.
          * @param ctx The context in which the receiver is running.
          * @param intent The intent being received.
          */
@@ -530,8 +677,17 @@ object CoreServiceManager {
                 AppConfig.MSG_MEASURE_DELAY -> {
                     measureV2rayDelay()
                 }
+
+                AppConfig.MSG_POLICY_ROUTE_OBSERVED -> {
+                    rememberProbedPolicyRoute(intent.serializable("content"))
+                }
             }
 
+        }
+    }
+
+    private class SystemEventHandler : BroadcastReceiver() {
+        override fun onReceive(ctx: Context?, intent: Intent?) {
             when (intent?.action) {
                 Intent.ACTION_SCREEN_OFF -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Screen off")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/OutboundProbeConfigBuilder.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/OutboundProbeConfigBuilder.kt
@@ -1,0 +1,296 @@
+package com.v2ray.ang.core
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.v2ray.ang.dto.OutboundProbeCandidate
+import com.v2ray.ang.dto.OutboundProbePlan
+import com.v2ray.ang.dto.OutboundProbeProfilePlan
+import com.v2ray.ang.util.JsonUtil
+
+/**
+ * Combines independently generated speed-test configurations into one core.
+ *
+ * Every source gets a private tag namespace. Only outbound definitions and the
+ * primary policy-group balancer are retained. AndroidLib drives the unchanged
+ * upstream BurstObservatory.Check API with profile-level concurrency and
+ * progressive candidate snapshots, so unrelated routing and inbound state must
+ * not affect another profile in the same batch.
+ */
+object OutboundProbeConfigBuilder {
+    data class Source(val guid: String, val content: String)
+
+    fun build(
+        sources: List<Source>,
+        destination: String,
+        timeout: String = DEFAULT_PROBE_TIMEOUT,
+        samples: Int = 1,
+    ): OutboundProbePlan {
+        require(destination.isNotBlank()) { "probe destination is empty" }
+        require(samples > 0) { "probe sample count must be positive" }
+
+        val mergedOutbounds = JsonArray()
+        val mergedBalancers = JsonArray()
+        val profiles = mutableListOf<OutboundProbeProfilePlan>()
+        val failedGuids = mutableListOf<String>()
+        var batchSamples = samples
+        var batchTimeout = timeout
+        var leastLoadHttpMethod: String? = null
+
+        sources.distinctBy { it.guid }.forEachIndexed { index, source ->
+            val root = JsonUtil.parseString(source.content)
+            val outbounds = root?.array("outbounds")
+            if (outbounds == null || outbounds.size() == 0) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+
+            val namespace = "probe-$index-"
+            val outboundElements = outbounds.toList()
+            if (outboundElements.any { !it.isJsonObject }) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+            val outboundObjects = outboundElements.map { it.asJsonObject.deepCopy() }
+            val originalTags = outboundObjects.mapIndexed { outboundIndex, outbound ->
+                outbound.string("tag") ?: "outbound-$outboundIndex"
+            }
+            if (originalTags.toSet().size != originalTags.size) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+
+            val tagMap = linkedMapOf<String, String>()
+            outboundObjects.forEachIndexed { outboundIndex, outbound ->
+                val originalTag = originalTags[outboundIndex]
+                val probeTag = "$namespace$originalTag"
+                tagMap[originalTag] = probeTag
+                outbound.addProperty("tag", probeTag)
+            }
+            if (outboundObjects.any { !remapOutboundReferences(it, tagMap) }) {
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+
+            val routing = root.obj("routing")
+            val routingRules = routing?.array("rules")
+                ?.mapNotNull { it.takeIf { rule -> rule.isJsonObject }?.asJsonObject }
+                .orEmpty()
+            val primaryBalancerTag = routingRules
+                .lastOrNull { it.isCatchAllRule() && it.string("balancerTag") != null }
+                ?.string("balancerTag")
+
+            val originalBalancer = primaryBalancerTag?.let { wanted ->
+                routing?.array("balancers")
+                    ?.mapNotNull { it.takeIf { balancer -> balancer.isJsonObject }?.asJsonObject }
+                    ?.firstOrNull { it.string("tag") == wanted }
+            }
+            if ((primaryBalancerTag != null && originalBalancer == null) ||
+                (primaryBalancerTag == null && routingRules.any { it.string("balancerTag") != null })
+            ) {
+                // Direct batch probing cannot reproduce conditional routing.
+                // Accept only the catch-all policy-group form emitted by v2rayNG.
+                failedGuids += source.guid
+                return@forEachIndexed
+            }
+
+            val localBalancers = JsonArray()
+            val profile = if (originalBalancer != null) {
+                buildPolicyProfile(
+                    source.guid,
+                    namespace,
+                    originalBalancer,
+                    tagMap,
+                    localBalancers,
+                )
+            } else {
+                val catchAllOutbound = routingRules.lastOrNull {
+                    it.isCatchAllRule() && it.string("outboundTag") != null
+                }?.string("outboundTag")
+                if (catchAllOutbound != null && catchAllOutbound !in tagMap) {
+                    failedGuids += source.guid
+                    return@forEachIndexed
+                }
+                if (catchAllOutbound == null && routingRules.isNotEmpty()) {
+                    failedGuids += source.guid
+                    return@forEachIndexed
+                }
+                val routedTag = catchAllOutbound
+                val runtimeTag = routedTag ?: tagMap.keys.first()
+                OutboundProbeProfilePlan(
+                    guid = source.guid,
+                    candidates = listOf(
+                        OutboundProbeCandidate(
+                            probeTag = tagMap.getValue(runtimeTag),
+                            runtimeTag = runtimeTag,
+                        )
+                    ),
+                )
+            }
+
+            if (profile == null || profile.candidates.isEmpty()) {
+                failedGuids += source.guid
+            } else {
+                if (originalBalancer?.obj("strategy")?.string("type")
+                        ?.equals("leastLoad", ignoreCase = true) == true
+                ) {
+                    root.obj("burstObservatory")?.obj("pingConfig")?.let { pingConfig ->
+                        batchSamples = maxOf(batchSamples, pingConfig.positiveInt("sampling") ?: 1)
+                        batchTimeout = longerDuration(
+                            batchTimeout,
+                            pingConfig.string("timeout") ?: DEFAULT_PROBE_TIMEOUT,
+                        )
+                        val method = pingConfig.string("httpMethod")
+                            ?.uppercase()
+                            ?.takeIf { it == "GET" || it == "HEAD" }
+                            ?: "HEAD"
+                        leastLoadHttpMethod = when {
+                            leastLoadHttpMethod == null -> method
+                            leastLoadHttpMethod == "GET" || method == "GET" -> "GET"
+                            else -> "HEAD"
+                        }
+                    }
+                }
+                outboundObjects.forEach { mergedOutbounds.add(it) }
+                localBalancers.forEach { mergedBalancers.add(it) }
+                profiles += profile
+            }
+        }
+
+        val root = JsonObject().apply {
+            add("log", JsonObject().apply { addProperty("loglevel", "warning") })
+            add("outbounds", mergedOutbounds)
+            add("routing", JsonObject().apply {
+                addProperty("domainStrategy", "AsIs")
+                add("rules", JsonArray())
+                if (mergedBalancers.size() > 0) add("balancers", mergedBalancers)
+            })
+            add("burstObservatory", JsonObject().apply {
+                add("subjectSelector", JsonArray())
+                add("pingConfig", JsonObject().apply {
+                    addProperty("destination", destination)
+                    addProperty("httpMethod", leastLoadHttpMethod ?: DEFAULT_HTTP_METHOD)
+                    addProperty("interval", "1h")
+                    addProperty("sampling", batchSamples)
+                    addProperty("timeout", batchTimeout)
+                })
+            })
+        }
+
+        return OutboundProbePlan(
+            content = JsonUtil.toJsonPretty(root).orEmpty(),
+            profiles = profiles,
+            failedGuids = failedGuids,
+            samples = batchSamples,
+        )
+    }
+
+    private fun buildPolicyProfile(
+        guid: String,
+        namespace: String,
+        sourceBalancer: JsonObject,
+        tagMap: Map<String, String>,
+        mergedBalancers: JsonArray,
+    ): OutboundProbeProfilePlan? {
+        val strategy = sourceBalancer.obj("strategy") ?: return null
+        val strategyType = strategy.string("type")
+        if (strategyType?.equals("leastPing", ignoreCase = true) != true &&
+            strategyType?.equals("leastLoad", ignoreCase = true) != true
+        ) return null
+        if ((strategy.obj("settings")?.array("costs")?.size() ?: 0) > 0) {
+            // Cost matchers refer to original outbound tags. Silently carrying
+            // them into a namespaced batch would change leastLoad semantics.
+            return null
+        }
+
+        val selectors = sourceBalancer.array("selector")
+            ?.mapNotNull { it.takeIf { selector -> selector.isJsonPrimitive }?.asString }
+            .orEmpty()
+        val candidates = tagMap.entries
+            .filter { (runtimeTag, _) -> selectors.any(runtimeTag::startsWith) }
+            .map { (runtimeTag, probeTag) -> OutboundProbeCandidate(probeTag, runtimeTag) }
+        if (candidates.isEmpty()) return null
+
+        val balancer = sourceBalancer.deepCopy()
+        val probeBalancerTag = "$namespace${sourceBalancer.string("tag").orEmpty()}"
+        balancer.addProperty("tag", probeBalancerTag)
+        balancer.add("selector", JsonArray().apply {
+            selectors.forEach { add("$namespace$it") }
+        })
+        sourceBalancer.string("fallbackTag")?.let { fallback ->
+            val mappedFallback = tagMap[fallback] ?: return null
+            balancer.addProperty("fallbackTag", mappedFallback)
+        }
+        mergedBalancers.add(balancer)
+        return OutboundProbeProfilePlan(guid, candidates, probeBalancerTag)
+    }
+
+    private fun remapOutboundReferences(outbound: JsonObject, tagMap: Map<String, String>): Boolean {
+        outbound.obj("streamSettings")
+            ?.obj("sockopt")
+            ?.let { sockopt ->
+                sockopt.string("dialerProxy")?.let { old ->
+                    if (old.isNotBlank()) {
+                        val mapped = tagMap[old] ?: return false
+                        sockopt.addProperty("dialerProxy", mapped)
+                    }
+                }
+            }
+        outbound.obj("proxySettings")?.let { proxySettings ->
+            proxySettings.string("tag")?.let { old ->
+                if (old.isNotBlank()) {
+                    val mapped = tagMap[old] ?: return false
+                    proxySettings.addProperty("tag", mapped)
+                }
+            }
+        }
+        return true
+    }
+
+    private fun JsonObject.obj(name: String): JsonObject? =
+        get(name)?.takeIf { it.isJsonObject }?.asJsonObject
+
+    private fun JsonObject.array(name: String): JsonArray? =
+        get(name)?.takeIf { it.isJsonArray }?.asJsonArray
+
+    private fun JsonObject.string(name: String): String? =
+        get(name)?.takeIf { it.isJsonPrimitive && it.asJsonPrimitive.isString }?.asString
+
+    private fun JsonObject.positiveInt(name: String): Int? =
+        get(name)?.takeIf { it.isJsonPrimitive }
+            ?.runCatching { asInt }
+            ?.getOrNull()
+            ?.takeIf { it > 0 }
+
+    private fun longerDuration(first: String, second: String): String {
+        val firstMillis = durationMillis(first) ?: return second
+        val secondMillis = durationMillis(second) ?: return first
+        return if (secondMillis > firstMillis) second else first
+    }
+
+    private fun durationMillis(value: String): Long? {
+        val match = DURATION_PATTERN.matchEntire(value.trim()) ?: return null
+        val amount = match.groupValues[1].toLongOrNull() ?: return null
+        val multiplier = when (match.groupValues[2]) {
+            "ms" -> 1L
+            "s" -> 1_000L
+            "m" -> 60_000L
+            "h" -> 3_600_000L
+            else -> return null
+        }
+        return if (amount <= Long.MAX_VALUE / multiplier) amount * multiplier else Long.MAX_VALUE
+    }
+
+    private fun JsonObject.isCatchAllRule(): Boolean {
+        val constrainedFields = listOf(
+            "domain", "ip", "port", "sourcePort", "source", "user", "inboundTag",
+            "protocol", "attrs", "process",
+        )
+        if (constrainedFields.any(::has)) return false
+        val network = string("network")
+        return network == null || network == "tcp,udp" || network == "tcp, udp"
+    }
+
+    private val DURATION_PATTERN = Regex("""([1-9]\d*)(ms|s|m|h)""")
+    private const val DEFAULT_HTTP_METHOD = "GET"
+    private const val DEFAULT_PROBE_TIMEOUT = "5s"
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyRouteCache.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/PolicyRouteCache.kt
@@ -1,0 +1,81 @@
+package com.v2ray.ang.core
+
+/**
+ * Process-local memory of the last policy-group outbound that worked on each
+ * underlay. Nothing is persisted to disk: explicit service stop/restart clears
+ * it, while an in-place core reset can carry it across a network transition.
+ */
+object PolicyRouteCache {
+    data class Snapshot(
+        val networkKey: String?,
+        val networkHandle: Long?,
+        val generation: Long,
+    )
+
+    private val routes = mutableMapOf<String, MutableMap<String, String>>()
+    private var currentNetworkKey: String? = null
+    private var currentNetworkHandle: Long? = null
+    private var generation = 0L
+
+    @Synchronized
+    fun snapshot(): Snapshot = Snapshot(currentNetworkKey, currentNetworkHandle, generation)
+
+    @Synchronized
+    fun setCurrentNetwork(networkKey: String, networkHandle: Long) {
+        currentNetworkKey = networkKey
+        currentNetworkHandle = networkHandle
+    }
+
+    @Synchronized
+    fun lookup(networkKey: String?, profileGuid: String): String? {
+        if (networkKey.isNullOrBlank() || profileGuid.isBlank()) return null
+        return routes[networkKey]?.get(profileGuid)
+    }
+
+    @Synchronized
+    fun remember(
+        networkKey: String?,
+        profileGuid: String,
+        outboundTag: String,
+        expectedGeneration: Long? = null,
+    ): Boolean {
+        if (networkKey.isNullOrBlank() || profileGuid.isBlank() || outboundTag.isBlank()) return false
+        if (expectedGeneration != null && expectedGeneration != generation) return false
+        routes.getOrPut(networkKey) { mutableMapOf() }[profileGuid] = outboundTag
+        return true
+    }
+
+    /** Returns true when the route belongs to the exact current underlay snapshot. */
+    @Synchronized
+    fun rememberCurrent(snapshot: Snapshot, profileGuid: String, outboundTag: String): Boolean {
+        if (snapshot.networkKey.isNullOrBlank() || profileGuid.isBlank() || outboundTag.isBlank()) return false
+        if (snapshot != Snapshot(currentNetworkKey, currentNetworkHandle, generation)) return false
+        val networkRoutes = routes.getOrPut(snapshot.networkKey) { mutableMapOf() }
+        networkRoutes[profileGuid] = outboundTag
+        return true
+    }
+
+    /** Accepts a result from another process only for the exact underlay that measured it. */
+    @Synchronized
+    fun rememberObserved(
+        networkKey: String,
+        networkHandle: Long,
+        profileGuid: String,
+        outboundTag: String,
+    ): Boolean {
+        if (networkKey != currentNetworkKey || networkHandle != currentNetworkHandle) return false
+        if (profileGuid.isBlank() || outboundTag.isBlank()) return false
+        val networkRoutes = routes.getOrPut(networkKey) { mutableMapOf() }
+        if (networkRoutes[profileGuid] == outboundTag) return false
+        networkRoutes[profileGuid] = outboundTag
+        return true
+    }
+
+    @Synchronized
+    fun clear() {
+        routes.clear()
+        currentNetworkKey = null
+        currentNetworkHandle = null
+        generation++
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/OutboundProbePlan.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/OutboundProbePlan.kt
@@ -1,0 +1,34 @@
+package com.v2ray.ang.dto
+
+/** One original runtime outbound represented by a uniquely tagged batch outbound. */
+data class OutboundProbeCandidate(
+    val probeTag: String,
+    val runtimeTag: String,
+)
+
+/** Mapping needed to turn native batch snapshots back into one UI result per profile. */
+data class OutboundProbeProfilePlan(
+    val guid: String,
+    val candidates: List<OutboundProbeCandidate>,
+    val balancerTag: String? = null,
+)
+
+/** One-core configuration and its profile/outbound mappings. */
+data class OutboundProbePlan(
+    val content: String,
+    val profiles: List<OutboundProbeProfilePlan>,
+    val failedGuids: List<String>,
+    val samples: Int,
+) {
+    /** One native concurrency slot per original UI configuration. */
+    val probeGroups: List<List<String>>
+        get() = profiles.map { profile ->
+            profile.candidates.map { it.probeTag }.distinct()
+        }
+
+    val outboundTags: List<String>
+        get() = probeGroups.flatten().distinct()
+
+    val balancerTags: List<String>
+        get() = profiles.mapNotNull { it.balancerTag }.distinct()
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/PolicyRouteUpdate.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/PolicyRouteUpdate.kt
@@ -1,0 +1,11 @@
+package com.v2ray.ang.dto
+
+import java.io.Serializable
+
+/** A viable policy-group route measured by the dedicated probe process. */
+data class PolicyRouteUpdate(
+    val profileGuid: String,
+    val outboundTag: String,
+    val networkKey: String,
+    val networkHandle: Long,
+) : Serializable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
@@ -6,7 +6,13 @@ sealed class RealPingEvent {
     data class Progress(val text: String) : RealPingEvent()
 
     /** A single server result is available. */
-    data class Result(val guid: String, val delayMillis: Long) : RealPingEvent()
+    data class Result(
+        val guid: String,
+        val delayMillis: Long,
+        val viableOutboundTag: String = "",
+        val networkKey: String? = null,
+        val networkHandle: Long? = null,
+    ) : RealPingEvent()
 
     /** The entire batch has finished or been cancelled. */
     data class Finish(val status: String) : RealPingEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/extension/_Ext.kt
@@ -103,6 +103,18 @@ fun Context.toastError(message: Int) {
 }
 
 /**
+ * Shows a long error toast message with the given resource ID.
+ *
+ * @param message The resource ID of the message to show.
+ */
+fun Context.toastErrorLong(message: Int) {
+    val text = getString(message)
+    dispatchMessage(text, ToastType.ERROR, long = true) {
+        Toast.makeText(this, text, Toast.LENGTH_LONG).show()
+    }
+}
+
+/**
  * Shows a toast message with the given text.
  *
  * @param message The text of the message to show.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -116,6 +116,29 @@ object NotificationManager {
     }
 
     /**
+     * Keeps the foreground VPN notification visible when Xray cannot be recovered.
+     * The VPN interface remains established so Android continues routing traffic into
+     * the nonfunctional tunnel instead of silently falling back to the physical network.
+     */
+    fun showCoreFailure(message: String) {
+        val service = getService() ?: return
+        speedNotificationJob?.cancel()
+        speedNotificationJob = null
+
+        val builder = mBuilder ?: run {
+            showNotification(null)
+            mBuilder
+        } ?: return
+
+        builder
+            .setSmallIcon(R.drawable.ic_stat_name)
+            .setContentTitle(service.getString(R.string.toast_services_failure))
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+        getNotificationManager()?.notify(NOTIFICATION_ID, builder.build())
+    }
+
+    /**
      * Cancels the notification.
      */
     fun cancelNotification() {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -408,7 +408,7 @@ object SettingsManager {
 
     /**
      * Get real ping concurrency.
-     * @return The number of concurrent real-ping tests (clamped to 1..64).
+     * @return The number of concurrent real-ping configuration groups (clamped to 1..128).
      */
     fun getRealPingConcurrency(): Int {
         val value = MmkvManager.decodeSettingsString(AppConfig.PREF_REAL_PING_CONCURRENCY)?.toIntOrNull() ?: 16

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -3,10 +3,14 @@ package com.v2ray.ang.service
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import android.os.Handler
+import android.os.Looper
+import android.os.Process
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreNativeManager
 import com.v2ray.ang.dto.RealPingEvent
+import com.v2ray.ang.dto.PolicyRouteUpdate
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.enums.NotificationChannelType
 import com.v2ray.ang.extension.serializable
@@ -14,12 +18,16 @@ import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.NotificationHelper
-import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
 
 class CoreTestService : Service() {
 
-    // manage active batch workers so each batch is independent and cancellable
-    private val activeWorkers = Collections.synchronizedList(mutableListOf<RealPingWorkerService>())
+    @Volatile
+    private var activeWorker: RealPingWorkerService? = null
+    @Volatile
+    private var replacementRequested = false
+    private var batchStarted = false
+    private val batchFinished = AtomicBoolean(false)
 
     /**
      * Initializes the V2Ray environment.
@@ -42,13 +50,19 @@ class CoreTestService : Service() {
      * Cleans up resources when the service is destroyed.
      */
     override fun onDestroy() {
-        LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed, cancelling ${activeWorkers.size} active workers")
-        // cancel any active workers
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
+        LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed")
+        activeWorker?.cancel()
+        activeWorker = null
+        if (!replacementRequested && batchFinished.compareAndSet(false, true)) {
+            MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "-1")
+        }
         NotificationHelper.stopForeground(this)
         super.onDestroy()
+        // This process exists solely to own one batch core. Discarding it after
+        // the service stops makes the one-core-per-process boundary explicit
+        // and keeps unchanged upstream native singleton state from overlapping
+        // the VPN core or leaking into a later batch.
+        Handler(Looper.getMainLooper()).post { Process.killProcess(Process.myPid()) }
     }
 
     /**
@@ -65,25 +79,34 @@ class CoreTestService : Service() {
             return START_NOT_STICKY
         }
 
-        when (message.key) {
+        return when (message.key) {
             AppConfig.MSG_MEASURE_CONFIG_START -> handleMeasureStart(message, startId)
-            AppConfig.MSG_MEASURE_CONFIG_CANCEL -> handleMeasureCancel()
             else -> {
-                NotificationHelper.stopForeground(this); stopSelf(startId)
+                NotificationHelper.stopForeground(this)
+                stopSelf(startId)
+                START_NOT_STICKY
             }
         }
-        return START_NOT_STICKY
     }
 
-    private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
-        LogUtil.i(AppConfig.TAG, "CoreTestService starting worker   subscription ${message.subscriptionId}")
+    private fun handleMeasureStart(message: TestServiceMessage, startId: Int): Int {
+        if (batchStarted) {
+            replacementRequested = true
+            startProbeForeground()
+            LogUtil.i(AppConfig.TAG, "CoreTestService handing the next batch to a fresh process")
 
-        NotificationHelper.startForeground(
-            this,
-            NotificationChannelType.CORE_TEST,
-            getString(R.string.app_name),
-            getString(R.string.title_real_ping_all_server)
-        )
+            // The latest start intent must remain start-requested while this
+            // single-use process exits. Returning REDELIVER before killing the
+            // process makes Android replay that exact request in a new process;
+            // stopService followed by startForegroundService can instead lose
+            // the replacement to a lifecycle race in the dying service.
+            Handler(Looper.getMainLooper()).post { Process.killProcess(Process.myPid()) }
+            return START_REDELIVER_INTENT
+        }
+        batchStarted = true
+        LogUtil.i(AppConfig.TAG, "CoreTestService starting batch for subscription ${message.subscriptionId}")
+
+        startProbeForeground()
 
         val guidsList = when {
             message.serverGuids.isNotEmpty() -> message.serverGuids
@@ -92,21 +115,34 @@ class CoreTestService : Service() {
         }
 
         if (guidsList.isNotEmpty()) {
-            lateinit var worker: RealPingWorkerService
-            worker = RealPingWorkerService(
+            activeWorker = RealPingWorkerService(
                 context = this,
                 guids = guidsList,
-                onEvent = { event -> handleWorkerEvent(event) { activeWorkers.remove(worker) } }
+                onEvent = ::handleWorkerEvent,
             )
-            activeWorkers.add(worker)
-            worker.start()
+            activeWorker?.start()
         } else {
             NotificationHelper.stopForeground(this)
+            batchFinished.set(true)
+            MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "0")
             stopSelf(startId)
         }
+        return START_NOT_STICKY
     }
 
-    private fun handleWorkerEvent(event: RealPingEvent, onWorkerDone: () -> Unit) {
+    private fun startProbeForeground() {
+        NotificationHelper.startForeground(
+            this,
+            NotificationChannelType.CORE_TEST,
+            getString(R.string.app_name),
+            getString(R.string.title_real_ping_all_server)
+        )
+    }
+
+    private fun handleWorkerEvent(event: RealPingEvent) {
+        // Once another start has claimed the service, the old process must not
+        // publish stale progress or results while waiting for its final kill.
+        if (replacementRequested) return
         when (event) {
             is RealPingEvent.Progress -> {
                 NotificationHelper.updateNotification(
@@ -119,26 +155,31 @@ class CoreTestService : Service() {
 
             is RealPingEvent.Result -> {
                 MmkvManager.encodeServerTestDelayMillis(event.guid, event.delayMillis)
+                val networkKey = event.networkKey
+                val networkHandle = event.networkHandle
+                if (event.viableOutboundTag.isNotEmpty() && networkKey != null && networkHandle != null) {
+                    MessageUtil.sendMsg2Service(
+                        this,
+                        AppConfig.MSG_POLICY_ROUTE_OBSERVED,
+                        PolicyRouteUpdate(
+                            event.guid,
+                            event.viableOutboundTag,
+                            networkKey,
+                            networkHandle,
+                        ),
+                    )
+                }
                 MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, event.guid)
             }
 
             is RealPingEvent.Finish -> {
+                if (!batchFinished.compareAndSet(false, true)) return
                 MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, event.status)
-                onWorkerDone()
-                if (activeWorkers.isEmpty()) {
-                    NotificationHelper.stopForeground(this)
-                    stopSelf()
-                }
+                activeWorker = null
+                NotificationHelper.stopForeground(this)
+                stopSelf()
             }
         }
     }
 
-    private fun handleMeasureCancel() {
-        LogUtil.i(AppConfig.TAG, "CoreTestService received cancel message, cancelling ${activeWorkers.size} active workers")
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
-        NotificationHelper.stopForeground(this)
-        stopSelf()
-    }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -21,6 +21,7 @@ import com.v2ray.ang.BuildConfig
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.contracts.Tun2SocksControl
 import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.core.PolicyRouteCache
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
@@ -35,6 +36,8 @@ class CoreVpnService : VpnService(), ServiceControl {
     private lateinit var mInterface: ParcelFileDescriptor
     private var isRunning = false
     private var tun2SocksService: Tun2SocksControl? = null
+    private val underlyingNetworkState = UnderlyingNetworkStateTracker<Network>()
+    private var pendingNetworkReset: Network? = null
 
     /**destroy
      * Unfortunately registerDefaultNetworkCallback is going to return our VPN interface: https://android.googlesource.com/platform/frameworks/base/+/dda156ab0c5d66ad82bdcf76cda07cbc0a9c8a2e
@@ -57,19 +60,63 @@ class CoreVpnService : VpnService(), ServiceControl {
 
     @delegate:RequiresApi(Build.VERSION_CODES.P)
     private val defaultNetworkCallback by lazy {
-        object : ConnectivityManager.NetworkCallback() {
-            override fun onAvailable(network: Network) {
-                setUnderlyingNetworks(arrayOf(network))
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            NetworkIdentityResolver.canReadWifiIdentity(applicationContext)
+        ) {
+            object : ConnectivityManager.NetworkCallback(
+                ConnectivityManager.NetworkCallback.FLAG_INCLUDE_LOCATION_INFO
+            ) {
+                override fun onAvailable(network: Network) = handleNetworkAvailable(network)
 
-            override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
-                // it's a good idea to refresh capabilities
-                setUnderlyingNetworks(arrayOf(network))
-            }
+                override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) =
+                    handleNetworkCapabilitiesChanged(network, capabilities)
 
-            override fun onLost(network: Network) {
-                setUnderlyingNetworks(null)
+                override fun onLost(network: Network) = handleNetworkLost(network)
             }
+        } else {
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) = handleNetworkAvailable(network)
+
+                override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) =
+                    handleNetworkCapabilitiesChanged(network, capabilities)
+
+                override fun onLost(network: Network) = handleNetworkLost(network)
+            }
+        }
+    }
+
+    private fun handleNetworkAvailable(network: Network) {
+        setUnderlyingNetworks(arrayOf(network))
+        if (underlyingNetworkState.onAvailable(network)) {
+            pendingNetworkReset = network
+            LogUtil.i(AppConfig.TAG, "StartCore-VPN: Underlying network changed to $network")
+        }
+    }
+
+    private fun handleNetworkCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) {
+        if (!underlyingNetworkState.isCurrent(network)) return
+
+        setUnderlyingNetworks(arrayOf(network))
+        val newNetworkKey = NetworkIdentityResolver.resolve(applicationContext, capabilities)
+        val previousNetworkKey = PolicyRouteCache.snapshot().networkKey
+        if (previousNetworkKey != newNetworkKey) {
+            LogUtil.i(
+                AppConfig.TAG,
+                "StartCore-VPN: Underlay identity resolved as ${newNetworkKey.substringBefore(':')}",
+            )
+        }
+
+        if (pendingNetworkReset == network) {
+            pendingNetworkReset = null
+            CoreServiceManager.resetCoreNetworkState(previousNetworkKey, newNetworkKey, network.networkHandle)
+        } else if (previousNetworkKey != newNetworkKey) {
+            CoreServiceManager.updateCoreNetworkIdentity(newNetworkKey, network.networkHandle)
+        }
+    }
+
+    private fun handleNetworkLost(network: Network) {
+        if (underlyingNetworkState.onLost(network)) {
+            setUnderlyingNetworks(null)
         }
     }
 
@@ -269,6 +316,8 @@ class CoreVpnService : VpnService(), ServiceControl {
     private fun configurePlatformFeatures(builder: Builder) {
         // Android P (API 28) and above: Configure network callbacks
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            underlyingNetworkState.reset()
+            pendingNetworkReset = null
             try {
                 connectivity.requestNetwork(defaultNetworkRequest, defaultNetworkCallback)
             } catch (e: Exception) {
@@ -361,6 +410,8 @@ class CoreVpnService : VpnService(), ServiceControl {
             } catch (e: Exception) {
                 LogUtil.w(AppConfig.TAG, "StartCore-VPN: Failed to unregister callback", e)
             }
+            underlyingNetworkState.reset()
+            pendingNetworkReset = null
         }
 
         tun2SocksService?.stopTun2Socks()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/NetworkIdentityResolver.kt
@@ -1,0 +1,110 @@
+package com.v2ray.ang.service
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.os.Build
+import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.handler.MmkvManager
+
+/** Resolves reconnect-stable underlay identities without phone-state access. */
+object NetworkIdentityResolver {
+    data class Identity(val key: String, val networkHandle: Long)
+
+    /** Captures both the reconnect-stable cache key and this network instance. */
+    fun resolveCurrent(context: Context): Identity? {
+        val connectivity = context.getSystemService(ConnectivityManager::class.java) ?: return null
+        val network = connectivity.activeNetwork ?: return null
+        val capabilities = connectivity.getNetworkCapabilities(network) ?: return null
+        return Identity(resolve(context, capabilities), network.networkHandle)
+    }
+
+    fun resolve(context: Context, capabilities: NetworkCapabilities): String = when {
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> {
+            val rememberPerNetwork = canReadWifiIdentity(context)
+            wifiKey(
+                ssid = if (rememberPerNetwork) readSsid(context, capabilities) else null,
+                rememberPerNetwork = rememberPerNetwork,
+            )
+        }
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
+            val (networkOperator, simOperator) = readCellularOperators(context)
+            cellularKey(networkOperator, simOperator)
+        }
+
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ethernet"
+        else -> "other"
+    }
+
+    fun canReadWifiIdentity(context: Context): Boolean {
+        val enabled = MmkvManager.decodeSettingsBool(
+            AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK,
+            false,
+        )
+        if (!enabled) return false
+
+        val permissionGranted =
+            context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED
+        if (!permissionGranted) {
+            MmkvManager.encodeSettings(AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK, false)
+        }
+        return permissionGranted
+    }
+
+    internal fun wifiKey(ssid: String?, rememberPerNetwork: Boolean = true): String {
+        if (!rememberPerNetwork) return "wifi"
+        val normalized = ssid
+            ?.trim()
+            ?.removeSurrounding("\"")
+            ?.takeIf { it.isNotBlank() && it != WifiManager.UNKNOWN_SSID }
+        return normalized?.let { "wifi:$it" } ?: "wifi"
+    }
+
+    internal fun cellularKey(networkOperator: String?, simOperator: String?): String {
+        val mccMnc = sequenceOf(networkOperator, simOperator)
+            .mapNotNull { it?.trim()?.takeIf(::isMccMnc) }
+            .firstOrNull()
+        return mccMnc?.let { "cellular:$it" } ?: "cellular"
+    }
+
+    private fun isMccMnc(value: String): Boolean =
+        value.length in 5..6 && value.all(Char::isDigit)
+
+    @Suppress("DEPRECATION")
+    private fun readSsid(context: Context, capabilities: NetworkCapabilities): String? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val capabilitiesSsid = (capabilities.transportInfo as? WifiInfo)?.ssid
+            if (wifiKey(capabilitiesSsid) != "wifi") return capabilitiesSsid
+        }
+        return runCatching {
+            context.applicationContext
+                .getSystemService(WifiManager::class.java)
+                ?.connectionInfo
+                ?.ssid
+        }.getOrNull()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun readCellularOperators(context: Context): Pair<String?, String?> {
+        val base = context.getSystemService(TelephonyManager::class.java)
+            ?: return null to null
+        val subscriptionId = when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> SubscriptionManager.getActiveDataSubscriptionId()
+            else -> SubscriptionManager.getDefaultDataSubscriptionId()
+        }
+        val telephony = if (SubscriptionManager.isValidSubscriptionId(subscriptionId)) {
+            base.createForSubscriptionId(subscriptionId)
+        } else {
+            base
+        }
+        return telephony.networkOperator to telephony.simOperator
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -1,107 +1,189 @@
 package com.v2ray.ang.service
 
 import android.content.Context
+import com.v2ray.ang.AppConfig
 import com.v2ray.ang.core.CoreConfigManager
 import com.v2ray.ang.core.CoreNativeManager
+import com.v2ray.ang.dto.OutboundProbePlan
+import com.v2ray.ang.dto.OutboundProbeProfilePlan
 import com.v2ray.ang.dto.RealPingEvent
-import com.v2ray.ang.enums.EConfigType
-import com.v2ray.ang.extension.isComplexType
-import com.v2ray.ang.extension.isNotNullEmpty
-import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
-import com.v2ray.ang.handler.SpeedtestManager
+import com.v2ray.ang.util.JsonUtil
+import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import libv2ray.OutboundProbeHandler
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Worker that runs a batch of real-ping tests independently.
- * Each batch owns its own CoroutineScope/dispatcher and can be cancelled separately.
+ * Runs one complete UI delay-test batch through one native Xray instance.
+ *
+ * CoreTestService hosts this worker in a dedicated process. AndroidLib keeps
+ * one Xray instance, limits active configuration groups with the user's True
+ * delay concurrency setting, and publishes a snapshot whenever one candidate
+ * finishes. This avoids the former one-temporary-core-per-profile fan-out.
  */
 class RealPingWorkerService(
     private val context: Context,
     private val guids: List<String>,
-    private val onEvent: (RealPingEvent) -> Unit = {}
+    private val onEvent: (RealPingEvent) -> Unit = {},
 ) {
-    private val job = SupervisorJob()
-    private val concurrency = SettingsManager.getRealPingConcurrency()
-    private val dispatcher = Executors.newFixedThreadPool(concurrency).asCoroutineDispatcher()
-    private val scope = CoroutineScope(job + dispatcher + CoroutineName("RealPingBatchWorker"))
-
-    private val runningCount = AtomicInteger(0)
-    private val totalCount = AtomicInteger(0)
+    private val job = Job()
+    private val scope = CoroutineScope(job + Dispatchers.IO + CoroutineName("OutboundProbeBatch"))
+    private val controller = CoreNativeManager.newOutboundProbeController()
+    private val networkIdentity = NetworkIdentityResolver.resolveCurrent(context)
+    private val finished = AtomicBoolean(false)
+    private val emittedDelays = mutableMapOf<String, Long>()
+    private val emittedRoutes = mutableMapOf<String, String>()
+    private val completedGuids = mutableSetOf<String>()
+    private var lastPayload = ""
+    private var totalProfiles = 0
 
     fun start() {
-        val jobs = guids.map { guid ->
-            totalCount.incrementAndGet()
-            scope.launch {
-                runningCount.incrementAndGet()
-                try {
-                    val result = startRealPing(guid)
-                    onEvent(RealPingEvent.Result(guid, result))
-                } catch (_: Throwable) {
-                    // ignore
-                } finally {
-                    val count = totalCount.decrementAndGet()
-                    val left = runningCount.decrementAndGet()
-                    onEvent(RealPingEvent.Progress("$left / $count"))
-                }
-            }
-        }
-
         scope.launch {
             try {
-                joinAll(*jobs.toTypedArray())
-                onEvent(RealPingEvent.Finish("0"))
+                val plan = CoreConfigManager.getV2rayConfig4BatchSpeedtest(context, guids)
+                totalProfiles = (plan.profiles.map { it.guid } + plan.failedGuids).distinct().size
+                plan.failedGuids.forEach { emitResult(it, -1L, completed = true) }
+
+                if (plan.probeGroups.isNotEmpty()) {
+                    val concurrency = SettingsManager.getRealPingConcurrency()
+                    LogUtil.i(
+                        AppConfig.TAG,
+                        "Starting ${plan.profiles.size} real-delay profiles with concurrency $concurrency",
+                    )
+                    val finalResult = CoreNativeManager.probeOutboundGroups(
+                        controller = controller,
+                        config = plan.content,
+                        outboundGroupsJson = JsonUtil.toJson(plan.probeGroups),
+                        balancerTagsJson = JsonUtil.toJson(plan.balancerTags),
+                        maxConcurrency = concurrency,
+                        samples = plan.samples,
+                        handler = object : OutboundProbeHandler {
+                            override fun onOutboundProbeUpdate(payload: String?): Long {
+                                payload?.let { processPayload(plan, it) }
+                                return 0
+                            }
+                        },
+                    )
+                    if (finished.get()) return@launch
+                    processSnapshot(plan, finalResult)
+                    completeMissing(plan)
+                    finish(if (finalResult.cancelled) "-1" else "0")
+                } else {
+                    completeMissing(plan)
+                    finish("0")
+                }
             } catch (_: CancellationException) {
-                onEvent(RealPingEvent.Finish("-1"))
-            } finally {
-                close()
+                finish("-1")
+            } catch (error: Throwable) {
+                LogUtil.e(AppConfig.TAG, "Outbound probe batch failed", error)
+                finish("-1")
             }
         }
     }
 
     fun cancel() {
+        controller.cancel()
         job.cancel()
+        finish("-1")
     }
 
-    private fun close() {
-        try {
-            dispatcher.close()
-        } catch (_: Throwable) {
-            // ignore
-        }
+    @Synchronized
+    private fun processPayload(plan: OutboundProbePlan, payload: String) {
+        if (finished.get()) return
+        if (payload == lastPayload) return
+        lastPayload = payload
+        val snapshot = JsonUtil.fromJsonSafe(payload, CoreNativeManager.OutboundProbeBatchResult::class.java)
+            ?: return
+        processSnapshot(plan, snapshot)
     }
 
-    private fun startRealPing(guid: String): Long {
-        val retFailure = -1L
+    @Synchronized
+    private fun processSnapshot(
+        plan: OutboundProbePlan,
+        snapshot: CoreNativeManager.OutboundProbeBatchResult,
+    ) {
+        if (finished.get()) return
+        val statuses = snapshot.results.associateBy { it.outboundTag }
+        plan.profiles.forEach { profile ->
+            val candidateStatuses = profile.candidates.mapNotNull { candidate ->
+                statuses[candidate.probeTag]?.let { candidate to it }
+            }
+            val allCandidatesCompleted = candidateStatuses.size == profile.candidates.size &&
+                candidateStatuses.all { (_, status) -> status.samples >= plan.samples }
 
-        val config = MmkvManager.decodeServerConfig(guid) ?: return retFailure
-        if (!config.configType.isComplexType()
-            && config.configType != EConfigType.HYSTERIA2
-            && config.configType != EConfigType.WIREGUARD
-            && config.alpn?.startsWith("h3") != true
-            && config.server.isNotNullEmpty()
-            && config.serverPort?.toIntOrNull() != null
-        ) {
-            val url = config.server.orEmpty()
-            val port = config.serverPort.orEmpty().toInt()
-            val tcpTime = SpeedtestManager.socketConnectTime(url, port, 1000)
-            if (tcpTime <= -1L) {
-                return retFailure
+            val selected = selectProfileResult(profile, snapshot, candidateStatuses)
+            if (selected != null) {
+                val (candidate, status) = selected
+                val viableRoute = candidate.runtimeTag.takeIf {
+                    status.alive && profile.balancerTag != null
+                }.orEmpty()
+                emitResult(
+                    profile.guid,
+                    if (status.alive) status.delay else -1L,
+                    viableRoute,
+                    allCandidatesCompleted,
+                )
+            } else if (allCandidatesCompleted) {
+                emitResult(profile.guid, -1L, completed = true)
             }
         }
+    }
 
-        val configResult = CoreConfigManager.getV2rayConfig4Speedtest(context, guid)
-        if (!configResult.status) {
-            return retFailure
+    private fun selectProfileResult(
+        profile: OutboundProbeProfilePlan,
+        snapshot: CoreNativeManager.OutboundProbeBatchResult,
+        statuses: List<Pair<com.v2ray.ang.dto.OutboundProbeCandidate, CoreNativeManager.OutboundProbeStatus>>,
+    ): Pair<com.v2ray.ang.dto.OutboundProbeCandidate, CoreNativeManager.OutboundProbeStatus>? {
+        if (profile.balancerTag == null) return statuses.firstOrNull()
+        val selectedTag = snapshot.balancerTargets[profile.balancerTag] ?: return null
+        return statuses.firstOrNull { (candidate, _) -> candidate.probeTag == selectedTag }
+    }
+
+    @Synchronized
+    private fun completeMissing(plan: OutboundProbePlan) {
+        (plan.profiles.map { it.guid } + plan.failedGuids).distinct().forEach { guid ->
+            if (guid !in completedGuids) emitResult(guid, emittedDelays[guid] ?: -1L, completed = true)
         }
-        return CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+    }
+
+    @Synchronized
+    private fun emitResult(
+        guid: String,
+        delay: Long,
+        viableOutboundTag: String = "",
+        completed: Boolean,
+    ) {
+        if (emittedDelays[guid] != delay ||
+            (viableOutboundTag.isNotEmpty() && emittedRoutes[guid] != viableOutboundTag)
+        ) {
+            emittedDelays[guid] = delay
+            if (viableOutboundTag.isNotEmpty()) emittedRoutes[guid] = viableOutboundTag
+            onEvent(
+                RealPingEvent.Result(
+                    guid = guid,
+                    delayMillis = delay,
+                    viableOutboundTag = viableOutboundTag,
+                    networkKey = networkIdentity?.key,
+                    networkHandle = networkIdentity?.networkHandle,
+                )
+            )
+        }
+        if (completed && completedGuids.add(guid)) {
+            val remaining = (totalProfiles - completedGuids.size).coerceAtLeast(0)
+            onEvent(RealPingEvent.Progress("$remaining / $totalProfiles"))
+        }
+    }
+
+    @Synchronized
+    private fun finish(status: String) {
+        if (finished.compareAndSet(false, true)) {
+            onEvent(RealPingEvent.Finish(status))
+        }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/UnderlyingNetworkStateTracker.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/UnderlyingNetworkStateTracker.kt
@@ -1,0 +1,38 @@
+package com.v2ray.ang.service
+
+/**
+ * Tracks Android's selected VPN underlay without treating the initial callback
+ * or repeated capability updates as a network transition.
+ */
+internal class UnderlyingNetworkStateTracker<T> {
+    private var current: T? = null
+    private var hasObservedNetwork = false
+    private var currentWasLost = false
+
+    @Synchronized
+    fun onAvailable(network: T): Boolean {
+        val changed = hasObservedNetwork && (current != network || currentWasLost)
+        current = network
+        hasObservedNetwork = true
+        currentWasLost = false
+        return changed
+    }
+
+    @Synchronized
+    fun onLost(network: T): Boolean {
+        if (current != network) return false
+        current = null
+        currentWasLost = true
+        return true
+    }
+
+    @Synchronized
+    fun isCurrent(network: T): Boolean = current == network
+
+    @Synchronized
+    fun reset() {
+        current = null
+        hasObservedNetwork = false
+        currentWasLost = false
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/SettingsActivity.kt
@@ -1,7 +1,11 @@
 package com.v2ray.ang.ui
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Bundle
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -23,6 +28,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.VPN
 import com.v2ray.ang.R
@@ -35,6 +44,7 @@ import com.v2ray.ang.compose.SettingsSwitchItem
 import com.v2ray.ang.compose.ThemeManager
 import com.v2ray.ang.compose.verticalScrollbar
 import com.v2ray.ang.extension.toastError
+import com.v2ray.ang.extension.toastErrorLong
 import com.v2ray.ang.handler.MmkvManager.rememberMmkvBool
 import com.v2ray.ang.handler.MmkvManager.rememberMmkvString
 import com.v2ray.ang.handler.SettingsChangeManager
@@ -111,6 +121,10 @@ fun SettingsScreen(
     var socksPassword by rememberMmkvString(AppConfig.PREF_SOCKS_PASSWORD, "")
     var socksEnableUdp by rememberMmkvBool(AppConfig.PREF_SOCKS_ENABLE_UDP, false)
     var proxySharing by rememberMmkvBool(AppConfig.PREF_PROXY_SHARING, false)
+    var rememberRoutesPerWifiNetwork by rememberMmkvBool(
+        AppConfig.PREF_REMEMBER_ROUTES_PER_WIFI_NETWORK,
+        false
+    )
 
     var speedEnabled by rememberMmkvBool(AppConfig.PREF_SPEED_ENABLED, false)
     var confirmRemove by rememberMmkvBool(AppConfig.PREF_CONFIRM_REMOVE, false)
@@ -163,6 +177,36 @@ fun SettingsScreen(
     val fragmentPacketsValues = stringArrayResource(R.array.fragment_packets).toList()
     val modeEntries = stringArrayResource(R.array.mode_entries).toList()
     val modeValues = stringArrayResource(R.array.mode_value).toList()
+
+    val requestWifiIdentityPermission = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { grants ->
+        val fineLocationGranted =
+            grants[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                context.hasFineLocationPermission()
+        rememberRoutesPerWifiNetwork = fineLocationGranted
+        if (!fineLocationGranted) {
+            context.toastErrorLong(R.string.toast_precise_location_required_for_wifi_route_memory)
+        }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, rememberRoutesPerWifiNetwork) {
+        fun disableWifiRouteMemoryWithoutPermission() {
+            if (rememberRoutesPerWifiNetwork && !context.hasFineLocationPermission()) {
+                rememberRoutesPerWifiNetwork = false
+            }
+        }
+
+        disableWifiRouteMemoryWithoutPermission()
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) {
+                disableWifiRouteMemoryWithoutPermission()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Scaffold(
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
@@ -509,6 +553,23 @@ fun SettingsScreen(
                 checked = autoSortAfterTest,
                 onCheckedChange = { autoSortAfterTest = it }
             )
+            SettingsSwitchItem(
+                title = stringResource(R.string.title_pref_remember_routes_per_wifi_network),
+                summary = stringResource(R.string.summary_pref_remember_routes_per_wifi_network),
+                checked = rememberRoutesPerWifiNetwork,
+                onCheckedChange = { newValue ->
+                    if (!newValue || context.hasFineLocationPermission()) {
+                        rememberRoutesPerWifiNetwork = newValue
+                    } else {
+                        requestWifiIdentityPermission.launch(
+                            arrayOf(
+                                Manifest.permission.ACCESS_COARSE_LOCATION,
+                                Manifest.permission.ACCESS_FINE_LOCATION
+                            )
+                        )
+                    }
+                }
+            )
             SettingsEditItem(
                 title = stringResource(R.string.title_pref_delay_test_url),
                 value = delayTestUrl,
@@ -575,3 +636,9 @@ fun SettingsScreen(
         }
     }
 }
+
+private fun Context.hasFineLocationPermission(): Boolean =
+    ContextCompat.checkSelfPermission(
+        this,
+        Manifest.permission.ACCESS_FINE_LOCATION
+    ) == PackageManager.PERMISSION_GRANTED

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/MessageUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/MessageUtil.kt
@@ -56,7 +56,8 @@ object MessageUtil {
                 }
 
                 AppConfig.MSG_MEASURE_CONFIG_CANCEL -> {
-                    // Do not wake up service just to cancel; stop only if it is already running.
+                    // An explicit cancel only stops an already-running one-shot
+                    // probe process; it must not start a new service instance.
                     ctx.stopService(intent)
                 }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/viewmodel/MainViewModel.kt
@@ -684,13 +684,6 @@ class MainViewModel(
     }
 
     fun testAllRealPing() {
-        MessageUtil.sendMsg2TestService(
-            app,
-            TestServiceMessage(
-                key = AppConfig.MSG_MEASURE_CONFIG_CANCEL
-            )
-        )
-
         val groupId = subscriptionId
         val servers = currentServers()
 

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">إيقاف الخدمات</string>
     <string name="toast_services_success">نجاح بدء الخدمات</string>
     <string name="toast_services_failure">فشل بدء الخدمات</string>
+    <string name="notification_core_recovery_failed">فشل استرداد الاتصال. ستظل حركة المرور محظورة لمنع التسرب؛ أعد تشغيل v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">ملف التكوين</string>
@@ -161,6 +162,9 @@
     <string name="summary_pref_per_app_proxy">عام: التطبيق المحدد هو وكيل، غير المحدد اتصال مباشر؛ \nوضع التجاوز: التطبيق المحدد متصل مباشرة، غير المحدد وكيل. \nخيار تحديد تطبيق الوكيل تلقائيًا في القائمة</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">تذكّر المسارات الصالحة لكل شبكة Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">يستخدم اسم شبكة Wi-Fi المتصلة للاحتفاظ بسجل مسارات منفصل. يتطلب إذن الموقع الدقيق لأن Android يحمي أسماء شبكات Wi-Fi باعتبارها معلومات موقع.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">يلزم إذن الموقع الدقيق لقراءة اسم شبكة Wi-Fi</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">সার্ভিস বন্ধ করুন</string>
     <string name="toast_services_success">সার্ভিস সফলভাবে শুরু হয়েছে</string>
     <string name="toast_services_failure">সার্ভিস শুরু হতে ব্যর্থ হয়েছে</string>
+    <string name="notification_core_recovery_failed">সংযোগ পুনরুদ্ধার ব্যর্থ হয়েছে। ট্রাফিক লিক রোধে অবরুদ্ধ থাকবে; v2rayNG পুনরায় চালু করুন।</string>
 
     <!--ServerActivity-->
     <string name="title_server">কনফিগারেশন ফাইল</string>
@@ -159,6 +160,9 @@
     <string name="summary_pref_per_app_proxy">সাধারণ: চেকড অ্যাপ প্রক্সি, আনচেকড সরাসরি সংযোগ; \nবাইপাস মোড: চেকড অ্যাপ সরাসরি সংযুক্ত, আনচেকড প্রক্সি। \nমেনুতে প্রক্সি অ্যাপ্লিকেশন স্বয়ংক্রিয়ভাবে নির্বাচন করার বিকল্প</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">প্রতিটি Wi-Fi নেটওয়ার্কের জন্য কার্যকর রুট মনে রাখুন</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">আলাদা রুটের ইতিহাস রাখতে সংযুক্ত Wi-Fi নেটওয়ার্কের নাম ব্যবহার করে। সুনির্দিষ্ট লোকেশন অনুমতি প্রয়োজন, কারণ Android Wi-Fi নেটওয়ার্কের নামকে লোকেশন তথ্য হিসেবে সুরক্ষিত রাখে।</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Wi-Fi নেটওয়ার্কের নাম পড়তে সুনির্দিষ্ট লোকেশন অনুমতি প্রয়োজন</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">واڌاشتن سرویس</string>
     <string name="toast_services_success">ره وستن سرویس وا مووفقیت ٱنجوم وابی</string>
     <string name="toast_services_failure">ره وستن سرویس وا مووفقیت ٱنجوم نوابی</string>
+    <string name="notification_core_recovery_failed">بازیابی اتصال ناموفق بود. برای جلوگیری از نشت، ترافیک مسدود می‌ماند؛ v2rayNG را دوباره راه‌اندازی کنید.</string>
 
     <!--ServerActivity-->
     <string name="title_server">فایل کانفیگ</string>
@@ -160,6 +161,9 @@
     <string name="summary_pref_per_app_proxy">پوی وولاتی: برنومه پسند وابیڌه وا ی پروکسی منپیز ابۊ، برنومه پسند نوابیڌه موستقیمن منپیز ابۊ.\nهالت دور زیڌن: برنومه پسند وابیڌه موستقیمن منپیز ابۊ، برنومه پسند نوابیڌه وا ی پروکسی منپیز ابۊ.\nپسند خوتکار برنومه یل پروکسی من نومگه امکووݩ پزیر هڌ.</string>
     <string name="title_pref_is_booted">منپیز خوتکار مجال ره ونی</string>
     <string name="summary_pref_is_booted">مجال ره وندن، خوساخوس و سرور پسند بیڌه منپیز ابۊ که گاشڌ نا مووفق بۊ.</string>
+    <string name="title_pref_remember_routes_per_wifi_network">تورا کارا سی هر شبکه وای‌فای ن و یاد ودارین</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">نوم شبکه وای‌فای منپیز وابیڌه ن سی نگهداشتن تاریخچه تور جۊری و کار اگره. چۊ ٱندروید نوم وای‌فای ن دووسمندی جایونی دونسته، دسرسی جای دقیق لازوم هڌ.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">دسرسی جای دقیق سی خوندن نوم شبکه وای‌فای لازوم هڌ</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">پاک کردن خوتکار کانفیگا نا موئتبر بئڌ پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتیجه یل پینگ گاشڌ دییق نبۊن؛ کانفیگا پاک وابیڌه ن نتری وورگنی.</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">توقف سرویس</string>
     <string name="toast_services_success">سرویس با موفقیت شروع شد</string>
     <string name="toast_services_failure">شروع سرویس با شکست مواجه شد</string>
+    <string name="notification_core_recovery_failed">بازیابی اتصال ناموفق بود. برای جلوگیری از نشت، ترافیک مسدود می‌ماند؛ v2rayNG را دوباره راه‌اندازی کنید.</string>
 
     <!--ServerActivity-->
     <string name="title_server">فایل کانفیگ</string>
@@ -157,6 +158,9 @@
     <string name="summary_pref_per_app_proxy">عمومی: برنامه انتخاب شده از طریق یک پروکسی متصل می شود، برنامه انتخاب نشده مستقیماً متصل می شود. \nحالت دور زدن: برنامه انتخاب شده مستقیماً متصل می شود، برنامه انتخاب نشده از طریق یک پروکسی متصل می شود. \nانتخاب خودکار برنامه های پراکسی در منو امکان پذیر است.</string>
     <string name="title_pref_is_booted">اتصال خودکار هنگام راه اندازی</string>
     <string name="summary_pref_is_booted">هنگام راه اندازی به طور خودکار به سرور انتخابی متصل می شود که ممکن است ناموفق باشد.</string>
+    <string name="title_pref_remember_routes_per_wifi_network">به‌خاطر سپردن مسیرهای قابل استفاده برای هر شبکه Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">برای نگه‌داری سابقه مسیر جداگانه، از نام شبکه Wi-Fi متصل استفاده می‌کند. به مجوز مکان دقیق نیاز دارد، زیرا Android نام شبکه‌های Wi-Fi را به‌عنوان اطلاعات مکانی محافظت می‌کند.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">برای خواندن نام شبکه Wi-Fi، مجوز مکان دقیق لازم است</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">حذف خودکار کانفیگ‌های نامعتبر بعد از پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتایج پینگ ممکن است همیشه دقیق نباشند؛ کانفیگ‌های حذف‌شده قابل بازیابی نیستند.</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">Остановка служб</string>
     <string name="toast_services_success">Службы успешно запущены</string>
     <string name="toast_services_failure">Сбой при запуске служб</string>
+    <string name="notification_core_recovery_failed">Не удалось восстановить подключение. Трафик заблокирован для предотвращения утечки; перезапустите v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">Профиль</string>
@@ -163,6 +164,9 @@
     <string name="summary_pref_per_app_proxy">Основной: выбранное приложение соединяется через прокси, не выбранное — напрямую;\nРежим обхода: выбранное приложение соединяется напрямую, не выбранное — через прокси.\nЕсть возможность автоматического выбора проксируемых приложений в меню.</string>
     <string name="title_pref_is_booted">Автоподключение при запуске</string>
     <string name="summary_pref_is_booted">Автоматически подключаться к выбранному серверу при запуске приложения (может оказаться неудачным)</string>
+    <string name="title_pref_remember_routes_per_wifi_network">Запоминать рабочие маршруты для каждой сети Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">Использует имя подключённой сети Wi-Fi, чтобы хранить отдельную историю маршрутов. Требуется доступ к точному местоположению, поскольку Android защищает имена сетей Wi-Fi как данные о местоположении.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Для чтения имени сети Wi-Fi требуется доступ к точному местоположению</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Автоудаление нерабочих профилей</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Автоматическое удаление нерабочих профилей после проверки (результаты проверки могут быть неточными; восстановить удалённые профили невозможно)</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">Đã dừng v2rayNG!</string>
     <string name="toast_services_success">Đã khởi động v2rayNG!</string>
     <string name="toast_services_failure">Không thể khởi động v2rayNG, kiểm tra lại cấu hình!</string>
+    <string name="notification_core_recovery_failed">Không thể khôi phục kết nối. Lưu lượng vẫn bị chặn để tránh rò rỉ; hãy khởi động lại v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">v2rayNG</string>
@@ -158,6 +159,9 @@
     <string name="summary_pref_per_app_proxy">- Bình thường: Ứng dụng đã chọn sẽ kết nối thông qua Proxy, chưa chọn sẽ kết nối trực tiếp. \n- Chế độ Bypass: Ứng dụng đã chọn sẽ kết nối trực tiếp, chưa chọn sẽ kết nối qua Proxy. \n- Nếu bạn đang ở Trung Quốc thì vào Menu, chọn Tự động chọn ứng dụng Proxy.</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">Ghi nhớ tuyến khả dụng cho từng mạng Wi-Fi</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">Dùng tên mạng Wi-Fi đang kết nối để lưu lịch sử tuyến riêng. Cần quyền vị trí chính xác vì Android bảo vệ tên mạng Wi-Fi như thông tin vị trí.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Cần quyền vị trí chính xác để đọc tên mạng Wi-Fi</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">关闭服务</string>
     <string name="toast_services_success">启动服务成功</string>
     <string name="toast_services_failure">启动服务失败</string>
+    <string name="notification_core_recovery_failed">连接恢复失败。流量将保持阻断以防泄漏；请重启 v2rayNG。</string>
 
     <!--ServerActivity-->
     <string name="title_server">配置项</string>
@@ -160,6 +161,9 @@
     <string name="summary_pref_per_app_proxy">常规: 勾选的 App 被代理, 未勾选的直连;\n绕行模式: 勾选的 App 直连, 未勾选的被代理.\n不明白者在菜单中选择自动选中需代理应用</string>
     <string name="title_pref_is_booted">开机时自动连接</string>
     <string name="summary_pref_is_booted">开机时自动连接选择的服务器，可能会不成功</string>
+    <string name="title_pref_remember_routes_per_wifi_network">按 Wi-Fi 网络记住可用路由</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">使用当前连接的 Wi-Fi 名称分别保存路由历史。由于 Android 将 Wi-Fi 名称作为位置信息加以保护，因此需要精确位置权限。</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">读取 Wi-Fi 网络名称需要精确位置权限</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">测试后自动删除无效配置</string>
     <string name="summary_pref_auto_remove_invalid_after_test">测试结果可能不准确且已删除的配置无法恢复</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,6 +19,7 @@
     <string name="toast_services_stop">停止服務</string>
     <string name="toast_services_success">啟動服務成功</string>
     <string name="toast_services_failure">啟動服務失敗</string>
+    <string name="notification_core_recovery_failed">連線復原失敗。流量將保持封鎖以防洩漏；請重新啟動 v2rayNG。</string>
 
     <!-- ServerActivity -->
     <string name="title_server">設定檔</string>
@@ -159,6 +160,9 @@
     <string name="summary_pref_per_app_proxy">常規：勾選的 App 啟用 Proxy，未勾選的直接連線；\n繞行模式：勾選的 App 直接連線，未勾選的啟用 Proxy。\n可在選單中選擇自動選中需 Proxy 應用</string>
     <string name="title_pref_is_booted">開機時自動連線</string>
     <string name="summary_pref_is_booted">開機時自動連線選擇的伺服器，可能會不成功</string>
+    <string name="title_pref_remember_routes_per_wifi_network">依 Wi-Fi 網路記住可用路由</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">使用目前連線的 Wi-Fi 名稱分別儲存路由記錄。由於 Android 將 Wi-Fi 名稱視為位置資訊加以保護，因此需要精確位置權限。</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">讀取 Wi-Fi 網路名稱需要精確位置權限</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">測試後自動刪除無效配置</string>
     <string name="summary_pref_auto_remove_invalid_after_test">測試結果可能不準確且已刪除的配置無法復原</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="toast_services_stop">Stop Services</string>
     <string name="toast_services_success">Start Services Success</string>
     <string name="toast_services_failure">Start Services Failure</string>
+    <string name="notification_core_recovery_failed">Connection recovery failed. Traffic remains blocked to prevent leaks; restart v2rayNG.</string>
 
     <!--ServerActivity-->
     <string name="title_server">Config</string>
@@ -164,6 +165,9 @@
     <string name="summary_pref_per_app_proxy">General: Checked apps use proxy, unchecked apps connect directly; \nBypass mode: checked apps connect directly, unchecked apps use proxy. \nThe option to automatically select proxy applications is in the menu</string>
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_remember_routes_per_wifi_network">Remember viable routes per Wi-Fi network</string>
+    <string name="summary_pref_remember_routes_per_wifi_network">Uses the connected Wi-Fi name to keep separate route histories. Requires precise location permission because Android protects Wi-Fi names as location information.</string>
+    <string name="toast_precise_location_required_for_wifi_route_memory">Precise location permission is required to read the Wi-Fi network name</string>
 
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/OutboundProbeConfigBuilderTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/OutboundProbeConfigBuilderTest.kt
@@ -1,0 +1,239 @@
+package com.v2ray.ang.core
+
+import com.google.gson.JsonParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OutboundProbeConfigBuilderTest {
+    @Test
+    fun namespacesOutboundsAndRemapsDialerChains() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "normal-a",
+                    """
+                    {
+                      "outbounds": [
+                        {
+                          "tag": "proxy",
+                          "protocol": "freedom",
+                          "streamSettings": {"sockopt": {"dialerProxy": "hop"}}
+                        },
+                        {"tag": "hop", "protocol": "freedom"}
+                      ],
+                      "routing": {"rules": []}
+                    }
+                    """.trimIndent(),
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "normal-b",
+                    """{"outbounds":[{"tag":"proxy","protocol":"freedom"}]}""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(listOf("probe-0-proxy", "probe-1-proxy"), plan.outboundTags)
+        assertEquals(
+            listOf(listOf("probe-0-proxy"), listOf("probe-1-proxy")),
+            plan.probeGroups,
+        )
+        val root = JsonParser.parseString(plan.content).asJsonObject
+        val outbounds = root.getAsJsonArray("outbounds")
+        assertEquals(3, outbounds.size())
+        val firstSockopt = outbounds[0].asJsonObject
+            .getAsJsonObject("streamSettings")
+            .getAsJsonObject("sockopt")
+        assertEquals("probe-0-hop", firstSockopt.get("dialerProxy").asString)
+        assertEquals(0, root.getAsJsonObject("burstObservatory").getAsJsonArray("subjectSelector").size())
+    }
+
+    @Test
+    fun retainsPrimaryPolicyBalancerAndMapsItsMembers() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "policy-guid",
+                    """
+                    {
+                      "outbounds": [
+                        {"tag":"proxy-proxy-1-a","protocol":"freedom"},
+                        {"tag":"proxy-proxy-2-b","protocol":"freedom"},
+                        {"tag":"direct","protocol":"freedom"}
+                      ],
+                      "routing": {
+                        "rules": [{"type":"field","network":"tcp,udp","balancerTag":"balancer-main"}],
+                        "balancers": [{
+                          "tag":"balancer-main",
+                          "selector":["proxy-proxy-"],
+                          "strategy":{"type":"leastPing"}
+                        }]
+                      }
+                    }
+                    """.trimIndent(),
+                )
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertTrue(plan.failedGuids.isEmpty())
+        assertEquals("probe-0-balancer-main", plan.profiles.single().balancerTag)
+        assertEquals(
+            listOf("proxy-proxy-1-a", "proxy-proxy-2-b"),
+            plan.profiles.single().candidates.map { it.runtimeTag },
+        )
+        assertEquals(
+            listOf(listOf("probe-0-proxy-proxy-1-a", "probe-0-proxy-proxy-2-b")),
+            plan.probeGroups,
+        )
+        val balancer = JsonParser.parseString(plan.content).asJsonObject
+            .getAsJsonObject("routing")
+            .getAsJsonArray("balancers")[0].asJsonObject
+        assertEquals("probe-0-proxy-proxy-", balancer.getAsJsonArray("selector")[0].asString)
+    }
+
+    @Test
+    fun preservesLeastLoadProbeRequirementsForTheWholeBatch() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "policy-guid",
+                    """
+                    {
+                      "outbounds": [
+                        {"tag":"proxy-a","protocol":"freedom"},
+                        {"tag":"proxy-b","protocol":"freedom"}
+                      ],
+                      "routing": {
+                        "rules": [{"type":"field","balancerTag":"balancer-main"}],
+                        "balancers": [{
+                          "tag":"balancer-main",
+                          "selector":["proxy-"],
+                          "strategy":{"type":"leastLoad"}
+                        }]
+                      },
+                      "burstObservatory": {
+                        "subjectSelector":["proxy-"],
+                        "pingConfig": {
+                          "destination":"https://ignored.example",
+                          "httpMethod":"HEAD",
+                          "interval":"5m",
+                          "sampling":3,
+                          "timeout":"30s"
+                        }
+                      }
+                    }
+                    """.trimIndent(),
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "normal-guid",
+                    """{"outbounds":[{"tag":"proxy","protocol":"freedom"}]}""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(3, plan.samples)
+        val pingConfig = JsonParser.parseString(plan.content).asJsonObject
+            .getAsJsonObject("burstObservatory")
+            .getAsJsonObject("pingConfig")
+        assertEquals("HEAD", pingConfig.get("httpMethod").asString)
+        assertEquals("30s", pingConfig.get("timeout").asString)
+        assertEquals(3, pingConfig.get("sampling").asInt)
+        assertEquals("https://example.com/generate_204", pingConfig.get("destination").asString)
+    }
+
+    @Test
+    fun rejectsPolicyStrategiesWithoutOneStableViableTarget() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "random-policy",
+                    """
+                    {
+                      "outbounds": [
+                        {"tag":"proxy-a","protocol":"freedom"},
+                        {"tag":"proxy-b","protocol":"freedom"}
+                      ],
+                      "routing": {
+                        "rules": [{"type":"field","balancerTag":"balancer-main"}],
+                        "balancers": [{
+                          "tag":"balancer-main",
+                          "selector":["proxy-"],
+                          "strategy":{"type":"random"}
+                        }]
+                      }
+                    }
+                    """.trimIndent(),
+                )
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(listOf("random-policy"), plan.failedGuids)
+        assertTrue(plan.profiles.isEmpty())
+        assertEquals(0, JsonParser.parseString(plan.content).asJsonObject.getAsJsonArray("outbounds").size())
+    }
+
+    @Test
+    fun rejectsAmbiguousOrBrokenSourceReferencesBeforeMerge() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source(
+                    "duplicate-tags",
+                    """{"outbounds":[
+                      {"tag":"proxy","protocol":"freedom"},
+                      {"tag":"proxy","protocol":"freedom"}
+                    ]}""",
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "missing-dialer",
+                    """{"outbounds":[{
+                      "tag":"proxy",
+                      "protocol":"freedom",
+                      "streamSettings":{"sockopt":{"dialerProxy":"missing"}}
+                    }]}""",
+                ),
+                OutboundProbeConfigBuilder.Source(
+                    "conditional-route",
+                    """{
+                      "outbounds":[{"tag":"proxy","protocol":"freedom"}],
+                      "routing":{"rules":[{
+                        "type":"field",
+                        "domain":["example.com"],
+                        "outboundTag":"proxy"
+                      }]}
+                    }""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(
+            listOf("duplicate-tags", "missing-dialer", "conditional-route"),
+            plan.failedGuids,
+        )
+        assertTrue(plan.profiles.isEmpty())
+        assertEquals(0, JsonParser.parseString(plan.content).asJsonObject.getAsJsonArray("outbounds").size())
+    }
+
+    @Test
+    fun isolatesMalformedProfilesFromTheViableBatch() {
+        val plan = OutboundProbeConfigBuilder.build(
+            sources = listOf(
+                OutboundProbeConfigBuilder.Source("broken", "{}"),
+                OutboundProbeConfigBuilder.Source(
+                    "valid",
+                    """{"outbounds":[{"tag":"proxy","protocol":"freedom"}]}""",
+                ),
+            ),
+            destination = "https://example.com/generate_204",
+        )
+
+        assertEquals(listOf("broken"), plan.failedGuids)
+        assertEquals(listOf("valid"), plan.profiles.map { it.guid })
+        assertFalse(plan.content.isBlank())
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyRouteCacheTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/PolicyRouteCacheTest.kt
@@ -1,0 +1,75 @@
+package com.v2ray.ang.core
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PolicyRouteCacheTest {
+    @After
+    fun tearDown() = PolicyRouteCache.clear()
+
+    @Test
+    fun keepsRoutesSeparateByNetworkAndProfile() {
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-a"))
+        assertTrue(PolicyRouteCache.remember("cellular:310260", "group-a", "proxy-b"))
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-b", "proxy-c"))
+
+        assertEquals("proxy-a", PolicyRouteCache.lookup("wifi:home", "group-a"))
+        assertEquals("proxy-b", PolicyRouteCache.lookup("cellular:310260", "group-a"))
+        assertEquals("proxy-c", PolicyRouteCache.lookup("wifi:home", "group-b"))
+    }
+
+    @Test
+    fun clearInvalidatesInFlightWrites() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
+        val snapshot = PolicyRouteCache.snapshot()
+
+        PolicyRouteCache.clear()
+
+        assertFalse(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-a", snapshot.generation))
+        assertNull(PolicyRouteCache.snapshot().networkKey)
+        assertNull(PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun freshObservatoryTargetReplacesPreviousRoute() {
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-old"))
+        assertTrue(PolicyRouteCache.remember("wifi:home", "group-a", "proxy-fresh"))
+
+        assertEquals("proxy-fresh", PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun networkSwitchInvalidatesInFlightCurrentRouteWrite() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
+        val snapshot = PolicyRouteCache.snapshot()
+
+        PolicyRouteCache.setCurrentNetwork("cellular:310260", 200L)
+
+        assertFalse(PolicyRouteCache.rememberCurrent(snapshot, "group-a", "proxy-a"))
+        assertNull(PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun currentRouteAcknowledgementIsIdempotent() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
+        val snapshot = PolicyRouteCache.snapshot()
+
+        assertTrue(PolicyRouteCache.rememberCurrent(snapshot, "group-a", "proxy-a"))
+        assertTrue(PolicyRouteCache.rememberCurrent(snapshot, "group-a", "proxy-a"))
+        assertEquals("proxy-a", PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+
+    @Test
+    fun batchResultMustMatchExactNetworkInstance() {
+        PolicyRouteCache.setCurrentNetwork("wifi:home", 100L)
+
+        assertFalse(PolicyRouteCache.rememberObserved("wifi:home", 99L, "group-a", "proxy-old"))
+        assertFalse(PolicyRouteCache.rememberObserved("cellular:310260", 100L, "group-a", "proxy-old"))
+        assertTrue(PolicyRouteCache.rememberObserved("wifi:home", 100L, "group-a", "proxy-current"))
+        assertEquals("proxy-current", PolicyRouteCache.lookup("wifi:home", "group-a"))
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/service/NetworkIdentityResolverTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/service/NetworkIdentityResolverTest.kt
@@ -1,0 +1,21 @@
+package com.v2ray.ang.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NetworkIdentityResolverTest {
+    @Test
+    fun normalizesWifiSsidWithoutSplittingMeshAccessPoints() {
+        assertEquals("wifi:Home Mesh", NetworkIdentityResolver.wifiKey("\"Home Mesh\""))
+        assertEquals("wifi", NetworkIdentityResolver.wifiKey("<unknown ssid>"))
+        assertEquals("wifi", NetworkIdentityResolver.wifiKey(null))
+        assertEquals("wifi", NetworkIdentityResolver.wifiKey("\"Home Mesh\"", rememberPerNetwork = false))
+    }
+
+    @Test
+    fun prefersCurrentCellularOperatorAndFallsBackToSimOperator() {
+        assertEquals("cellular:310260", NetworkIdentityResolver.cellularKey("310260", "23415"))
+        assertEquals("cellular:23415", NetworkIdentityResolver.cellularKey("", "23415"))
+        assertEquals("cellular", NetworkIdentityResolver.cellularKey("invalid", null))
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/service/UnderlyingNetworkStateTrackerTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/service/UnderlyingNetworkStateTrackerTest.kt
@@ -1,0 +1,49 @@
+package com.v2ray.ang.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnderlyingNetworkStateTrackerTest {
+    private val tracker = UnderlyingNetworkStateTracker<String>()
+
+    @Test
+    fun initialAndRepeatedAvailabilityAreNotTransitions() {
+        assertFalse(tracker.onAvailable("wifi"))
+        assertFalse(tracker.onAvailable("wifi"))
+        assertTrue(tracker.isCurrent("wifi"))
+    }
+
+    @Test
+    fun changingNetworksIsATransition() {
+        tracker.onAvailable("wifi")
+
+        assertTrue(tracker.onAvailable("cellular"))
+        assertTrue(tracker.isCurrent("cellular"))
+    }
+
+    @Test
+    fun losingAndReacquiringAnUnderlayIsATransition() {
+        tracker.onAvailable("wifi")
+
+        assertTrue(tracker.onLost("wifi"))
+        assertTrue(tracker.onAvailable("wifi"))
+    }
+
+    @Test
+    fun losingAStaleNetworkDoesNotClearTheCurrentUnderlay() {
+        tracker.onAvailable("wifi")
+        tracker.onAvailable("cellular")
+
+        assertFalse(tracker.onLost("wifi"))
+        assertTrue(tracker.isCurrent("cellular"))
+    }
+
+    @Test
+    fun resetMakesTheNextNetworkInitialAgain() {
+        tracker.onAvailable("wifi")
+        tracker.reset()
+
+        assertFalse(tracker.onAvailable("cellular"))
+    }
+}


### PR DESCRIPTION
## Summary

This PR prevents policy-group VPN connections from becoming stuck after Wi-Fi/cellular transitions for the duration of policy-group timeout and moves the real-delay test to a single disposable, batched probing process utilizing xray-core Observatory.

It is an alternative implementation of https://github.com/2dust/v2rayNG/pull/5905 that does not depend on changes to xray-core.

## Network-switch recovery

The VPN service tracks the actual underlying Android network and performs an in-process Xray reset after a confirmed underlay transition.

The reset:

- Keeps the VPN interface and service alive.
- Recreates the native Xray instance so stale sockets, transports, mux sessions, DNS state, and connection pools are discarded.
- Avoids running two Xray instances simultaneously.
- Keeps the VPN fail-closed and reports a visible error if both replacement startup and original-configuration recovery fail.

Network callbacks are filtered through an underlay state tracker so duplicate availability or capability callbacks do not cause redundant resets.

## Per-network policy-route memory

The app keeps a process-local cache of the last successful policy-group outbound for each profile and underlay.

- Cellular identities use the available operator identity.
- Wi-Fi route memory is used only when a sufficiently precise network identity is available and the user explicitly enables it.
- Results from the delay-test process are accepted only when both the network key and Android network handle still match.
- In-flight results from an older network generation are rejected.

Nothing is persisted to storage; explicit service shutdown clears the cache.

## Gap-free warm handoff for policy-groups

When returning to a previously observed network, the cached outbound is applied immediately while the replacement Observatory gathers fresh results.

The override remains active until:

1. Xray reports a viable fresh policy-group target.
2. v2rayNG accepts that target for the exact current underlay.
3. The app acknowledges the callback.
4. AndroidLib releases the warm override.

Callbacks received while a network transition is still active are rejected and retried after the transition settles. Idempotent cache writes count as successful acknowledgement.

This prevents the app from entering a route-less interval between warm-start expiry and final policy-group selection. If Observatory never finds a viable replacement, the known warm route remains active.

## Real-delay probing

The current v2rayN method of bulk probing, apparently https://github.com/XTLS/Xray-core/pull/6483#issuecomment-4954335868 where only one xray core should be run in a single process. Running temporary xray cores in the same process as the main core can corrupt the main core. Real-delay tests now run in a dedicated disposable service process using one combined Xray instance.

- Each original UI configuration becomes one native concurrency group.
- The existing True delay concurrency preference limits the number of active profile groups.
- Policy-group candidates inside an active group are checked concurrently.
- Each candidate publishes a progressive snapshot as soon as it finishes.
- An unresponsive policy-group member does not hold back successful candidates.
- Profile progress is marked complete only after all required candidate samples finish.
- Successful policy-group selections can update the route cache for the exact network instance that was tested.
- Repeated and back-to-back requests are handed to fresh processes, preserving the native isolation boundary.

Malformed or unsupported source configurations fail individually instead of invalidating the entire batch.

## Dependency

This PR depends on [AndroidLibXrayLite PR "Add xraycore-compatible probing and policy-group warm-start"
](https://github.com/2dust/AndroidLibXrayLite/pull/200).

That AndroidLib implementation uses the existing unchanged xray-core APIs. No xray-core PR or new Observatory functionality is required.

## Verification

- AndroidLib `go test .`
- AndroidLib `go test -race .`
- Focused `PolicyRouteCacheTest`
- Focused `OutboundProbeConfigBuilderTest`
- `:app:assemblePlaystoreDebug`
- Four-ABI AndroidLib AAR build
- Verified that the APK’s x86_64 `libgojni.so` matches the rebuilt AAR
- APK signature verification with v2 and v3 schemes
- Debug APK installed successfully on the x86_64 emulator