### PR TITLE
Shadowsocks parser never reads transport type, always falls back to TCP

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -28,16 +28,13 @@ object ShadowsocksFmt : FmtBase() {
      */
     fun parseSip002(str: String): ProfileItem? {
         val config = ProfileItem.create(EConfigType.SHADOWSOCKS)
-
         val uri = URI(Utils.fixIllegalUrl(str))
         if (uri.idnHost.isEmpty()) return null
         if (uri.port <= 0) return null
         if (uri.userInfo.isNullOrEmpty()) return null
-
         config.remarks = Utils.decodeURIComponent(uri.fragment.orEmpty()).let { it.ifEmpty { "none" } }
         config.server = uri.idnHost
         config.serverPort = uri.port.toString()
-
         val result = if (uri.userInfo.contains(":")) {
             uri.userInfo.split(":", limit = 2)
         } else {
@@ -47,9 +44,9 @@ object ShadowsocksFmt : FmtBase() {
             config.method = result.first()
             config.password = result.last()
         }
-
         if (!uri.rawQuery.isNullOrEmpty()) {
             val queryParam = getQueryParam(uri)
+            getItemFormQuery(config, queryParam, false)
             if (queryParam["plugin"]?.contains("obfs=http") == true) {
                 val queryPairs = HashMap<String, String>()
                 for (pair in queryParam["plugin"]?.split(";") ?: listOf()) {
@@ -64,7 +61,6 @@ object ShadowsocksFmt : FmtBase() {
                 config.path = queryPairs["path"]
             }
         }
-
         return config
     }
 
@@ -119,7 +115,6 @@ object ShadowsocksFmt : FmtBase() {
      */
     fun toUri(config: ProfileItem): String {
         val pw = "${config.method}:${config.password}"
-
-        return toUri(config, Utils.encode(pw, true), null)
+        return toUri(config, Utils.encode(pw, true), getQueryDic(config))
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -46,7 +46,7 @@ object ShadowsocksFmt : FmtBase() {
         }
         if (!uri.rawQuery.isNullOrEmpty()) {
             val queryParam = getQueryParam(uri)
-            getItemFormQuery(config, queryParam, false)
+            getItemFormQuery(config, queryParam)
             if (queryParam["plugin"]?.contains("obfs=http") == true) {
                 val queryPairs = HashMap<String, String>()
                 for (pair in queryParam["plugin"]?.split(";") ?: listOf()) {


### PR DESCRIPTION
ShadowsocksFmt.parseSip002() never read the type/host/path/security/mode/fp/alpn
query params from ss:// links. It only handled the legacy plugin=obfs-http case,
so any ss:// link using ws/xhttp/grpc transport silently fell back to TCP and
failed to connect.

Added a call to the shared getItemFormQuery() before the existing obfs check
same function VLESS/VMess/Trojan already use for this. Legacy obfs links still
work since that check runs after and overrides network/headerType as before.

Also fixed toUri(), which passed null for the query dict and dropped these
fields when re-exporting a profile back to a share link.

Tested with an ss:// link using type=xhttp connects now, failed before :)