### PR TITLE
Fix wrong profile selection in ProxyChain dropdown (#5920)

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerProxyChainMemberAdapter.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ServerProxyChainMemberAdapter.kt
@@ -31,7 +31,6 @@ class ServerProxyChainMemberAdapter(
     }
 
     override fun onBindViewHolder(holder: MemberViewHolder, position: Int) {
-        val adapterPos = holder.bindingAdapterPosition.takeIf { it != RecyclerView.NO_POSITION } ?: position
         val value = members[position]
         holder.binding.tvMemberIndex.text = (position + 1).toString()
 
@@ -44,17 +43,20 @@ class ServerProxyChainMemberAdapter(
         holder.binding.spMemberRemark.threshold = 0
         holder.binding.spMemberRemark.setText(value, false)
 
-        holder.binding.spMemberRemark.setOnItemClickListener { _, _, selectedIndex, _ ->
-            if (adapterPos in members.indices) {
-                members[adapterPos] = suggestions[selectedIndex].trim()
+        holder.binding.spMemberRemark.setOnItemClickListener { parent, _, selectedIndex, _ ->
+            val currentPos = holder.bindingAdapterPosition
+            val selectedValue = parent.getItemAtPosition(selectedIndex) as? String ?: return@setOnItemClickListener
+            if (currentPos != RecyclerView.NO_POSITION && currentPos in members.indices) {
+                members[currentPos] = selectedValue.trim()
                 adapterListener?.onRefreshData()
             }
         }
         holder.binding.spMemberRemark.onFocusChangeListener = View.OnFocusChangeListener { _, hasFocus ->
             if (hasFocus) return@OnFocusChangeListener
+            val currentPos = holder.bindingAdapterPosition
             val text = holder.binding.spMemberRemark.text?.toString().orEmpty().trim()
-            if (adapterPos in members.indices && members[adapterPos] != text) {
-                members[adapterPos] = text
+            if (currentPos != RecyclerView.NO_POSITION && currentPos in members.indices && members[currentPos] != text) {
+                members[currentPos] = text
                 adapterListener?.onRefreshData()
             }
         }


### PR DESCRIPTION
## Problem
When selecting a profile from the ProxyChain member dropdown, a different profile was saved instead of the one that was clicked. This happened consistently when the user interacted with the filtered dropdown list. Reported in issue #5920 

## Root Cause
The issue was in `ServerProxyChainMemberAdapter.kt`. The code used `suggestions[selectedIndex]` to retrieve the selected profile, but `selectedIndex` from `setOnItemClickListener` refers to the index in the **filtered adapter list**, not the original `suggestions` array.

When `AutoCompleteTextView` filters the dropdown (which happens as users type or interact with it), the indices change, causing the wrong profile to be selected.

## Solution
Changed the implementation to use `parent.getItemAtPosition(selectedIndex)` which retrieves the actual selected value directly from the adapter, regardless of filtering state.

### Before
```kotlin
holder.binding.spMemberRemark.setOnItemClickListener { _, _, selectedIndex, _ ->
    members[currentPos] = suggestions[selectedIndex].trim()
    // ...
}
```

### After
```kotlin
holder.binding.spMemberRemark.setOnItemClickListener { parent, _, selectedIndex, _ ->
    val selectedValue = parent.getItemAtPosition(selectedIndex) as? String ?: return@setOnItemClickListener
    members[currentPos] = selectedValue.trim()
    // ...
}
```

## Testing
Tested by:
1. Creating a new ProxyChain configuration
2. Selecting different profiles from the dropdown for multiple members
3. Verifying that the selected profiles are correctly saved
4. Editing existing ProxyChain configurations and changing member selections

All selections now work correctly and save the intended profile.

## Changes
- Modified `ServerProxyChainMemberAdapter.kt`: Fixed profile selection logic in `setOnItemClickListener`