### PR TITLE
feat: randomize VPN session name and socks credentials on start

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -95,4 +95,4 @@ jobs:
       if: ${{ success() }}
       with:
         name: v2rayNG-nightly-debug-apk
-        path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/debug/*.apk
+        path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/**/*.apk

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
       - feat/security-interface
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build-nightly:
@@ -90,9 +90,12 @@ jobs:
         chmod +x gradlew
         ./gradlew assembleDebug
 
-    - name: Upload Nightly Debug APK Artifact
-      uses: actions/upload-artifact@v4
-      if: ${{ success() }}
+    - name: Create Direct Download Release
+      uses: softprops/action-gh-release@v2
       with:
-        name: v2rayNG-nightly-debug-apk
-        path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/**/*.apk
+        tag_name: nightly-build
+        name: Nightly Security Build
+        files: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/playstore/debug/*arm64-v8a*.apk
+        prerelease: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,98 @@
+name: Nightly Build APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - feat/security-interface
+
+permissions:
+  contents: read
+
+jobs:
+  build-nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+        fetch-depth: '0'
+
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3
+      with:
+        log-accepted-android-sdk-licenses: false
+        cmdline-tools-version: '14742923'
+        packages: 'platforms;android-37.0 build-tools;37.0.0 platform-tools'
+
+    - name: Install NDK
+      run: |
+        echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager \
+          --channel=0 \
+          --install "ndk;29.0.14206865"
+        echo "NDK_HOME=$ANDROID_HOME/ndk/29.0.14206865" >> $GITHUB_ENV
+        sed -i '10i\
+        \
+            ndkVersion = "29.0.14206865"' ${{ github.workspace }}/V2rayNG/app/build.gradle.kts
+
+    - name: Restore cached libhevtun
+      id: cache-libhevtun-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ github.workspace }}/libs
+        key: libhevtun-${{ runner.os }}-${{ env.NDK_HOME }}-${{ hashFiles('.git/modules/hev-socks5-tunnel/HEAD') }}-${{ hashFiles('compile-hevtun.sh') }}
+
+    - name: Build libhevtun
+      if: steps.cache-libhevtun-restore.outputs.cache-hit != 'true'
+      run: |
+        bash compile-hevtun.sh
+
+    - name: Save libhevtun
+      if: steps.cache-libhevtun-restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/libs
+        key: libhevtun-${{ runner.os }}-${{ env.NDK_HOME }}-${{ hashFiles('.git/modules/hev-socks5-tunnel/HEAD') }}-${{ hashFiles('compile-hevtun.sh') }}
+
+    - name: Copy libhevtun
+      run: |
+        cp -r ${{ github.workspace }}/libs ${{ github.workspace }}/V2rayNG/app
+
+    - name: Fetch AndroidLibXrayLite tag
+      run: |
+        pushd AndroidLibXrayLite
+        CURRENT_TAG=$(git describe --tags --abbrev=0)
+        echo "Current tag in this repo: $CURRENT_TAG"
+        echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
+        popd
+
+    - name: Download libv2ray
+      uses: robinraju/release-downloader@v1.13
+      with:
+        repository: '2dust/AndroidLibXrayLite'
+        tag: ${{ env.CURRENT_TAG }}
+        fileName: 'libv2ray.aar'
+        out-file-path: V2rayNG/app/libs/
+
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Build Debug APK
+      run: |
+        cd ${{ github.workspace }}/V2rayNG
+        echo "sdk.dir=${ANDROID_HOME}" > local.properties
+        chmod +x gradlew
+        ./gradlew assembleDebug
+
+    - name: Upload Nightly Debug APK Artifact
+      uses: actions/upload-artifact@v4
+      if: ${{ success() }}
+      with:
+        name: v2rayNG-nightly-debug-apk
+        path: ${{ github.workspace }}/V2rayNG/app/build/outputs/apk/debug/*.apk

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -87,6 +87,9 @@ object AppConfig {
     const val PREF_AUTO_REMOVE_INVALID_AFTER_TEST = "pref_auto_remove_invalid_after_test"
     const val PREF_AUTO_SORT_AFTER_TEST = "pref_auto_sort_after_test"
     const val PREF_REAL_PING_CONCURRENCY = "pref_real_ping_concurrency"
+    const val PREF_INTERFACE_NAME_MODE = "pref_interface_name_mode"
+    const val PREF_INTERFACE_NAME_CUSTOM = "pref_interface_name_custom"
+    const val PREF_SOCKS_AUTH_MODE = "pref_socks_auth_mode"
 
     /** Cache keys. */
     const val CACHE_SUBSCRIPTION_ID = "cache_subscription_id"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -92,6 +92,9 @@ object CoreServiceManager {
             MmkvManager.setSelectServer(guid)
         }
 
+        SettingsManager.refreshRuntimeInterfaceName()
+        SettingsManager.refreshRuntimeSocksCredentials()
+
         try {
             startContextService(context)
         } catch (e: Exception) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -39,6 +39,15 @@ object SettingsManager {
     @Volatile
     private var runtimeSocksPort: Int? = null
 
+    @Volatile
+    private var runtimeInterfaceName: String? = null
+
+    @Volatile
+    private var runtimeSocksUsername: String? = null
+
+    @Volatile
+    private var runtimeSocksPassword: String? = null
+
     fun initApp(context: Context) {
         ensureDefaultSettings()
         //ensureDefaultSubscription()
@@ -304,12 +313,67 @@ object SettingsManager {
         return null
     }
 
+    fun getInterfaceNameMode(): String {
+        return MmkvManager.decodeSettingsString(AppConfig.PREF_INTERFACE_NAME_MODE) ?: "random"
+    }
+
+    fun getSocksAuthMode(): String {
+        return MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_AUTH_MODE) ?: "random"
+    }
+
+    @Synchronized
+    fun refreshRuntimeInterfaceName(): String {
+        val mode = getInterfaceNameMode()
+        if (mode == "custom") {
+            val custom = MmkvManager.decodeSettingsString(AppConfig.PREF_INTERFACE_NAME_CUSTOM)?.trim()
+            runtimeInterfaceName = if (!custom.isNullOrEmpty()) custom else "v2rayNG"
+        } else {
+            runtimeInterfaceName = "v2ray_" + generateRandomAlphanumeric(6)
+        }
+        return runtimeInterfaceName!!
+    }
+
+    fun getVpnInterfaceName(): String {
+        return runtimeInterfaceName ?: refreshRuntimeInterfaceName()
+    }
+
+    @Synchronized
+    fun refreshRuntimeSocksCredentials() {
+        val mode = getSocksAuthMode()
+        if (mode == "random") {
+            runtimeSocksUsername = "usr_" + generateRandomAlphanumeric(8)
+            runtimeSocksPassword = "pwd_" + generateRandomAlphanumeric(12)
+        } else {
+            runtimeSocksUsername = null
+            runtimeSocksPassword = null
+        }
+    }
+
+    private fun generateRandomAlphanumeric(length: Int): String {
+        val allowed = "abcdefghijklmnopqrstuvwxyz0123456789"
+        return (1..length).map { allowed.random() }.joinToString("")
+    }
+
     fun getSocksUsername(): String? {
-        return MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_USERNAME)?.trim()?.takeIf { it.isNotEmpty() }
+        val mode = getSocksAuthMode()
+        if (mode == "static") {
+            return MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_USERNAME)?.trim()?.takeIf { it.isNotEmpty() }
+        }
+        return runtimeSocksUsername ?: run {
+            refreshRuntimeSocksCredentials()
+            runtimeSocksUsername
+        }
     }
 
     fun getSocksPassword(): String? {
-        return MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_PASSWORD)?.trim()?.takeIf { it.isNotEmpty() }
+        val mode = getSocksAuthMode()
+        if (mode == "static") {
+            return MmkvManager.decodeSettingsString(AppConfig.PREF_SOCKS_PASSWORD)?.trim()?.takeIf { it.isNotEmpty() }
+        }
+        return runtimeSocksPassword ?: run {
+            refreshRuntimeSocksCredentials()
+            runtimeSocksPassword
+        }
     }
 
     /**
@@ -528,6 +592,9 @@ object SettingsManager {
         ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_METHOD, AppConfig.OBSERVATORY_LEAST_LOAD_METHOD)
         ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_SAMPLING, AppConfig.OBSERVATORY_LEAST_LOAD_SAMPLING)
         ensureDefaultValue(AppConfig.PREF_OBSERVATORY_LEAST_LOAD_TIMEOUT, AppConfig.OBSERVATORY_LEAST_LOAD_TIMEOUT)
+        ensureDefaultValue(AppConfig.PREF_INTERFACE_NAME_MODE, "random")
+        ensureDefaultValue(AppConfig.PREF_INTERFACE_NAME_CUSTOM, "v2rayNG")
+        ensureDefaultValue(AppConfig.PREF_SOCKS_AUTH_MODE, "random")
     }
 
     private fun ensureDefaultValue(key: String, default: String) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -268,7 +268,7 @@ class CoreVpnService : VpnService(), ServiceControl {
             }
         }
 
-        //builder.setSession(V2RayServiceManager.getRunningServerName())
+        builder.setSession(SettingsManager.getVpnInterfaceName())
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
@@ -27,6 +27,7 @@ import com.v2ray.ang.AppConfig.VPN
 import com.v2ray.ang.R
 import com.v2ray.ang.compose.AppTopBar
 import com.v2ray.ang.compose.CollapsiblePreferenceGroupHeader
+import com.v2ray.ang.compose.PreferenceGroupHeader
 import com.v2ray.ang.compose.SettingsEditItem
 import com.v2ray.ang.compose.SettingsListItem
 import com.v2ray.ang.compose.SettingsMenuItem
@@ -397,7 +398,7 @@ fun SettingsScreen(
                     keyboardNumber = true,
                     onValueChanged = { socksPort = it }
                 )
-                SettingsCategoryHeader(title = stringResource(R.string.category_internal_interface))
+                PreferenceGroupHeader(title = stringResource(R.string.category_internal_interface))
                 SettingsListItem(
                     title = stringResource(R.string.title_pref_interface_name_mode),
                     entries = interfaceNameModeEntries,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
@@ -138,6 +138,10 @@ fun SettingsScreen(
     var realPingConcurrency by rememberMmkvString(AppConfig.PREF_REAL_PING_CONCURRENCY, "16")
     var ipApiUrl by rememberMmkvString(AppConfig.PREF_IP_API_URL, "")
 
+    var interfaceNameMode by rememberMmkvString(AppConfig.PREF_INTERFACE_NAME_MODE, "random")
+    var interfaceNameCustom by rememberMmkvString(AppConfig.PREF_INTERFACE_NAME_CUSTOM, "v2rayNG")
+    var socksAuthMode by rememberMmkvString(AppConfig.PREF_SOCKS_AUTH_MODE, "random")
+
     val isVpn = mode == VPN
     val hevTunEnabled = isVpn && useHevTun
     val localProxyForced = hevTunEnabled
@@ -166,6 +170,10 @@ fun SettingsScreen(
     val observatoryLeastLoadMethodValues = stringArrayResource(R.array.observatory_least_load_method).toList()
     val modeEntries = stringArrayResource(R.array.mode_entries).toList()
     val modeValues = stringArrayResource(R.array.mode_value).toList()
+    val interfaceNameModeEntries = stringArrayResource(R.array.pref_interface_name_mode_entries).toList()
+    val interfaceNameModeValues = stringArrayResource(R.array.pref_interface_name_mode_values).toList()
+    val socksAuthModeEntries = stringArrayResource(R.array.pref_socks_auth_mode_entries).toList()
+    val socksAuthModeValues = stringArrayResource(R.array.pref_socks_auth_mode_values).toList()
 
     Scaffold(
         contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
@@ -389,19 +397,43 @@ fun SettingsScreen(
                     keyboardNumber = true,
                     onValueChanged = { socksPort = it }
                 )
-                SettingsEditItem(
-                    title = stringResource(R.string.title_pref_socks_username),
-                    value = socksUsername,
-                    enabled = effectiveLocalProxy,
-                    onValueChanged = { socksUsername = it }
+                SettingsCategoryHeader(title = stringResource(R.string.category_internal_interface))
+                SettingsListItem(
+                    title = stringResource(R.string.title_pref_interface_name_mode),
+                    entries = interfaceNameModeEntries,
+                    values = interfaceNameModeValues,
+                    selectedValue = interfaceNameMode,
+                    onSelected = { interfaceNameMode = it }
                 )
-                SettingsEditItem(
-                    title = stringResource(R.string.title_pref_socks_password),
-                    value = socksPassword,
-                    enabled = effectiveLocalProxy,
-                    isPassword = true,
-                    onValueChanged = { socksPassword = it }
+                if (interfaceNameMode == "custom") {
+                    SettingsEditItem(
+                        title = stringResource(R.string.title_pref_interface_name_custom),
+                        value = interfaceNameCustom,
+                        onValueChanged = { interfaceNameCustom = it }
+                    )
+                }
+                SettingsListItem(
+                    title = stringResource(R.string.title_pref_socks_auth_mode),
+                    entries = socksAuthModeEntries,
+                    values = socksAuthModeValues,
+                    selectedValue = socksAuthMode,
+                    onSelected = { socksAuthMode = it }
                 )
+                if (socksAuthMode == "static") {
+                    SettingsEditItem(
+                        title = stringResource(R.string.title_pref_socks_username),
+                        value = socksUsername,
+                        enabled = effectiveLocalProxy,
+                        onValueChanged = { socksUsername = it }
+                    )
+                    SettingsEditItem(
+                        title = stringResource(R.string.title_pref_socks_password),
+                        value = socksPassword,
+                        enabled = effectiveLocalProxy,
+                        isPassword = true,
+                        onValueChanged = { socksPassword = it }
+                    )
+                }
                 SettingsSwitchItem(
                     title = stringResource(R.string.title_pref_socks_enable_udp),
                     summary = stringResource(R.string.summary_pref_socks_enable_udp),

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -497,4 +497,26 @@
         <item>WebDAV</item>
     </string-array>
 
+    <string name="category_internal_interface">Internal Network Interface &amp; Security</string>
+    <string name="title_pref_interface_name_mode">Network interface name</string>
+    <string-array name="pref_interface_name_mode_entries">
+        <item>Random</item>
+        <item>Custom</item>
+    </string-array>
+    <string-array name="pref_interface_name_mode_values">
+        <item>random</item>
+        <item>custom</item>
+    </string-array>
+    <string name="title_pref_interface_name_custom">Custom interface name</string>
+
+    <string name="title_pref_socks_auth_mode">Local proxy credentials</string>
+    <string-array name="pref_socks_auth_mode_entries">
+        <item>Random</item>
+        <item>Static</item>
+    </string-array>
+    <string-array name="pref_socks_auth_mode_values">
+        <item>random</item>
+        <item>static</item>
+    </string-array>
+
 </resources>


### PR DESCRIPTION
This PR adds security features to randomize the VPN Session Name (via `VpnService.Builder.setSession()`) on start, as well as randomize local SOCKS credentials on start. Configuration options are added to the settings UI. This addresses privacy issues regarding session visibility to third-party apps and local network proxy security.