### PR TITLE
feat: add configurable dual ping (HTTP and ICMP/TCP) support

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -87,6 +87,7 @@ object AppConfig {
     const val PREF_AUTO_REMOVE_INVALID_AFTER_TEST = "pref_auto_remove_invalid_after_test"
     const val PREF_AUTO_SORT_AFTER_TEST = "pref_auto_sort_after_test"
     const val PREF_REAL_PING_CONCURRENCY = "pref_real_ping_concurrency"
+    const val PREF_PING_TYPE = "pref_ping_type"
 
     /** Cache keys. */
     const val CACHE_SUBSCRIPTION_ID = "cache_subscription_id"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -385,15 +385,33 @@ object CoreServiceManager {
                 }
             }
 
-            val result = if (time >= 0) {
-                service.getString(R.string.connection_test_available, time)
-            } else {
-                service.getString(R.string.connection_test_error, errorStr)
+            val pingType = SettingsManager.getPingType()
+            var tcpTime = -1L
+            if (pingType == "both" || pingType == "icmp") {
+                val selectGuid = MmkvManager.getSelectServer()
+                if (!selectGuid.isNullOrEmpty()) {
+                    val config = MmkvManager.decodeServerConfig(selectGuid)
+                    if (config != null && config.server.isNotNullEmpty() && config.serverPort?.toIntOrNull() != null) {
+                        tcpTime = SpeedtestManager.socketConnectTime(config.server.orEmpty(), config.serverPort.orEmpty().toInt(), 1000)
+                    }
+                }
+            }
+
+            val httpStr = if (time >= 0) "${time}ms" else ""
+            val icmpStr = if (tcpTime >= 0) "${tcpTime}ms" else ""
+            val result = when {
+                pingType == "both" && httpStr.isNotEmpty() && icmpStr.isNotEmpty() -> "HTTP: $httpStr | ICMP: $icmpStr"
+                pingType == "both" && httpStr.isNotEmpty() -> "HTTP: $httpStr"
+                pingType == "both" && icmpStr.isNotEmpty() -> "ICMP: $icmpStr"
+                pingType == "icmp" && icmpStr.isNotEmpty() -> "ICMP: $icmpStr"
+                pingType == "icmp" -> service.getString(R.string.connection_test_error, errorStr)
+                time >= 0 -> service.getString(R.string.connection_test_available, time)
+                else -> service.getString(R.string.connection_test_error, errorStr)
             }
             MessageUtil.sendMsg2UI(service, AppConfig.MSG_MEASURE_DELAY_SUCCESS, result)
 
             // Only fetch IP info if the delay test was successful
-            if (time >= 0) {
+            if (time >= 0 || tcpTime >= 0) {
                 SpeedtestManager.getRemoteIPInfo()?.let { ip ->
                     MessageUtil.sendMsg2UI(service, AppConfig.MSG_MEASURE_DELAY_SUCCESS, "$result\n$ip")
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
@@ -6,7 +6,7 @@ sealed class RealPingEvent {
     data class Progress(val text: String) : RealPingEvent()
 
     /** A single server result is available. */
-    data class Result(val guid: String, val delayMillis: Long) : RealPingEvent()
+    data class Result(val guid: String, val delayMillis: Long, val icmpDelayMillis: Long = 0L) : RealPingEvent()
 
     /** The entire batch has finished or been cancelled. */
     data class Finish(val status: String) : RealPingEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServerAffiliationInfo.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServerAffiliationInfo.kt
@@ -1,10 +1,16 @@
 package com.v2ray.ang.dto.entities
 
-data class ServerAffiliationInfo(var testDelayMillis: Long = 0L) {
+data class ServerAffiliationInfo(
+    var testDelayMillis: Long = 0L,
+    var icmpDelayMillis: Long = 0L
+) {
     fun getTestDelayString(): String {
-        if (testDelayMillis == 0L) {
-            return ""
+        val http = if (testDelayMillis == 0L) "" else "${testDelayMillis}ms"
+        val icmp = if (icmpDelayMillis == 0L) "" else "${icmpDelayMillis}ms"
+        if (http.isNotEmpty() && icmp.isNotEmpty()) {
+            return "HTTP: $http | ICMP: $icmp"
         }
-        return testDelayMillis.toString() + "ms"
+        if (icmp.isNotEmpty()) return "ICMP: $icmp"
+        return http
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServersCache.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServersCache.kt
@@ -4,5 +4,6 @@ data class ServersCache(
     val guid: String,
     val profile: ProfileItem,
     val testDelayMillis: Long = 0L,
+    val icmpDelayMillis: Long = 0L,
     val testDelayString: String = "",
 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -300,6 +300,23 @@ object MmkvManager {
     }
 
     /**
+     * Encodes both HTTP and ICMP test delays in milliseconds.
+     *
+     * @param guid The server GUID.
+     * @param httpDelay The HTTP test delay in milliseconds.
+     * @param icmpDelay The ICMP test delay in milliseconds.
+     */
+    fun encodeServerDelays(guid: String, httpDelay: Long, icmpDelay: Long) {
+        if (guid.isBlank()) {
+            return
+        }
+        val aff = decodeServerAffiliationInfo(guid) ?: ServerAffiliationInfo()
+        aff.testDelayMillis = httpDelay
+        aff.icmpDelayMillis = icmpDelay
+        serverAffStorage.encode(guid, JsonUtil.toJson(aff))
+    }
+
+    /**
      * Clears all test delay results.
      *
      * @param keys The list of server GUIDs.
@@ -308,6 +325,7 @@ object MmkvManager {
         keys?.forEach { key ->
             decodeServerAffiliationInfo(key)?.let { aff ->
                 aff.testDelayMillis = 0
+                aff.icmpDelayMillis = 0
                 serverAffStorage.encode(key, JsonUtil.toJson(aff))
             }
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -416,6 +416,14 @@ object SettingsManager {
     }
 
     /**
+     * Get ping type preference (both, icmp, http).
+     * @return The ping type string.
+     */
+    fun getPingType(): String {
+        return MmkvManager.decodeSettingsString(AppConfig.PREF_PING_TYPE) ?: "both"
+    }
+
+    /**
      * Get the locale.
      * @return The locale.
      */
@@ -528,6 +536,7 @@ object SettingsManager {
         ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD, AppConfig.OBSERVATORY_LEAST_LOAD_METHOD)
         ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING, AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING)
         ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT, AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT)
+        ensureDefaultValue(AppConfig.PREF_PING_TYPE, "both")
     }
 
     private fun ensureDefaultValue(key: String, default: String) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -118,7 +118,7 @@ class CoreTestService : Service() {
             }
 
             is RealPingEvent.Result -> {
-                MmkvManager.encodeServerTestDelayMillis(event.guid, event.delayMillis)
+                MmkvManager.encodeServerDelays(event.guid, event.delayMillis, event.icmpDelayMillis)
                 MessageUtil.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, event.guid)
             }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -44,7 +44,7 @@ class RealPingWorkerService(
                 runningCount.incrementAndGet()
                 try {
                     val result = startRealPing(guid)
-                    onEvent(RealPingEvent.Result(guid, result))
+                    onEvent(RealPingEvent.Result(guid, result.first, result.second))
                 } catch (_: Throwable) {
                     // ignore
                 } finally {
@@ -79,29 +79,42 @@ class RealPingWorkerService(
         }
     }
 
-    private fun startRealPing(guid: String): Long {
+    private fun startRealPing(guid: String): Pair<Long, Long> {
         val retFailure = -1L
+        val config = MmkvManager.decodeServerConfig(guid) ?: return Pair(retFailure, retFailure)
+        
+        val pingType = SettingsManager.getPingType()
+        var icmpDelay = 0L
 
-        val config = MmkvManager.decodeServerConfig(guid) ?: return retFailure
-        if (!config.configType.isComplexType()
-            && config.configType != EConfigType.HYSTERIA2
-            && config.configType != EConfigType.WIREGUARD
-            && config.alpn?.startsWith("h3") != true
-            && config.server.isNotNullEmpty()
-            && config.serverPort?.toIntOrNull() != null
-        ) {
-            val url = config.server.orEmpty()
-            val port = config.serverPort.orEmpty().toInt()
-            val tcpTime = SpeedtestManager.socketConnectTime(url, port, 1000)
-            if (tcpTime <= -1L) {
-                return retFailure
+        if (pingType == "both" || pingType == "icmp") {
+            if (!config.configType.isComplexType()
+                && config.configType != EConfigType.HYSTERIA2
+                && config.configType != EConfigType.WIREGUARD
+                && config.alpn?.startsWith("h3") != true
+                && config.server.isNotNullEmpty()
+                && config.serverPort?.toIntOrNull() != null
+            ) {
+                val url = config.server.orEmpty()
+                val port = config.serverPort.orEmpty().toInt()
+                val tcpTime = SpeedtestManager.socketConnectTime(url, port, 1000)
+                icmpDelay = tcpTime
+                if (tcpTime <= -1L && pingType == "both") {
+                    return Pair(retFailure, tcpTime)
+                }
+            } else if (pingType == "icmp") {
+                icmpDelay = retFailure
             }
+        }
+
+        if (pingType == "icmp") {
+            return Pair(0L, icmpDelay)
         }
 
         val configResult = CoreConfigManager.getV2rayConfig4Speedtest(context, guid)
         if (!configResult.status) {
-            return retFailure
+            return Pair(retFailure, icmpDelay)
         }
-        return CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+        val httpDelay = CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+        return Pair(httpDelay, icmpDelay)
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
@@ -151,7 +151,8 @@ private fun ServerListPage(
                         onEditServer = onEditServer,
                         onShareServer = onShareServer,
                         onMoreServer = onMoreServer,
-                        onRemoveServer = onRemoveServer
+                        onRemoveServer = onRemoveServer,
+                        onPingServer = { mainViewModel.testSingleRealPing(it) }
                     )
                 }
                 if (canReorder && reorderableGridState != null) {
@@ -218,7 +219,8 @@ private fun ServerListPage(
                         onEditServer = onEditServer,
                         onShareServer = onShareServer,
                         onMoreServer = onMoreServer,
-                        onRemoveServer = onRemoveServer
+                        onRemoveServer = onRemoveServer,
+                        onPingServer = { mainViewModel.testSingleRealPing(it) }
                     )
                     ItemDivider()
                 }
@@ -236,7 +238,8 @@ private fun ServerItemRow(
     onEditServer: (String, ProfileItem) -> Unit,
     onShareServer: (String, ProfileItem) -> Unit,
     onMoreServer: (String, ProfileItem) -> Unit,
-    onRemoveServer: (String) -> Unit
+    onRemoveServer: (String) -> Unit,
+    onPingServer: (String) -> Unit
 ) {
     val profile = serverCache.profile
     val subRemarks = if (subscriptionId.isEmpty()) {
@@ -258,7 +261,8 @@ private fun ServerItemRow(
         onShare = { onShareServer(serverCache.guid, profile) },
         onEdit = { onEditServer(serverCache.guid, profile) },
         onRemove = { onRemoveServer(serverCache.guid) },
-        onMore = { onMoreServer(serverCache.guid, profile) }
+        onMore = { onMoreServer(serverCache.guid, profile) },
+        onPing = { onPingServer(serverCache.guid) }
     )
 }
 
@@ -272,7 +276,8 @@ private fun ServerItemColumn(
     onEditServer: (String, ProfileItem) -> Unit,
     onShareServer: (String, ProfileItem) -> Unit,
     onMoreServer: (String, ProfileItem) -> Unit,
-    onRemoveServer: (String) -> Unit
+    onRemoveServer: (String) -> Unit,
+    onPingServer: (String) -> Unit
 ) {
     val profile = serverCache.profile
     val subRemarks = if (subscriptionId.isEmpty()) {
@@ -292,7 +297,8 @@ private fun ServerItemColumn(
             onEdit = { onEditServer(serverCache.guid, profile) },
             onShare = { onShareServer(serverCache.guid, profile) },
             onRemove = { onRemoveServer(serverCache.guid) },
-            onMore = { onMoreServer(serverCache.guid, profile) }
+            onMore = { onMoreServer(serverCache.guid, profile) },
+            onPing = { onPingServer(serverCache.guid) }
         )
         ItemDivider()
     }
@@ -313,6 +319,7 @@ fun ServerListItem(
     onShare: () -> Unit,
     onRemove: () -> Unit,
     onMore: () -> Unit,
+    onPing: () -> Unit = {},
     modifier: Modifier = Modifier,
     dragModifier: Modifier = Modifier
 ) {
@@ -354,6 +361,7 @@ fun ServerListItem(
                         Icon(painterResource(R.drawable.ic_more_vert_24dp), null, Modifier.size(24.dp))
                     }
                 } else {
+                    IconButton(onClick = onPing, Modifier.size(36.dp)) { Icon(painterResource(R.drawable.ic_lte_ping_24dp), null, Modifier.size(24.dp)) }
                     IconButton(onClick = onShare, Modifier.size(36.dp)) { Icon(painterResource(R.drawable.ic_share_24dp), null, Modifier.size(24.dp)) }
                     IconButton(onClick = onEdit, Modifier.size(36.dp)) { Icon(painterResource(R.drawable.ic_edit_24dp), null, Modifier.size(24.dp)) }
                     IconButton(onClick = onRemove, Modifier.size(36.dp)) { Icon(painterResource(R.drawable.ic_delete_24dp), null, Modifier.size(24.dp)) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -237,6 +237,7 @@ class MainViewModel(
                 guid = guid,
                 profile = profile.copy(),
                 testDelayMillis = affiliation?.testDelayMillis ?: 0L,
+                icmpDelayMillis = affiliation?.icmpDelayMillis ?: 0L,
                 testDelayString = affiliation?.getTestDelayString().orEmpty()
             )
         }
@@ -694,6 +695,19 @@ class MainViewModel(
                     key = AppConfig.MSG_MEASURE_CONFIG_START,
                     subscriptionId = groupId,
                     serverGuids = if (keywordFilter.isNotEmpty()) servers.map { it.guid } else emptyList()
+                )
+            )
+        }
+    }
+
+    fun testSingleRealPing(guid: String) {
+        dataSource.clearAllTestDelayResults(listOf(guid))
+        viewModelScope.launch(ioDispatcher) {
+            dataSource.sendMsg2TestService(
+                TestServiceMessage(
+                    key = AppConfig.MSG_MEASURE_CONFIG_START,
+                    subscriptionId = "",
+                    serverGuids = listOf(guid)
                 )
             )
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
@@ -137,6 +137,7 @@ fun SettingsScreen(
     var delayTestUrl by rememberMmkvString(AppConfig.PREF_DELAY_TEST_URL, "")
     var realPingConcurrency by rememberMmkvString(AppConfig.PREF_REAL_PING_CONCURRENCY, "16")
     var ipApiUrl by rememberMmkvString(AppConfig.PREF_IP_API_URL, "")
+    var pingType by rememberMmkvString(AppConfig.PREF_PING_TYPE, "both")
 
     val isVpn = mode == VPN
     val hevTunEnabled = isVpn && useHevTun
@@ -166,6 +167,8 @@ fun SettingsScreen(
     val observatoryLeastLoadMethodValues = stringArrayResource(R.array.observatory_least_load_method).toList()
     val modeEntries = stringArrayResource(R.array.mode_entries).toList()
     val modeValues = stringArrayResource(R.array.mode_value).toList()
+    val pingTypeEntries = stringArrayResource(R.array.pref_ping_type_entries).toList()
+    val pingTypeValues = stringArrayResource(R.array.pref_ping_type_values).toList()
 
     Scaffold(
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
@@ -590,6 +593,13 @@ fun SettingsScreen(
                     value = realPingConcurrency,
                     keyboardNumber = true,
                     onValueChanged = { realPingConcurrency = it }
+                )
+                SettingsListItem(
+                    title = stringResource(R.string.title_pref_ping_type),
+                    entries = pingTypeEntries,
+                    values = pingTypeValues,
+                    selectedValue = pingType,
+                    onSelected = { pingType = it }
                 )
                 SettingsEditItem(
                     title = stringResource(R.string.title_pref_ip_api_url),

--- a/V2rayNG/app/src/main/res/drawable/ic_lte_ping_24dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_lte_ping_24dp.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <!-- Bar 1 -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M2,14 h2 v6 h-2 z" />
+  <!-- Bar 2 -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M5.5,10 h2 v10 h-2 z" />
+  <!-- Bar 3 -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M9,6 h2 v14 h-2 z" />
+  <!-- Bar 4 -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12.5,2 h2 v18 h-2 z" />
+  <!-- Lightning bolt -->
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19.5,2 L15.5,11 H18.5 L16.5,22 L22,10 H18.5 Z" />
+</vector>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -497,4 +497,16 @@
         <item>WebDAV</item>
     </string-array>
 
+    <string name="title_pref_ping_type">Ping type</string>
+    <string-array name="pref_ping_type_entries">
+        <item>Both</item>
+        <item>ICMP/Tcping</item>
+        <item>HTTP</item>
+    </string-array>
+    <string-array name="pref_ping_type_values">
+        <item>both</item>
+        <item>icmp</item>
+        <item>http</item>
+    </string-array>
+
 </resources>


### PR DESCRIPTION
### Summary
This PR adds support for configurable dual-ping testing (HTTP and ICMP/TCP socket connection speed).

### Key Features
1. **Ping Type Setting**: Added `Ping type` setting in Settings under Advanced Options (`Both`, `ICMP/Tcping`, `HTTP`).
2. **Dual Ping Results**: Server item row displays dual ping results formatted clearly (e.g. `HTTP: 120ms | ICMP: 45ms`).
3. **Per-Server Quick Ping**: Added an LTE signal ping button to each server row for on-demand quick pinging of individual profiles.
4. **Bottom Bar Integration**: Test results on the active connection in the bottom status bar reflect the selected ping preference.