### PR TITLE
Simplified two-row status bar with selected policyGroup outbound.

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -15,6 +15,8 @@ import com.v2ray.ang.R
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.dto.OutboundTrafficStat
 import com.v2ray.ang.dto.entities.ProfileItem
+import com.v2ray.ang.enums.BalancerStrategyType
+import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.extension.isComplexType
 import com.v2ray.ang.extension.toast
 import com.v2ray.ang.extension.toastError
@@ -120,6 +122,42 @@ object CoreServiceManager {
      * @return The name of the running server.
      */
     fun getRunningServerName() = currentConfig?.remarks.orEmpty()
+
+    fun getActiveBalancerTarget(): String {
+        val config = currentConfig
+        if (!coreController.isRunning || config?.configType != EConfigType.POLICYGROUP) {
+            return ""
+        }
+        when (BalancerStrategyType.from(config.policyGroupType)) {
+            BalancerStrategyType.LEAST_PING,
+            BalancerStrategyType.LEAST_LOAD -> Unit
+            else -> return ""
+        }
+        return try {
+            coreController.getBalancerPrincipleTarget(AppConfig.TAG_BALANCER)
+        } catch (e: Exception) {
+            LogUtil.d(AppConfig.TAG, "Active balancer target unavailable: ${e.message}")
+            ""
+        }
+    }
+
+    private fun activeBalancerDisplayName(): String {
+        val target = getActiveBalancerTarget().trim()
+        if (target.isBlank()) return ""
+
+        val parts = target.split("-", limit = 4)
+        if (parts.size != 4 || parts[0] != AppConfig.TAG_PROXY || parts[2].toIntOrNull() == null) {
+            return ""
+        }
+
+        val remarks = parts[3].trim()
+        return if (
+            remarks.isNotBlank() &&
+            !remarks.contains('\n') &&
+            !remarks.contains('\r') &&
+            !remarks.contains(",${AppConfig.TAG_PROXY}-")
+        ) remarks else ""
+    }
 
     /**
      * Starts the context service for V2Ray.
@@ -386,7 +424,9 @@ object CoreServiceManager {
             }
 
             val result = if (time >= 0) {
-                service.getString(R.string.connection_test_available, time)
+                val activeTarget = activeBalancerDisplayName()
+                val delayResult = service.getString(R.string.connection_test_available, time)
+                if (activeTarget.isBlank()) delayResult else "$delayResult ($activeTarget)"
             } else {
                 service.getString(R.string.connection_test_error, errorStr)
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
 import com.v2ray.ang.compose.AppDivider
@@ -33,7 +34,8 @@ import com.v2ray.ang.compose.colorFabInactiveLight
 
 @Composable
 fun MainBottomBar(
-    displayText: String,
+    connectionText: String,
+    statusText: String,
     isRunning: Boolean,
     isDarkTheme: Boolean,
     onAction: (MainAction) -> Unit
@@ -57,7 +59,23 @@ fun MainBottomBar(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text(text = displayText, style = MaterialTheme.typography.bodyMedium)
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(
+                            text = connectionText,
+                            style = MaterialTheme.typography.bodyMedium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = statusText,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
             }
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -26,8 +26,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.v2ray.ang.R
 import com.v2ray.ang.compose.LocalDarkTheme
 import com.v2ray.ang.compose.QRCodeDialog
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -48,7 +50,12 @@ fun MainScreen(
     val groups = uiState.groups
     val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
     val isRunning = uiState.isRunning
-    val displayText = uiState.statusText
+    val connectionText = if (isRunning) {
+        stringResource(R.string.connection_connected)
+    } else {
+        stringResource(R.string.connection_not_connected)
+    }
+    val statusText = uiState.statusText
     val selectedGuid = uiState.selectedGuid
     val doubleColumnDisplay = uiState.doubleColumnDisplay
     val confirmRemove = uiState.confirmRemove
@@ -224,7 +231,8 @@ fun MainScreen(
             },
             bottomBar = {
                 MainBottomBar(
-                    displayText = displayText,
+                    connectionText = connectionText,
+                    statusText = statusText,
                     isRunning = isRunning,
                     isDarkTheme = isDarkTheme,
                     onAction = onAction

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -44,16 +44,13 @@ class MainViewModel(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
     private val preloadDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1)
-
-    private val disconnectedText: String = dataSource.getString(R.string.connection_not_connected)
-    private val connectedText: String = dataSource.getString(R.string.connection_connected)
+    private val checkConnectionText: String = dataSource.getString(R.string.connection_test_pending)
 
     // ---------- UI state ----------
     private val _uiState = MutableStateFlow(
         MainUiState(
             selectedGroupId = dataSource.getSelectedSubscriptionId(),
             selectedGuid = dataSource.getSelectServer(),
-            statusText = disconnectedText,
             confirmRemove = dataSource.getConfirmRemove(),
             doubleColumnDisplay = dataSource.getDoubleColumnDisplay()
         )
@@ -156,6 +153,9 @@ class MainViewModel(
 
     private fun currentServers(): List<ServersCache> =
         mutableServersForGroup(uiState.value.selectedGroupId).value
+
+    private fun idleStatusText(running: Boolean, currentText: String = ""): String =
+        if (!running) "" else currentText.ifBlank { checkConnectionText }
 
     // ---------- Action handler ----------
     fun onAction(action: MainAction) {
@@ -666,7 +666,7 @@ class MainViewModel(
         _uiState.update {
             it.copy(
                 isTesting = false,
-                statusText = if (it.isRunning) connectedText else disconnectedText
+                statusText = idleStatusText(it.isRunning)
             )
         }
     }
@@ -715,7 +715,7 @@ class MainViewModel(
             _uiState.update {
                 it.copy(
                     isTesting = false,
-                    statusText = if (it.isRunning) connectedText else disconnectedText
+                    statusText = idleStatusText(it.isRunning)
                 )
             }
             reloadAllGroups(_uiState.value.groups.map { it.id })
@@ -751,8 +751,11 @@ class MainViewModel(
         _uiState.update { state ->
             state.copy(
                 isRunning = running,
-                statusText = if (!clearTestingText && state.isTesting) state.statusText
-                else if (running) connectedText else disconnectedText
+                statusText = if (!clearTestingText && state.isTesting) {
+                    state.statusText
+                } else {
+                    idleStatusText(running, state.statusText)
+                }
             )
         }
     }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -349,14 +349,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
-    <string name="connection_test_pending">التحقق من الاتصال</string>
+    <string name="connection_test_pending">انقر للتحقق من الاتصال</string>
     <string name="connection_test_testing">يجري الاختبار…</string>
     <string name="connection_test_testing_count">Testing %d configurations…</string>
-    <string name="connection_test_available">نجاح: استغرق اتصال HTTP %dms</string>
+    <string name="connection_test_available">استغرق اتصال HTTP %dms</string>
     <string name="connection_test_error">فشل اكتشاف اتصال الإنترنت: %s</string>
     <string name="connection_test_fail">الإنترنت غير متاح</string>
     <string name="connection_test_error_status_code">رمز الخطأ: #%d</string>
-    <string name="connection_connected">متصل، انقر للتحقق من الاتصال</string>
+    <string name="connection_connected">متصل</string>
     <string name="connection_not_connected">غير متصل</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
 

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -348,14 +348,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
-    <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
+    <string name="connection_test_pending">সংযোগ পরীক্ষা করতে ট্যাপ করুন</string>
     <string name="connection_test_testing">পরীক্ষা চলছে…</string>
     <string name="connection_test_testing_count">Testing %d configurations…</string>
-    <string name="connection_test_available">সফল: HTTP সংযোগ নিয়েছে %dms</string>
+    <string name="connection_test_available">HTTP সংযোগ নিয়েছে %dms</string>
     <string name="connection_test_error">ইন্টারনেট সংযোগ সনাক্ত করতে ব্যর্থ: %s</string>
     <string name="connection_test_fail">ইন্টারনেট উপলব্ধ নয়</string>
     <string name="connection_test_error_status_code">ত্রুটি কোড: #%d</string>
-    <string name="connection_connected">সংযুক্ত, সংযোগ পরীক্ষা করতে ট্যাপ করুন</string>
+    <string name="connection_connected">সংযুক্ত</string>
     <string name="connection_not_connected">সংযুক্ত নয়</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
 

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -354,14 +354,14 @@
     <string name="routing_settings_network_tip" translatable="false">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
-    <string name="connection_test_pending">منپیزن واجۊری کوݩ</string>
+    <string name="connection_test_pending">سی واجۊری کیلیک کوݩ</string>
     <string name="connection_test_testing">هونی آزمایش ابۊ…</string>
     <string name="connection_test_testing_count">%d کانفیگ هونی آزمایش ابۊ...</string>
-    <string name="connection_test_available">مووفق بی: منپیز %dms تۊل کشی</string>
+    <string name="connection_test_available">منپیز %dms تۊل کشی</string>
     <string name="connection_test_error">منپیز و اینترنتن نجوست: %s</string>
     <string name="connection_test_fail">اینترنت من دسرس نؽ</string>
     <string name="connection_test_error_status_code">کود ختا: #%d</string>
-    <string name="connection_connected">منپیز هڌ، سی واجۊری کیلیک کوݩ</string>
+    <string name="connection_connected">منپیز هڌ</string>
     <string name="connection_not_connected">منپیز نؽڌ</string>
     <string name="connection_runing_task_left">تعداد وزیفه یل آزمایشی ک ره اۊفتانه: %s</string>
 

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -345,14 +345,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">برچسب خروجی</string>
 
-    <string name="connection_test_pending">اتصال را بررسی کنید</string>
+    <string name="connection_test_pending">برای بررسی اتصال ضربه بزنید</string>
     <string name="connection_test_testing">در حال آزمایش...</string>
     <string name="connection_test_testing_count">تست کردن %d کانفیگ…</string>
-    <string name="connection_test_available">موفقیت: اتصال %dms طول کشید</string>
+    <string name="connection_test_available">اتصال %dms طول کشید</string>
     <string name="connection_test_error">اتصال به اینترنت شناسایی نشد: %s</string>
     <string name="connection_test_fail">اینترنت در دسترس نیست</string>
     <string name="connection_test_error_status_code">کد خطا: #%d</string>
-    <string name="connection_connected">متصل است، برای بررسی اتصال ضربه بزنید</string>
+    <string name="connection_connected">متصل است</string>
     <string name="connection_not_connected">متصل نیست</string>
     <string name="connection_runing_task_left">تعداد وظایف آزمایشی در حال اجرا: %s</string>
 

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -360,14 +360,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">Исходящее соединение</string>
 
-    <string name="connection_test_pending">Проверить соединение</string>
+    <string name="connection_test_pending">Нажмите для проверки</string>
     <string name="connection_test_testing">Проверка…</string>
     <string name="connection_test_testing_count">Проверка профилей (%d)</string>
-    <string name="connection_test_available">Успешно: соединение заняло %d мс</string>
+    <string name="connection_test_available">Соединение заняло %d мс</string>
     <string name="connection_test_error">Сбой проверки интернет-соединения: %s</string>
     <string name="connection_test_fail">Интернет недоступен</string>
     <string name="connection_test_error_status_code">Код ошибки: #%d</string>
-    <string name="connection_connected">Соединено, нажмите для проверки</string>
+    <string name="connection_connected">Соединено</string>
     <string name="connection_not_connected">Нет соединения</string>
     <string name="connection_runing_task_left">Запущено проверок: %s</string>
 

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -349,14 +349,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
-    <string name="connection_test_pending">Kiểm tra kết nối</string>
+    <string name="connection_test_pending">Nhấn để kiểm tra kết nối mạng</string>
     <string name="connection_test_testing">Đang kiểm tra kết nối mạng...</string>
     <string name="connection_test_testing_count">Testing %d configurations…</string>
-    <string name="connection_test_available">Kiểm tra thành công: thời gian truy cập Google là %d ms</string>
+    <string name="connection_test_available">Thời gian truy cập Google là %d ms</string>
     <string name="connection_test_error">Lỗi kết nối mạng, hãy thử đổi cấu hình hoặc kiểm tra lại! Mã lỗi: %s</string>
     <string name="connection_test_fail">Không có kết nối mạng!</string>
     <string name="connection_test_error_status_code">Mã lỗi: #%d</string>
-    <string name="connection_connected">Đã kết nối, nhấn để kiểm tra kết nối mạng!</string>
+    <string name="connection_connected">Đã kết nối</string>
     <string name="connection_not_connected">Chưa kết nối</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
 

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -362,14 +362,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
-    <string name="connection_test_pending">"检查网络连接"</string>
+    <string name="connection_test_pending">"点击测试连接"</string>
     <string name="connection_test_testing">"测试中…"</string>
     <string name="connection_test_testing_count">测试 %d 个配置中…</string>
-    <string name="connection_test_available">"连接成功：延时 %d 毫秒"</string>
+    <string name="connection_test_available">"延时 %d 毫秒"</string>
     <string name="connection_test_error">"失败：%s"</string>
     <string name="connection_test_fail">"无互联网连接"</string>
     <string name="connection_test_error_status_code">"状态码无效（#%d）"</string>
-    <string name="connection_connected">"已连接，点击测试连接"</string>
+    <string name="connection_connected">"已连接"</string>
     <string name="connection_not_connected">"未连接"</string>
     <string name="connection_runing_task_left">运行中的测试任务数：%s</string>
 

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -360,14 +360,14 @@
     <string name="routing_settings_network_tip">[udp|tcp]</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
-    <string name="connection_test_pending">"測試連線能力"</string>
+    <string name="connection_test_pending">"輕觸以檢查連線能力"</string>
     <string name="connection_test_testing">"測試中……"</string>
     <string name="connection_test_testing_count">測試 %d 個配置中…</string>
-    <string name="connection_test_available">"成功：%d ms延遲"</string>
+    <string name="connection_test_available">"延遲 %d ms"</string>
     <string name="connection_test_error">"測試網際網路連線失敗：%s"</string>
     <string name="connection_test_fail">"無法使用網際網路"</string>
     <string name="connection_test_error_status_code">"錯誤碼：(#%d)"</string>
-    <string name="connection_connected">"已連線，輕觸以檢查連線能力"</string>
+    <string name="connection_connected">"已連線"</string>
     <string name="connection_not_connected">"未連線"</string>
     <string name="connection_runing_task_left">運行中的測試任務數：%s</string>
 

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -369,14 +369,14 @@
     <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
-    <string name="connection_test_pending">Check Connectivity</string>
+    <string name="connection_test_pending">Tap to check connection</string>
     <string name="connection_test_testing">Testing…</string>
     <string name="connection_test_testing_count">Testing %d configs…</string>
-    <string name="connection_test_available">Success: Connection took %dms</string>
+    <string name="connection_test_available">Connection took %dms</string>
     <string name="connection_test_error">Fail to detect internet connection: %s</string>
     <string name="connection_test_fail">Internet Unavailable</string>
     <string name="connection_test_error_status_code">Error code: #%d</string>
-    <string name="connection_connected">Connected, tap to check connection</string>
+    <string name="connection_connected">Connected</string>
     <string name="connection_not_connected">Not connected</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
 


### PR DESCRIPTION
Simplified non-realtime version of https://github.com/2dust/v2rayNG/pull/5938

This PR depends on a small additional function in https://github.com/2dust/AndroidLibXrayLite/pull/202

The status bar is split in two rows.
The first row always displays "Not connected" or "Connected" which is never overwritten by diagnostic responses.
The second row shows "Tap to check connection" or other diagnostic messages. When checking connection to a `leastLoad` or `leastPing` `policyGroup`, the second row shows the outbound that is currently selected by the `policyGroup` balancer in addition to the latency.