### PR TITLE
Fix backup and restore on Android TV (#5916)

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -40,6 +40,11 @@
     <!-- <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /> -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32"
+        tools:ignore="ScopedStorage" />
 
     <application
         android:name=".AngApplication"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/enums/PermissionType.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/enums/PermissionType.kt
@@ -23,6 +23,11 @@ enum class PermissionType {
     ACCESS_LOCAL_NETWORK {
         @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
         override fun getPermission(): String = Manifest.permission.ACCESS_LOCAL_NETWORK
+    },
+
+    /** External storage write permission (Android 12 and below) */
+    WRITE_EXTERNAL_STORAGE {
+        override fun getPermission(): String = Manifest.permission.WRITE_EXTERNAL_STORAGE
     };
 
     /** Return the actual Android permission string */
@@ -34,6 +39,7 @@ enum class PermissionType {
             CAMERA -> "Camera"
             POST_NOTIFICATIONS -> "Notification"
             ACCESS_LOCAL_NETWORK -> "Local Network"
+            WRITE_EXTERNAL_STORAGE -> "Storage"
         }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/WebDavManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/WebDavManager.kt
@@ -46,7 +46,29 @@ object WebDavManager {
     suspend fun uploadFile(localFile: File, remoteFileName: String): Boolean = withContext(Dispatchers.IO) {
         val remote = buildRemoteUrl(remoteFileName)
         try {
-            val cl = client ?: return@withContext false
+            val cl = client ?: run {
+                LogUtil.e(AppConfig.TAG, "WebDAV upload failed: client not initialized")
+                return@withContext false
+            }
+
+            // Validate local file
+            if (!localFile.exists()) {
+                LogUtil.e(AppConfig.TAG, "WebDAV upload failed: local file does not exist: ${localFile.absolutePath}")
+                return@withContext false
+            }
+
+            if (!localFile.canRead()) {
+                LogUtil.e(AppConfig.TAG, "WebDAV upload failed: cannot read local file: ${localFile.absolutePath}")
+                return@withContext false
+            }
+
+            val fileSize = localFile.length()
+            if (fileSize == 0L) {
+                LogUtil.e(AppConfig.TAG, "WebDAV upload failed: local file is empty (0 bytes): ${localFile.absolutePath}")
+                return@withContext false
+            }
+
+            LogUtil.i(AppConfig.TAG, "WebDAV upload starting: ${localFile.absolutePath} ($fileSize bytes) -> $remote")
 
             // Ensure parent directories exist
             val dirPath = remote.substringBeforeLast('/')
@@ -67,9 +89,9 @@ object WebDavManager {
             cl.newCall(req).execute().use { resp ->
                 val success = resp.isSuccessful
                 if (success) {
-                    LogUtil.i(AppConfig.TAG, "WebDAV upload success: $remote")
+                    LogUtil.i(AppConfig.TAG, "WebDAV upload success: $remote ($fileSize bytes)")
                 } else {
-                    LogUtil.e(AppConfig.TAG, "WebDAV upload failed: $remote (HTTP ${resp.code})")
+                    LogUtil.e(AppConfig.TAG, "WebDAV upload failed: $remote (HTTP ${resp.code}) - ${resp.message}")
                 }
                 return@withContext success
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/BackupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/BackupActivity.kt
@@ -2,7 +2,9 @@ package com.v2ray.ang.ui
 
 import android.app.AlertDialog
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import androidx.core.content.FileProvider
 import androidx.lifecycle.lifecycleScope
 import com.tencent.mmkv.MMKV
@@ -13,6 +15,7 @@ import com.v2ray.ang.R
 import com.v2ray.ang.databinding.ActivityBackupBinding
 import com.v2ray.ang.databinding.DialogWebdavBinding
 import com.v2ray.ang.dto.entities.WebDavConfig
+import com.v2ray.ang.enums.PermissionType
 import com.v2ray.ang.extension.toastError
 import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.handler.MmkvManager
@@ -20,6 +23,7 @@ import com.v2ray.ang.handler.SettingsChangeManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.handler.WebDavManager
 import com.v2ray.ang.util.LogUtil
+import com.v2ray.ang.util.Utils
 import com.v2ray.ang.util.ZipUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -156,6 +160,12 @@ class BackupActivity : HelperBaseActivity() {
     }
 
     private fun backupViaLocal() {
+        // Check if running on Android TV - use fallback method
+        if (Utils.isAndroidTv(this)) {
+            backupToDownloadsFolder()
+            return
+        }
+
         val dateFormatted = SimpleDateFormat(
             "yyyy-MM-dd-HH-mm-ss",
             Locale.getDefault()
@@ -188,6 +198,12 @@ class BackupActivity : HelperBaseActivity() {
     }
 
     private fun restoreViaLocal() {
+        // Check if running on Android TV - use fallback method
+        if (Utils.isAndroidTv(this)) {
+            restoreFromDownloadsFolder()
+            return
+        }
+
         showFileChooser()
     }
 
@@ -212,6 +228,25 @@ class BackupActivity : HelperBaseActivity() {
                 }
 
                 tempFile = File(ret.second)
+
+                // Verify the file was created successfully and is not empty
+                if (!tempFile.exists()) {
+                    LogUtil.e(AppConfig.TAG, "WebDAV backup: temp file does not exist")
+                    withContext(Dispatchers.Main) {
+                        toastError(R.string.toast_failure)
+                    }
+                    return@launch
+                }
+
+                if (tempFile.length() == 0L) {
+                    LogUtil.e(AppConfig.TAG, "WebDAV backup: temp file is empty (0 bytes)")
+                    withContext(Dispatchers.Main) {
+                        toastError(R.string.toast_failure)
+                    }
+                    return@launch
+                }
+
+                LogUtil.i(AppConfig.TAG, "WebDAV backup: uploading file ${tempFile.length()} bytes")
                 WebDavManager.init(saved)
 
                 val ok = try {
@@ -310,5 +345,159 @@ class BackupActivity : HelperBaseActivity() {
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
+    }
+
+    /**
+     * Backup to Downloads folder (fallback for Android TV where SAF may not be available)
+     */
+    private fun backupToDownloadsFolder() {
+        // Check storage permission for Android 12 and below
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            checkAndRequestPermission(PermissionType.WRITE_EXTERNAL_STORAGE) {
+                performBackupToDownloadsFolder()
+            }
+        } else {
+            // Android 13+ doesn't need permission for Downloads
+            performBackupToDownloadsFolder()
+        }
+    }
+
+    private fun performBackupToDownloadsFolder() {
+        try {
+            val dateFormatted = SimpleDateFormat(
+                "yyyy-MM-dd-HH-mm-ss",
+                Locale.getDefault()
+            ).format(System.currentTimeMillis())
+            val fileName = "${getString(R.string.app_name)}_${dateFormatted}.zip"
+
+            // Use public Downloads directory
+            val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            if (!downloadsDir.exists()) {
+                downloadsDir.mkdirs()
+            }
+
+            val destFile = File(downloadsDir, fileName)
+
+            val ret = backupConfigurationToCache()
+            if (ret.first) {
+                // Copy from cache to Downloads
+                File(ret.second).inputStream().use { input ->
+                    destFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+                File(ret.second).delete()
+                toastSuccess("${getString(R.string.toast_success)}\n${destFile.absolutePath}")
+                LogUtil.i(AppConfig.TAG, "Backup saved to: ${destFile.absolutePath}")
+            } else {
+                toastError(R.string.toast_failure)
+            }
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to backup to Downloads folder", e)
+            toastError(R.string.toast_failure)
+        }
+    }
+
+    /**
+     * Restore from Downloads folder (fallback for Android TV where SAF may not be available)
+     * Scans for the most recent backup file
+     */
+    private fun restoreFromDownloadsFolder() {
+        // Check storage permission for Android 12 and below
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            checkAndRequestPermission(PermissionType.WRITE_EXTERNAL_STORAGE) {
+                performRestoreFromDownloadsFolder()
+            }
+        } else {
+            // Android 13+ doesn't need permission for Downloads
+            performRestoreFromDownloadsFolder()
+        }
+    }
+
+    private fun performRestoreFromDownloadsFolder() {
+        try {
+            val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            if (!downloadsDir.exists() || !downloadsDir.isDirectory) {
+                toastError(getString(R.string.backup_downloads_folder_not_found))
+                return
+            }
+
+            // Find all backup zip files
+            val backupFiles = downloadsDir.listFiles { file ->
+                file.isFile && file.name.endsWith(".zip") &&
+                (file.name.startsWith(getString(R.string.app_name)) || file.name.contains("v2rayNG"))
+            }?.sortedByDescending { it.lastModified() }
+
+            if (backupFiles.isNullOrEmpty()) {
+                toastError(getString(R.string.backup_no_files_found))
+                return
+            }
+
+            // Show dialog to select backup file
+            val fileNames = backupFiles.map {
+                "${it.name} (${android.text.format.Formatter.formatFileSize(this, it.length())})"
+            }.toTypedArray()
+
+            AlertDialog.Builder(this)
+                .setTitle(R.string.title_configuration_restore)
+                .setItems(fileNames) { _, which ->
+                    val selectedFile = backupFiles[which]
+                    performRestore(selectedFile)
+                }
+                .setNeutralButton(R.string.backup_delete_old) { _, _ ->
+                    showDeleteBackupsDialog(backupFiles)
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to restore from Downloads folder", e)
+            toastError(R.string.toast_failure)
+        }
+    }
+
+    private fun showDeleteBackupsDialog(backupFiles: List<File>) {
+        val fileNames = backupFiles.map {
+            "${it.name} (${android.text.format.Formatter.formatFileSize(this, it.length())})"
+        }.toTypedArray()
+
+        val selectedItems = BooleanArray(backupFiles.size) { false }
+
+        AlertDialog.Builder(this)
+            .setTitle(R.string.backup_select_to_delete)
+            .setMultiChoiceItems(fileNames, selectedItems) { _, which, isChecked ->
+                selectedItems[which] = isChecked
+            }
+            .setPositiveButton(R.string.backup_delete_button) { _, _ ->
+                var deletedCount = 0
+                selectedItems.forEachIndexed { index, selected ->
+                    if (selected) {
+                        try {
+                            if (backupFiles[index].delete()) {
+                                deletedCount++
+                            }
+                        } catch (e: Exception) {
+                            LogUtil.e(AppConfig.TAG, "Failed to delete ${backupFiles[index].name}", e)
+                        }
+                    }
+                }
+                if (deletedCount > 0) {
+                    toastSuccess(getString(R.string.backup_deleted_count, deletedCount))
+                }
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun performRestore(zipFile: File) {
+        try {
+            if (restoreConfiguration(zipFile)) {
+                toastSuccess(R.string.toast_success)
+            } else {
+                toastError(R.string.toast_failure)
+            }
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to restore configuration", e)
+            toastError(R.string.toast_failure)
+        }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -1,9 +1,11 @@
 package com.v2ray.ang.util
 
+import android.app.UiModeManager
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.content.res.Configuration.UI_MODE_NIGHT_MASK
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.os.Build
@@ -611,5 +613,16 @@ object Utils {
             LogUtil.e(AppConfig.TAG, "Failed to format timestamp", e)
             ""
         }
+    }
+
+    /**
+     * Check if the app is running on Android TV.
+     *
+     * @param context The context to use.
+     * @return True if running on Android TV, false otherwise.
+     */
+    fun isAndroidTv(context: Context): Boolean {
+        val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        return uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
     }
 }

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -410,6 +410,12 @@
     <string name="title_webdav_user">Пользователь</string>
     <string name="title_webdav_pass">Пароль</string>
     <string name="title_webdav_remote_path">Удалённый путь (необязательно)</string>
+    <string name="backup_downloads_folder_not_found">Папка Загрузки не найдена</string>
+    <string name="backup_no_files_found">Файлы резервных копий не найдены в папке Загрузки</string>
+    <string name="backup_delete_old">Удалить старые копии</string>
+    <string name="backup_select_to_delete">Выберите резервные копии для удаления</string>
+    <string name="backup_deleted_count">Удалено копий: %d</string>
+    <string name="backup_delete_button">Удалить</string>
 
     <string-array name="share_method">
         <item>QR-код</item>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -404,10 +404,16 @@
     <string name="title_configuration_share">分享配置</string>
     <string name="title_webdav_config_setting">WebDAV 设置</string>
     <string name="title_webdav_config_setting_unknown">请先设置 WebDAV</string>
-    <string name="title_webdav_url">WebDAV 服务器地址</string>WebDAV server address
+    <string name="title_webdav_url">WebDAV 服务器地址</string>
     <string name="title_webdav_user">用户名</string>
     <string name="title_webdav_pass">密码</string>
     <string name="title_webdav_remote_path">远程文件夹名（可选）</string>
+    <string name="backup_downloads_folder_not_found">未找到下载文件夹</string>
+    <string name="backup_no_files_found">下载文件夹中未找到备份文件</string>
+    <string name="backup_delete_old">删除旧备份</string>
+    <string name="backup_select_to_delete">选择要删除的备份</string>
+    <string name="backup_deleted_count">已删除 %d 个备份</string>
+    <string name="backup_delete_button">删除</string>
 
     <string-array name="share_method">
         <item>二维码</item>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -406,6 +406,12 @@
     <string name="title_webdav_user">使用者名稱</string>
     <string name="title_webdav_pass">密碼</string>
     <string name="title_webdav_remote_path">遠端目錄（可選）</string>
+    <string name="backup_downloads_folder_not_found">找不到下載資料夾</string>
+    <string name="backup_no_files_found">下載資料夾中找不到備份檔案</string>
+    <string name="backup_delete_old">刪除舊備份</string>
+    <string name="backup_select_to_delete">選擇要刪除的備份</string>
+    <string name="backup_deleted_count">已刪除 %d 個備份</string>
+    <string name="backup_delete_button">刪除</string>
 
     <string-array name="share_method">
         <item>二維碼</item>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -413,6 +413,12 @@
     <string name="title_webdav_user">Username</string>
     <string name="title_webdav_pass">Password</string>
     <string name="title_webdav_remote_path">Remote directory (optional)</string>
+    <string name="backup_downloads_folder_not_found">Downloads folder not found</string>
+    <string name="backup_no_files_found">No backup files found in Downloads folder</string>
+    <string name="backup_delete_old">Delete old backups</string>
+    <string name="backup_select_to_delete">Select backups to delete</string>
+    <string name="backup_deleted_count">Deleted %d backup(s)</string>
+    <string name="backup_delete_button">Delete</string>
 
     <string-array name="share_method">
         <item>QRcode</item>


### PR DESCRIPTION
## Fix backup and restore on Android TV (#5916)

### Problem

This PR addresses the critical regression in the Backup & Restore feature on Android TV devices reported in issue #5916.

**Issues fixed:**
1. **Local Backup/Restore failure** - Storage Access Framework (SAF) document picker is often unavailable on Android TV, causing immediate "Failure" errors
2. **WebDAV 0-byte files** - WebDAV backup successfully creates files but they are empty (0 bytes), making restoration impossible
3. **No way to manage old backups** - Users couldn't delete accumulated backup files

### Solution

#### 1. Android TV Support
- Added `Utils.isAndroidTv()` detection method
- Implemented fallback mechanism using public Downloads folder (`/storage/emulated/0/Download/`)
- On Android TV, backup/restore automatically uses Downloads folder instead of SAF
- Success message shows full path to backup file
- Added storage permissions (`READ/WRITE_EXTERNAL_STORAGE`) for Android ≤12

#### 2. WebDAV Fix
- Added comprehensive file validation before upload in `WebDavManager.uploadFile()`
- Validates file exists, is readable, and has non-zero size
- Enhanced error logging with file sizes and HTTP response details
- Prevents 0-byte file creation on server

#### 3. Backup Management
- Added "Delete old backups" button in restore dialog
- Multi-select dialog to choose which backups to delete
- Shows file names with sizes for easy identification
- Confirmation with deleted count

#### 4. Localization
- Added 6 new string resources for new features
- Translated to English, Russian, Chinese (Simplified & Traditional)

### Testing on Android TV

**Backup:**
- File saves to Downloads folder with timestamp
- Full path displayed in success message
- File can be transferred via USB or file manager

**Restore:**
- Scans Downloads folder for backup files
- Shows sorted list (newest first) with file sizes
- User selects file to restore
- Option to delete old backups

**WebDAV:**
- Now creates proper non-empty backup files
- Enhanced logging helps diagnose connection issues

### Technical Changes

- **`BackupActivity.kt`**: Added TV fallback methods with permission handling
- **`WebDavManager.kt`**: File validation and enhanced logging
- **`Utils.kt`**: Android TV detection using UiModeManager
- **`PermissionType.kt`**: Added WRITE_EXTERNAL_STORAGE permission type
- **`AndroidManifest.xml`**: Added storage permissions (maxSdkVersion=32)

Tested on my Xiaomi TV Stick (Android 9)