### PR TITLE
Add Cloudflare clean IP scanner (cf-clean-ip-scanner) for VLESS/VMESS/Trojan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.dat
 *.jks
 
+# Temporary clone used when porting CF scan engine
+CFSTAPP-tmp/
+
 # Ignore output JSON file
 V2rayNG/app/release/output.json
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/CloudflareIpScanner.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/CloudflareIpScanner.kt
@@ -1,0 +1,209 @@
+package com.v2ray.ang.cfscan
+
+import com.v2ray.ang.cfscan.model.SpeedTestResult
+import com.v2ray.ang.cfscan.speedtest.SpeedTestEngine
+import com.v2ray.ang.cfscan.utils.IpRangeParser
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Cloudflare IP scanner facade for v2rayNG.
+ *
+ * Credits: https://github.com/Murtaza-codes/cf-scanner-android
+ */
+object CloudflareIpScanner {
+
+    private const val CLOUDFLARE_IPV4_URL = "https://www.cloudflare.com/ips-v4"
+
+    /** Progress status keys — resolve via app language string resources. */
+    const val STATUS_FETCHING = "fetching"
+    const val STATUS_PING = SpeedTestEngine.Status.PING
+    const val STATUS_DOWNLOAD = SpeedTestEngine.Status.DOWNLOAD
+    const val STATUS_TESTING = SpeedTestEngine.Status.TESTING
+
+    // Built-in Cloudflare IPv4 ranges (fallback when remote fetch fails)
+    private val BUILTIN_IPV4_RANGES = """
+173.245.48.0/20
+103.21.244.0/22
+103.22.200.0/22
+103.31.4.0/22
+141.101.64.0/18
+108.162.192.0/18
+190.93.240.0/20
+188.114.96.0/20
+197.234.240.0/22
+198.41.128.0/17
+162.158.0.0/15
+104.16.0.0/12
+172.64.0.0/17
+172.64.128.0/18
+172.64.192.0/19
+172.64.224.0/22
+172.64.229.0/24
+172.64.230.0/23
+172.64.232.0/21
+172.64.240.0/21
+172.64.248.0/21
+172.65.0.0/16
+172.66.0.0/16
+172.67.0.0/16
+131.0.72.0/22
+    """.trimIndent()
+
+    data class ScanProgress(
+        val current: Int,
+        val total: Int,
+        val status: String,
+        val currentIp: String = ""
+    )
+
+    data class ScanBestResult(
+        val ipAddress: String,
+        val avgLatencyMs: Double,
+        val downloadSpeedMBps: Double = 0.0,
+        val packetLoss: Double = 0.0
+    )
+
+    /**
+     * Full default search:
+     * 1) TCP ping 100 IPs (3 times each, concurrency 8)
+     * 2) Download-speed test top 20 (10s each, concurrency 5)
+     * 3) Pick best by loss → latency → download speed
+     *
+     * Warning: download stage can use a lot of mobile data.
+     */
+    suspend fun findBestCloudflareIp(
+        testCount: Int = 100,
+        pingCount: Int = 3,
+        maxConcurrentPings: Int = 8,
+        downloadTest: Boolean = true,
+        downloadTestCount: Int = 20,
+        downloadDurationMs: Long = 10_000L,
+        maxConcurrentDownloads: Int = 5,
+        speedLimit: Double = 0.0,
+        latencyLimit: Double = 0.0,
+        onProgress: (ScanProgress) -> Unit = {}
+    ): ScanBestResult? {
+        onProgress(ScanProgress(0, testCount, STATUS_FETCHING))
+        val ranges = withContext(Dispatchers.IO) { loadIpv4Ranges() }
+        if (ranges.isEmpty()) {
+            throw IllegalStateException("No Cloudflare IP ranges available")
+        }
+
+        val engine = SpeedTestEngine()
+        val config = SpeedTestEngine.TestConfig(
+            testCount = testCount,
+            pingCount = pingCount,
+            pingTimeout = 1000,
+            downloadTest = downloadTest,
+            downloadDuration = downloadDurationMs,
+            speedLimit = speedLimit,
+            latencyLimit = latencyLimit,
+            port = 443,
+            pingOnly = false,
+            downloadTestCount = downloadTestCount,
+            pingFirst = true,
+            maxConcurrentDownloads = maxConcurrentDownloads,
+            maxConcurrentPings = maxConcurrentPings
+        )
+
+        return try {
+            val results = runEngine(engine, ranges, config, onProgress)
+            val best = results
+                .sortedWith(
+                    compareBy<SpeedTestResult> { it.packetLoss }
+                        .thenBy { it.avgLatency }
+                        .thenByDescending { it.downloadSpeed }
+                )
+                .firstOrNull()
+                ?: return null
+            ScanBestResult(
+                ipAddress = best.ipAddress,
+                avgLatencyMs = best.avgLatency,
+                downloadSpeedMBps = best.downloadSpeed,
+                packetLoss = best.packetLoss
+            )
+        } finally {
+            engine.stopTest()
+        }
+    }
+
+    private suspend fun runEngine(
+        engine: SpeedTestEngine,
+        ranges: List<IpRangeParser.IpRange>,
+        config: SpeedTestEngine.TestConfig,
+        onProgress: (ScanProgress) -> Unit
+    ): List<SpeedTestResult> = suspendCancellableCoroutine { cont ->
+        val job = CoroutineScope(Dispatchers.IO).launch {
+            try {
+                var completed: List<SpeedTestResult> = emptyList()
+                engine.startTest(
+                    ipRanges = ranges,
+                    config = config,
+                    onProgress = { progress ->
+                        onProgress(
+                            ScanProgress(
+                                current = progress.current,
+                                total = progress.total,
+                                status = progress.status,
+                                currentIp = progress.currentIp
+                            )
+                        )
+                    },
+                    onResult = {},
+                    onComplete = { sorted ->
+                        completed = sorted
+                    }
+                )
+                if (cont.isActive) {
+                    cont.resume(completed)
+                }
+            } catch (e: Exception) {
+                if (cont.isActive) {
+                    cont.resumeWithException(e)
+                }
+            }
+        }
+        cont.invokeOnCancellation {
+            engine.stopTest()
+            job.cancel()
+        }
+    }
+
+    private fun loadIpv4Ranges(): List<IpRangeParser.IpRange> {
+        val remote = fetchCloudflareIpv4Content()
+        val content = if (!remote.isNullOrBlank()) {
+            remote.trim()
+                .split(Regex("\\s+"))
+                .filter { it.isNotBlank() }
+                .joinToString("\n")
+        } else {
+            BUILTIN_IPV4_RANGES
+        }
+        val parsed = IpRangeParser.parseIpFile(content)
+        return parsed.ifEmpty { IpRangeParser.parseIpFile(BUILTIN_IPV4_RANGES) }
+    }
+
+    private fun fetchCloudflareIpv4Content(): String? {
+        return try {
+            val client = OkHttpClient.Builder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(15, TimeUnit.SECONDS)
+                .build()
+            val request = Request.Builder().url(CLOUDFLARE_IPV4_URL).get().build()
+            client.newCall(request).execute().use { response ->
+                if (response.isSuccessful) response.body.string() else null
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/model/SpeedTestResult.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/model/SpeedTestResult.kt
@@ -1,0 +1,45 @@
+package com.v2ray.ang.cfscan.model
+
+import java.util.Date
+
+/**
+ * 测速结果数据类
+ */
+data class SpeedTestResult(
+    val ipAddress: String,          // IP地址
+    val packetsSent: Int,           // 发送的包数量
+    val packetsReceived: Int,       // 接收的包数量
+    val packetLoss: Double,         // 丢包率 (0.00 - 100.00)
+    val avgLatency: Double,         // 平均延迟 (ms)
+    val downloadSpeed: Double,      // 下载速度 (MB/s)
+    val regionCode: String,         // 地区码
+    val testTime: Long = System.currentTimeMillis()  // 测试时间戳
+) : Comparable<SpeedTestResult> {
+    
+    override fun compareTo(other: SpeedTestResult): Int {
+        // 先按丢包率升序，再按延迟升序，最后按下载速度降序
+        val lossCompare = this.packetLoss.compareTo(other.packetLoss)
+        if (lossCompare != 0) return lossCompare
+        
+        val latencyCompare = this.avgLatency.compareTo(other.avgLatency)
+        if (latencyCompare != 0) return latencyCompare
+        
+        return other.downloadSpeed.compareTo(this.downloadSpeed)
+    }
+
+    fun getTestTimeFormatted(): String {
+        val date = Date(this.testTime)
+        val sdf = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss", java.util.Locale.getDefault())
+        return sdf.format(date)
+    }
+    
+    fun toCsvString(): String {
+        return "$ipAddress,$packetsSent,$packetsReceived,${String.format("%.2f", packetLoss)},${String.format("%.2f", avgLatency)},${String.format("%.2f", downloadSpeed)},$regionCode,${getTestTimeFormatted()}"
+    }
+    
+    companion object {
+        fun getCsvHeader(): String {
+            return "IP 地址,已发送,已接收,丢包率,平均延迟,下载速度(MB/s),地区码,测试时间"
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/speedtest/DownloadTest.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/speedtest/DownloadTest.kt
@@ -1,0 +1,125 @@
+package com.v2ray.ang.cfscan.speedtest
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Dns
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.net.InetAddress
+import java.util.concurrent.TimeUnit
+import kotlin.math.round
+
+/**
+ * 下载速度测试类
+ * 参考 Windows 版 cfst.exe 的测速逻辑优化
+ * 
+ * Windows 原版逻辑：
+ * - 下载测试时间：10 秒
+ * - 使用单连接下载（不是多线程并发）
+ * - 测速 URL：https://cf.xiu2.xyz/url (可自建)
+ * - 计算方式：总字节数 / 实际耗时
+ */
+class DownloadTest {
+
+    companion object {
+        // 下载测速 URL - 使用官方测速地址，同时改用 http 以避免由于国内 HTTPS SNI 阻断导致的连接重置，解决 cf.xiu2.xyz 403 Forbidden 的问题。
+        // bytes=50000000 代表单次请求 50MB。
+        private const val DOWNLOAD_URL = "http://speed.cloudflare.com/__down?bytes=50000000"
+        private const val HOST_NAME = "speed.cloudflare.com"
+
+        /**
+         * 创建 OkHttpClient 用于测速
+         * 使用自定义 DNS 解析强制请求发送到指定 IP
+         */
+        private fun createClientForIp(ip: String): OkHttpClient {
+            return OkHttpClient.Builder()
+                .connectTimeout(5, TimeUnit.SECONDS)
+                .readTimeout(10, TimeUnit.SECONDS)
+                .writeTimeout(5, TimeUnit.SECONDS)
+                .dns(object : Dns {
+                    override fun lookup(hostname: String): List<InetAddress> {
+                        // 强制将测速域名的 DNS 解析结果指向我们要测速的 Cloudflare IP
+                        if (hostname == HOST_NAME) {
+                            return try {
+                                listOf(InetAddress.getByName(ip))
+                            } catch (e: Exception) {
+                                emptyList()
+                            }
+                        }
+                        return Dns.SYSTEM.lookup(hostname)
+                    }
+                })
+                .build()
+        }
+
+        /**
+         * 执行下载速度测试（挂起函数）
+         *
+         * 参考 Windows 原版 cfst.exe 的逻辑：
+         * - 单连接下载（不是多线程并发）
+         * - 下载时长默认 10 秒
+         * - 持续读取数据直到超时或完成，如果不到10秒就下载完了，则继续发起请求
+         *
+         * @param ip 目标 IP 地址
+         * @param testDurationMs 测试时长 (毫秒)，默认 10000ms (10 秒)
+         * @return 下载速度 (MB/s)，失败返回 0.0
+         */
+        suspend fun testDownloadSpeed(
+            ip: String,
+            testDurationMs: Long = 10000  // 改为 10 秒，与 Windows 原版一致
+        ): Double = withContext(Dispatchers.IO) {
+            val client = createClientForIp(ip)
+
+            var downloadedBytes = 0L
+            var actualElapsedMs = 0L
+
+            val downloadStartTime = System.currentTimeMillis()
+            val deadline = downloadStartTime + testDurationMs
+
+            try {
+                // 通过 while 循环保持测速，直到 10 秒倒计时结束。应对 Gigabit 带宽 50MB 瞬间跑完的情况。
+                while (System.currentTimeMillis() < deadline) {
+                    val request = Request.Builder()
+                        .url(DOWNLOAD_URL)
+                        .header("Host", HOST_NAME)
+                        .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                        .header("Accept", "*/*")
+                        .header("Connection", "close")
+                        .build()
+
+                    val response = client.newCall(request).execute()
+
+                    if (response.isSuccessful) {
+                        response.body?.byteStream()?.use { inputStream ->
+                            val buffer = ByteArray(131072) // 128KB 缓冲区
+                            var bytesRead: Int
+
+                            while (System.currentTimeMillis() < deadline) {
+                                bytesRead = inputStream.read(buffer)
+                                if (bytesRead == -1) break
+                                downloadedBytes += bytesRead
+                            }
+                        }
+                    } else {
+                        // 如果响应失败 (如 403 Forbidden)，直接跳出防止无效死循环空跑
+                        break
+                    }
+                }
+
+                actualElapsedMs = System.currentTimeMillis() - downloadStartTime
+            } catch (e: Exception) {
+                // 如果是发生超时/中断等异常，我们仍可以拿已下载的字节数计算速度
+                actualElapsedMs = System.currentTimeMillis() - downloadStartTime
+            }
+
+            // 计算下载速度
+            if (actualElapsedMs > 0 && downloadedBytes > 0) {
+                val speedBps = (downloadedBytes * 1000.0) / actualElapsedMs
+                val speedMBps = speedBps / (1024 * 1024)
+                round(speedMBps * 100) / 100
+            } else {
+                0.0
+            }
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/speedtest/SpeedTestEngine.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/speedtest/SpeedTestEngine.kt
@@ -1,0 +1,364 @@
+package com.v2ray.ang.cfscan.speedtest
+
+import com.v2ray.ang.cfscan.model.SpeedTestResult
+import com.v2ray.ang.cfscan.utils.IpRangeParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import java.util.Random
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Speed test engine (ping + download).
+ */
+class SpeedTestEngine {
+
+    /**
+     * Test configuration.
+     */
+    data class TestConfig(
+        val testCount: Int = 100,
+        val pingCount: Int = 4,
+        val pingTimeout: Int = 1000,
+        val downloadTest: Boolean = true,
+        val downloadDuration: Long = 10000,
+        val speedLimit: Double = 0.0,
+        val latencyLimit: Double = 0.0,
+        val port: Int = 443,
+        val pingOnly: Boolean = false,
+        val downloadTestCount: Int = 20,
+        val pingFirst: Boolean = true,
+        val maxConcurrentDownloads: Int = 5,
+        val maxConcurrentPings: Int = 8
+    )
+
+    /**
+     * Progress status keys — resolve with app string resources (R.string.cf_ip_status_*).
+     */
+    object Status {
+        const val PING = "ping"
+        const val DOWNLOAD = "download"
+        const val TESTING = "testing"
+    }
+
+    /**
+     * Test progress.
+     */
+    data class TestProgress(
+        val current: Int,
+        val total: Int,
+        val currentIp: String,
+        val status: String
+    )
+
+    private val isRunning = AtomicBoolean(false)
+    private var shouldStop = AtomicBoolean(false)
+
+    suspend fun startTest(
+        ipRanges: List<IpRangeParser.IpRange>,
+        config: TestConfig,
+        onProgress: (TestProgress) -> Unit,
+        onResult: (SpeedTestResult) -> Unit,
+        onComplete: (List<SpeedTestResult>) -> Unit
+    ) {
+        if (isRunning.getAndSet(true)) {
+            return
+        }
+
+        shouldStop.set(false)
+        val results = mutableListOf<SpeedTestResult>()
+        val random = Random()
+        val testedIps = mutableSetOf<String>()
+
+        var consecutiveFailures = 0
+        val maxConsecutiveFailures = 50
+
+        try {
+            withContext(Dispatchers.IO) {
+                if (config.pingFirst) {
+                    val candidateIps = collectCandidateIps(
+                        ipRanges = ipRanges,
+                        random = random,
+                        testedIps = testedIps,
+                        targetCount = config.testCount,
+                        shouldStop = shouldStop
+                    )
+
+                    val pingResults = pingCandidates(
+                        candidateIps = candidateIps,
+                        config = config,
+                        onProgress = onProgress
+                    )
+
+                    consecutiveFailures = if (pingResults.isEmpty()) {
+                        candidateIps.size.coerceAtMost(maxConsecutiveFailures)
+                    } else {
+                        0
+                    }
+
+                    if (config.pingOnly) {
+                        pingResults.forEach { (ip, pingResult) ->
+                            val result = SpeedTestResult(
+                                ipAddress = ip,
+                                packetsSent = pingResult.sent,
+                                packetsReceived = pingResult.received,
+                                packetLoss = pingResult.packetLoss,
+                                avgLatency = pingResult.avgLatency,
+                                downloadSpeed = 0.0,
+                                regionCode = "N/A"
+                            )
+                            results.add(result)
+                            onResult(result)
+                        }
+                        return@withContext
+                    }
+
+                    val sortedPingResults = pingResults
+                        .sortedBy { it.second.avgLatency }
+                        .take(config.downloadTestCount)
+
+                    val totalDownloads = sortedPingResults.size
+                    val downloadSemaphore = Semaphore(config.maxConcurrentDownloads.coerceAtLeast(1))
+                    val completedDownloads = AtomicInteger(0)
+
+                    if (totalDownloads > 0) {
+                        onProgress(
+                            TestProgress(
+                                current = totalDownloads,
+                                total = totalDownloads,
+                                currentIp = sortedPingResults.first().first,
+                                status = Status.DOWNLOAD
+                            )
+                        )
+                    }
+
+                    val downloadTasks = sortedPingResults.map { (ip, pingResult) ->
+                        async {
+                            if (shouldStop.get()) return@async null
+
+                            downloadSemaphore.withPermit {
+                                if (shouldStop.get()) return@withPermit null
+
+                                try {
+                                    val downloadSpeed = if (config.downloadTest) {
+                                        DownloadTest.testDownloadSpeed(
+                                            ip = ip,
+                                            testDurationMs = config.downloadDuration
+                                        )
+                                    } else {
+                                        0.0
+                                    }
+
+                                    if (config.speedLimit > 0 && downloadSpeed < config.speedLimit) {
+                                        return@withPermit null
+                                    }
+
+                                    SpeedTestResult(
+                                        ipAddress = ip,
+                                        packetsSent = pingResult.sent,
+                                        packetsReceived = pingResult.received,
+                                        packetLoss = pingResult.packetLoss,
+                                        avgLatency = pingResult.avgLatency,
+                                        downloadSpeed = downloadSpeed,
+                                        regionCode = "N/A"
+                                    )
+                                } finally {
+                                    val finished = completedDownloads.incrementAndGet()
+                                    val remaining = (totalDownloads - finished).coerceAtLeast(1)
+                                    onProgress(
+                                        TestProgress(
+                                            current = remaining,
+                                            total = totalDownloads,
+                                            currentIp = ip,
+                                            status = Status.DOWNLOAD
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    val downloadResults = downloadTasks.awaitAll()
+                    downloadResults.filterNotNull().forEach { result ->
+                        results.add(result)
+                        onResult(result)
+                    }
+                } else {
+                    for (i in 0 until config.testCount) {
+                        if (shouldStop.get()) break
+                        if (consecutiveFailures >= maxConsecutiveFailures) break
+
+                        var ip: String? = null
+                        var attempts = 0
+                        while (ip == null || testedIps.contains(ip)) {
+                            ip = IpRangeParser.getRandomIpFromRanges(ipRanges, random)
+                            attempts++
+                            if (attempts > 100) break
+                        }
+
+                        if (ip == null || testedIps.contains(ip)) continue
+                        testedIps.add(ip)
+
+                        onProgress(
+                            TestProgress(
+                                current = i + 1,
+                                total = config.testCount,
+                                currentIp = ip,
+                                status = Status.TESTING
+                            )
+                        )
+
+                        val pingResult = TcpPingTest.ping(
+                            ip = ip,
+                            port = config.port,
+                            count = config.pingCount,
+                            timeoutMs = config.pingTimeout
+                        )
+
+                        if (pingResult.received == 0) {
+                            consecutiveFailures++
+                            continue
+                        }
+
+                        consecutiveFailures = 0
+
+                        if (config.latencyLimit > 0 && pingResult.avgLatency > config.latencyLimit) {
+                            continue
+                        }
+
+                        var downloadSpeed = 0.0
+                        if (config.downloadTest && !shouldStop.get()) {
+                            downloadSpeed = DownloadTest.testDownloadSpeed(
+                                ip = ip,
+                                testDurationMs = config.downloadDuration
+                            )
+                        }
+
+                        if (config.speedLimit > 0 && downloadSpeed < config.speedLimit) {
+                            continue
+                        }
+
+                        val result = SpeedTestResult(
+                            ipAddress = ip,
+                            packetsSent = pingResult.sent,
+                            packetsReceived = pingResult.received,
+                            packetLoss = pingResult.packetLoss,
+                            avgLatency = pingResult.avgLatency,
+                            downloadSpeed = downloadSpeed,
+                            regionCode = "N/A"
+                        )
+
+                        results.add(result)
+                        onResult(result)
+                    }
+                }
+
+                if (consecutiveFailures >= maxConsecutiveFailures) {
+                    throw java.io.IOException(
+                        "网络不可达：连续 $consecutiveFailures 次 Ping 测试失败，可能是 IPv6 网络未启用或不支持"
+                    )
+                }
+            }
+        } finally {
+            isRunning.set(false)
+            val sortedResults = results.sorted()
+            onComplete(sortedResults)
+        }
+    }
+
+    fun stopTest() {
+        shouldStop.set(true)
+    }
+
+    fun isRunning(): Boolean = isRunning.get()
+
+    private fun collectCandidateIps(
+        ipRanges: List<IpRangeParser.IpRange>,
+        random: Random,
+        testedIps: MutableSet<String>,
+        targetCount: Int,
+        shouldStop: AtomicBoolean
+    ): List<String> {
+        val candidateIps = mutableListOf<String>()
+        var duplicateAttempts = 0
+        val maxDuplicateAttempts = (targetCount * 20).coerceAtLeast(100)
+
+        while (
+            candidateIps.size < targetCount &&
+            !shouldStop.get() &&
+            duplicateAttempts < maxDuplicateAttempts
+        ) {
+            val ip = IpRangeParser.getRandomIpFromRanges(ipRanges, random)
+            if (ip == null) {
+                duplicateAttempts++
+                continue
+            }
+
+            if (!testedIps.add(ip)) {
+                duplicateAttempts++
+                continue
+            }
+
+            candidateIps.add(ip)
+        }
+
+        return candidateIps
+    }
+
+    private suspend fun pingCandidates(
+        candidateIps: List<String>,
+        config: TestConfig,
+        onProgress: (TestProgress) -> Unit
+    ): List<Pair<String, TcpPingTest.PingResult>> {
+        if (candidateIps.isEmpty()) {
+            return emptyList()
+        }
+
+        val pingSemaphore = Semaphore(config.maxConcurrentPings.coerceAtLeast(1))
+        val startedPings = AtomicInteger(0)
+
+        return coroutineScope {
+            candidateIps.map { ip ->
+                async {
+                    if (shouldStop.get()) return@async null
+
+                    pingSemaphore.withPermit {
+                        if (shouldStop.get()) return@withPermit null
+
+                        val started = startedPings.incrementAndGet()
+                        onProgress(
+                            TestProgress(
+                                current = started,
+                                total = candidateIps.size,
+                                currentIp = ip,
+                                status = Status.PING
+                            )
+                        )
+
+                        val pingResult = TcpPingTest.ping(
+                            ip = ip,
+                            port = config.port,
+                            count = config.pingCount,
+                            timeoutMs = config.pingTimeout
+                        )
+
+                        if (pingResult.received == 0) {
+                            return@withPermit null
+                        }
+
+                        if (config.latencyLimit > 0 && pingResult.avgLatency > config.latencyLimit) {
+                            return@withPermit null
+                        }
+
+                        ip to pingResult
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/speedtest/TcpPingTest.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/speedtest/TcpPingTest.kt
@@ -1,0 +1,121 @@
+package com.v2ray.ang.cfscan.speedtest
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.InetSocketAddress
+import java.net.Socket
+import kotlin.math.round
+
+/**
+ * TCP Ping 测试类
+ * 参考 Windows 版 cfst.exe 的测速逻辑优化
+ */
+class TcpPingTest {
+    
+    /**
+     * Ping 测试结果
+     */
+    data class PingResult(
+        val sent: Int,           // 发送的包数
+        val received: Int,       // 接收的包数
+        val packetLoss: Double,  // 丢包率 (0.00 - 100.00)
+        val avgLatency: Double,  // 平均延迟 (ms)
+        val minLatency: Double,  // 最小延迟 (ms)
+        val maxLatency: Double   // 最大延迟 (ms)
+    )
+    
+    companion object {
+        private const val DEFAULT_PORT = 443
+        private const val DEFAULT_TIMEOUT_MS = 1000
+        
+        /**
+         * 执行 TCP Ping 测试（挂起函数）
+         * @param ip 目标 IP 地址
+         * @param port 目标端口，默认 443
+         * @param count 测试次数，默认 4 次
+         * @param timeoutMs 超时时间 (毫秒)，默认 1000ms
+         * @return PingResult 对象
+         */
+        suspend fun ping(
+            ip: String,
+            port: Int = DEFAULT_PORT,
+            count: Int = 4,
+            timeoutMs: Int = DEFAULT_TIMEOUT_MS
+        ): PingResult = withContext(Dispatchers.IO) {
+            val latencies = mutableListOf<Double>()
+            
+            repeat(count) {
+                val latency = singleTcpPing(ip, port, timeoutMs)
+                if (latency != null) {
+                    latencies.add(latency)
+                }
+            }
+            
+            val received = latencies.size
+            val packetLoss = if (count > 0) {
+                round(((count - received).toDouble() / count) * 10000) / 100
+            } else {
+                0.0
+            }
+            
+            val avgLatency = if (received > 0) {
+                round((latencies.sum() / received) * 100) / 100
+            } else {
+                0.0
+            }
+            
+            val minLatency = if (latencies.isNotEmpty()) {
+                round(latencies.min() * 100) / 100
+            } else {
+                0.0
+            }
+            
+            val maxLatency = if (latencies.isNotEmpty()) {
+                round(latencies.max() * 100) / 100
+            } else {
+                0.0
+            }
+            
+            PingResult(
+                sent = count,
+                received = received,
+                packetLoss = packetLoss,
+                avgLatency = avgLatency,
+                minLatency = minLatency,
+                maxLatency = maxLatency
+            )
+        }
+        
+        /**
+         * 执行单次 TCP Ping
+         * @return 延迟 (ms)，如果失败返回 null
+         */
+        private fun singleTcpPing(ip: String, port: Int, timeoutMs: Int): Double? {
+            return try {
+                val socket = Socket()
+                val startTime = System.nanoTime()
+                
+                try {
+                    socket.connect(
+                        InetSocketAddress(ip, port),
+                        timeoutMs
+                    )
+                    val endTime = System.nanoTime()
+                    val latencyMs = (endTime - startTime) / 1_000_000.0
+                    
+                    // 限制最大延迟显示
+                    val roundedLatency = round(latencyMs * 100) / 100
+                    if (roundedLatency > 9999) null else roundedLatency
+                } finally {
+                    try {
+                        socket.close()
+                    } catch (e: Exception) {
+                        // 忽略关闭错误
+                    }
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/utils/IpRangeParser.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/cfscan/utils/IpRangeParser.kt
@@ -1,0 +1,344 @@
+package com.v2ray.ang.cfscan.utils
+
+import java.util.Random
+import java.math.BigInteger
+
+/**
+ * IP 段解析和随机 IP 生成工具类
+ * 支持 CIDR 格式的 IP 段，如 173.245.48.0/20 (IPv4) 和 2400:cb00:2049::/48 (IPv6)
+ */
+class IpRangeParser {
+
+    /**
+     * IP 范围数据类
+     * 使用 BigInteger 存储 IP 地址以同时支持 IPv4 和 IPv6
+     */
+    data class IpRange(
+        val startIp: BigInteger,
+        val endIp: BigInteger,
+        val isIpv6: Boolean = false
+    )
+
+    companion object {
+        private val random = Random()
+
+        /**
+         * 解析 CIDR 格式的 IP 段（支持 IPv4 和 IPv6）
+         * @param cidr CIDR 格式字符串，如 "173.245.48.0/20" 或 "2400:cb00:2049::/48"
+         * @return IpRange 对象，包含起始和结束 IP
+         */
+        fun parseCidr(cidr: String): IpRange? {
+            return try {
+                val parts = cidr.trim().split("/")
+                if (parts.size != 2) return null
+
+                val ip = parts[0].trim()
+                val prefixLength = parts[1].toIntOrNull() ?: return null
+
+                // 判断是 IPv4 还是 IPv6
+                val isIpv6 = ip.contains(':')
+
+                if (isIpv6) {
+                    // IPv6 处理
+                    if (prefixLength < 0 || prefixLength > 128) return null
+
+                    val fullIp = expandIpv6(ip) ?: return null
+                    val ipBigInt = ipv6ToBigInteger(fullIp)
+
+                    // 计算网络掩码：前 prefixLength 位为 1，其余为 0
+                    // 例如 /48 表示前 48 位是网络位
+                    val mask = if (prefixLength == 0) {
+                        BigInteger.ZERO
+                    } else if (prefixLength == 128) {
+                        BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE)
+                    } else {
+                        // 创建前缀掩码：高 prefixLength 位为 1
+                        BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE)
+                            .xor(BigInteger.ONE.shiftLeft(128 - prefixLength).subtract(BigInteger.ONE))
+                    }
+
+                    val networkAddress = ipBigInt.and(mask)
+                    // 广播地址：网络地址 + 主机部分全 1
+                    val hostBits = 128 - prefixLength
+                    val broadcastAddress = if (hostBits == 0) {
+                        networkAddress
+                    } else {
+                        networkAddress.add(BigInteger.ONE.shiftLeft(hostBits).subtract(BigInteger.ONE))
+                    }
+
+                    // 对于 /128 这样的单个 IP，直接返回
+                    if (prefixLength == 128) {
+                        IpRange(networkAddress, networkAddress, isIpv6 = true)
+                    } else {
+                        // 排除网络地址和广播地址
+                        IpRange(
+                            networkAddress.add(BigInteger.ONE),
+                            broadcastAddress.subtract(BigInteger.ONE),
+                            isIpv6 = true
+                        )
+                    }
+                } else {
+                    // IPv4 处理
+                    if (prefixLength < 0 || prefixLength > 32) return null
+
+                    val ipLong = ipToLong(ip) ?: return null
+                    val mask = if (prefixLength == 0) 0L else (-1L shl (32 - prefixLength))
+                    val networkAddress = ipLong and mask
+                    val broadcastAddress = networkAddress or mask.inv()
+
+                    IpRange(
+                        BigInteger.valueOf(networkAddress + 1),
+                        BigInteger.valueOf(broadcastAddress - 1),
+                        isIpv6 = false
+                    )
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        /**
+         * 展开 IPv6 地址的压缩格式
+         * 例如：2400:cb00:2049::/48 -> 2400:cb00:2049:0000:0000:0000:0000:0000
+         */
+        private fun expandIpv6(ipv6: String): String? {
+            return try {
+                // 移除可能存在的方括号和前后空格
+                var cleanIp = ipv6.trim('[', ']', ' ')
+                
+                // 如果包含 CIDR 前缀，移除它
+                if ('/' in cleanIp) {
+                    cleanIp = cleanIp.substringBefore('/')
+                }
+                
+                // 处理 :: 压缩
+                if ("::" in cleanIp) {
+                    val parts = cleanIp.split("::")
+                    val leftParts = if (parts[0].isEmpty()) emptyList() else parts[0].split(':').filter { it.isNotEmpty() }
+                    val rightParts = if (parts.size > 1 && parts[1].isEmpty()) emptyList() 
+                                     else if (parts.size > 1) parts[1].split(':').filter { it.isNotEmpty() } 
+                                     else emptyList()
+
+                    val missingParts = 8 - leftParts.size - rightParts.size
+                    if (missingParts < 0) return null
+                    
+                    val middleParts = List(missingParts) { "0000" }
+
+                    val allParts = (leftParts + middleParts + rightParts)
+                        .map { it.padStart(4, '0') }
+                    
+                    if (allParts.size != 8) return null
+
+                    allParts.joinToString(":")
+                } else {
+                    // 没有压缩，直接展开
+                    val parts = cleanIp.split(':').filter { it.isNotEmpty() }
+                    if (parts.size != 8) return null
+                    parts
+                        .map { it.padStart(4, '0') }
+                        .joinToString(":")
+                }
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        /**
+         * 将展开的 IPv6 字符串转换为 BigInteger
+         */
+        private fun ipv6ToBigInteger(ipv6: String): BigInteger {
+            val parts = ipv6.split(':')
+            var result = BigInteger.ZERO
+
+            for (part in parts) {
+                val value = part.toIntOrNull(16) ?: 0
+                result = result.shiftLeft(16).or(BigInteger.valueOf(value.toLong()))
+            }
+
+            return result
+        }
+
+        /**
+         * 从 IP 范围中随机选择一个 IP（支持 IPv4 和 IPv6）
+         */
+        fun getRandomIpFromRange(range: IpRange, random: Random = this.random): String {
+            val rangeSize = range.endIp.subtract(range.startIp).add(BigInteger.ONE)
+            if (rangeSize.compareTo(BigInteger.ONE) <= 0) {
+                return if (range.isIpv6) {
+                    bigIntegerToIpv6(range.startIp)
+                } else {
+                    longToIp(range.startIp.toLong())
+                }
+            }
+
+            val randomOffset = if (range.isIpv6 && rangeSize.compareTo(BigInteger.valueOf(0xFFFF)) > 0) {
+                // [关键修复]：对于 IPv6 (如 /32, /48)，它的地址池庞大到离谱（例如 /48 是 2^80 个 IP）。
+                // Cloudflare 等 CDN 绝对不可能在池里的每一个随机叶子节点上绑定服务器监听。
+                // 如果我们随意随机分布在巨大的 Host 区间内，高达 99.999% 的概率会命中一个无人监听的黑洞 IP。
+                // 结果就是去 Ping 黑洞毫无响应，APP 会误判认为是 50 次连续失败导致网络断网。
+                // 解决方案：采用 Anycast CDN 通用测速逻辑，锁定前置网络段位，并严格只随机最后 16 位主机号 (0x0000 ~ 0xFFFF)
+                BigInteger(16, random).mod(BigInteger.valueOf(0x10000))
+            } else if (rangeSize.bitLength() < 64) {
+                BigInteger.valueOf((random.nextDouble() * rangeSize.toDouble()).toLong())
+            } else {
+                // 对于非常大的范围，使用随机 BigInteger
+                BigInteger(rangeSize.bitLength(), random).mod(rangeSize)
+            }
+
+            val ipBigInt = range.startIp.add(randomOffset)
+
+            return if (range.isIpv6) {
+                bigIntegerToIpv6(ipBigInt)
+            } else {
+                longToIp(ipBigInt.toLong())
+            }
+        }
+
+        /**
+         * 从多个 IP 范围中随机选择一个 IP（支持 IPv4 和 IPv6）
+         */
+        fun getRandomIpFromRanges(ranges: List<IpRange>, random: Random = this.random): String? {
+            if (ranges.isEmpty()) return null
+
+            // 首先根据每个范围的 IP 数量加权随机选择一个范围
+            val totalIps = ranges.sumOf { it.endIp.subtract(it.startIp).add(BigInteger.ONE) }
+            var randomValue = if (totalIps.bitLength() < 64) {
+                BigInteger.valueOf((random.nextDouble() * totalIps.toDouble()).toLong())
+            } else {
+                BigInteger(totalIps.bitLength(), random).mod(totalIps)
+            }
+
+            for (range in ranges) {
+                val rangeSize = range.endIp.subtract(range.startIp).add(BigInteger.ONE)
+                if (randomValue < rangeSize) {
+                    return getRandomIpFromRange(range, random)
+                }
+                randomValue = randomValue.subtract(rangeSize)
+            }
+
+            return getRandomIpFromRange(ranges.last(), random)
+        }
+
+        /**
+         * 解析 IP 文件，返回 IP 范围列表
+         */
+        fun parseIpFile(content: String): List<IpRange> {
+            return content.replace("\uFEFF", "")
+                .lines()
+                .mapNotNull { line ->
+                    val trimmedLine = line.trim().removePrefix("\uFEFF")
+                    if (trimmedLine.isEmpty() || trimmedLine.startsWith("#")) null
+                    else parseCidr(trimmedLine)
+                }
+                .filter { it.endIp >= it.startIp }
+        }
+
+        /**
+         * IP 字符串转 Long（仅 IPv4）
+         */
+        fun ipToLong(ip: String): Long? {
+            return try {
+                val parts = ip.split(".")
+                if (parts.size != 4) return null
+
+                var result = 0L
+                for (part in parts) {
+                    val num = part.toIntOrNull() ?: return null
+                    if (num < 0 || num > 255) return null
+                    result = (result shl 8) or num.toLong()
+                }
+                result
+            } catch (e: Exception) {
+                null
+            }
+        }
+
+        /**
+         * Long 转 IP 字符串（仅 IPv4）
+         */
+        fun longToIp(ip: Long): String {
+            return "${(ip shr 24) and 0xFF}.${(ip shr 16) and 0xFF}.${(ip shr 8) and 0xFF}.${ip and 0xFF}"
+        }
+
+        /**
+         * BigInteger 转 IPv6 字符串
+         */
+        private fun bigIntegerToIpv6(value: BigInteger): String {
+            var bigInteger = value.and(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE))
+            val parts = mutableListOf<String>()
+
+            repeat(8) {
+                parts.add(bigInteger.and(BigInteger.valueOf(0xFFFF.toLong())).toString(16).padStart(4, '0'))
+                bigInteger = bigInteger.shiftRight(16)
+            }
+
+            // 压缩连续的 0000 段为 ::
+            return compressIpv6(parts.reversed().joinToString(":"))
+        }
+
+        /**
+         * 压缩 IPv6 地址中的连续 0 段
+         */
+        private fun compressIpv6(ipv6: String): String {
+            val parts = ipv6.split(':')
+
+            // 找到最长的连续 0 段
+            var maxStart = -1
+            var maxLen = 0
+            var currentStart = -1
+            var currentLen = 0
+
+            for (i in parts.indices) {
+                if (parts[i] == "0000" || parts[i] == "0") {
+                    if (currentStart == -1) {
+                        currentStart = i
+                        currentLen = 1
+                    } else {
+                        currentLen++
+                    }
+                } else {
+                    if (currentLen > maxLen) {
+                        maxStart = currentStart
+                        maxLen = currentLen
+                    }
+                    currentStart = -1
+                    currentLen = 0
+                }
+            }
+
+            if (currentLen > maxLen) {
+                maxStart = currentStart
+                maxLen = currentLen
+            }
+
+            // 只有当连续 0 段长度 >= 2 时才压缩
+            if (maxLen < 2) {
+                return parts.joinToString(":")
+            }
+
+            val leftParts = parts.subList(0, maxStart).map { it.replaceFirst("^0+".toRegex(), "").ifEmpty { "0" } }
+            val rightParts = parts.subList(maxStart + maxLen, parts.size).map { it.replaceFirst("^0+".toRegex(), "").ifEmpty { "0" } }
+
+            return when {
+                leftParts.isEmpty() && rightParts.isEmpty() -> "::"
+                leftParts.isEmpty() -> "::" + rightParts.joinToString(":")
+                rightParts.isEmpty() -> leftParts.joinToString(":") + "::"
+                else -> leftParts.joinToString(":") + "::" + rightParts.joinToString(":")
+            }
+        }
+
+        /**
+         * 获取 IP 范围的总 IP 数量
+         */
+        fun getTotalIpCount(ranges: List<IpRange>): BigInteger {
+            return ranges.sumOf { it.endIp.subtract(it.startIp).add(BigInteger.ONE) }
+        }
+
+        /**
+         * 判断 IP 地址是否为 IPv6
+         */
+        fun isIpv6Address(ip: String): Boolean {
+            return ip.contains(':')
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -4,8 +4,10 @@ import android.os.Bundle
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -14,14 +16,19 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -32,12 +39,14 @@ import androidx.compose.ui.unit.dp
 import com.v2ray.ang.AppConfig.REALITY
 import com.v2ray.ang.AppConfig.TLS
 import com.v2ray.ang.R
+import com.v2ray.ang.cfscan.CloudflareIpScanner
 import com.v2ray.ang.compose.AppTopBar
 import com.v2ray.ang.compose.ConfirmDialog
 import com.v2ray.ang.compose.FormDropdownField
 import com.v2ray.ang.compose.FormTextField
 import com.v2ray.ang.compose.SettingsSwitchItem
 import com.v2ray.ang.compose.verticalScrollbar
+import com.v2ray.ang.core.CoreServiceManager
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.enums.NetworkType
@@ -104,17 +113,139 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         state: ServerUiState,
         showPort: Boolean = true
     ) {
+        val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+        val showCfIpScan = state.configType == EConfigType.VLESS ||
+            state.configType == EConfigType.VMESS ||
+            state.configType == EConfigType.TROJAN
+        var isScanning by rememberSaveable { mutableStateOf(false) }
+        var scanProgress by rememberSaveable { mutableFloatStateOf(0f) }
+        var scanStatus by rememberSaveable { mutableStateOf("") }
+        var addressPingMs by rememberSaveable { mutableStateOf<String?>(null) }
+
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             FormTextField(
                 stringResource(R.string.server_lab_remarks),
                 state.remarks,
                 { state.remarks = it }
             )
-            FormTextField(
-                stringResource(R.string.server_lab_address),
-                state.address,
-                { state.address = it }
-            )
+            if (showCfIpScan) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    FormTextField(
+                        label = stringResource(R.string.server_lab_address),
+                        value = state.address,
+                        onValueChange = {
+                            state.address = it
+                            addressPingMs = null
+                        },
+                        enabled = !isScanning,
+                        modifier = Modifier.weight(1f)
+                    )
+                    if (!addressPingMs.isNullOrBlank()) {
+                        Text(
+                            text = addressPingMs.orEmpty(),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(end = 4.dp)
+                        )
+                    }
+                    IconButton(
+                        onClick = {
+                            if (isScanning) return@IconButton
+                            // VPN / Start must be OFF before scanning
+                            if (CoreServiceManager.isRunning()) {
+                                context.toast(R.string.toast_cf_ip_scan_stop_vpn)
+                                return@IconButton
+                            }
+                            isScanning = true
+                            scanProgress = 0f
+                            addressPingMs = null
+                            scanStatus = context.getString(R.string.toast_cf_ip_scanning)
+                            context.toast(R.string.toast_cf_ip_scan_data_warning)
+                            scope.launch {
+                                try {
+                                    // Full scan: ping 100 + download top 20
+                                    val best = CloudflareIpScanner.findBestCloudflareIp { progress ->
+                                        scope.launch(Dispatchers.Main.immediate) {
+                                            val total = progress.total.coerceAtLeast(1)
+                                            scanProgress =
+                                                (progress.current.toFloat() / total).coerceIn(0f, 1f)
+                                            val statusText = when (progress.status) {
+                                                CloudflareIpScanner.STATUS_FETCHING ->
+                                                    context.getString(R.string.cf_ip_status_fetching)
+                                                CloudflareIpScanner.STATUS_PING ->
+                                                    context.getString(R.string.cf_ip_status_ping)
+                                                CloudflareIpScanner.STATUS_DOWNLOAD ->
+                                                    context.getString(R.string.cf_ip_status_download)
+                                                CloudflareIpScanner.STATUS_TESTING ->
+                                                    context.getString(R.string.cf_ip_status_testing)
+                                                else ->
+                                                    context.getString(R.string.toast_cf_ip_scanning)
+                                            }
+                                            val ipPart = progress.currentIp.takeIf { it.isNotBlank() }
+                                                ?.let { " $it" }
+                                                .orEmpty()
+                                            scanStatus =
+                                                "$statusText$ipPart (${progress.current}/${progress.total})"
+                                        }
+                                    }
+                                    if (best == null || best.ipAddress.isBlank()) {
+                                        context.toast(R.string.toast_cf_ip_scan_failed)
+                                    } else {
+                                        state.address = best.ipAddress
+                                        addressPingMs = context.getString(
+                                            R.string.cf_ip_ping_ms,
+                                            best.avgLatencyMs.toInt().coerceAtLeast(0)
+                                        )
+                                        context.toastSuccess(R.string.toast_cf_ip_scan_success)
+                                    }
+                                } catch (_: Exception) {
+                                    context.toast(R.string.toast_cf_ip_scan_failed)
+                                } finally {
+                                    isScanning = false
+                                    scanProgress = 0f
+                                    scanStatus = ""
+                                }
+                            }
+                        },
+                        // Off while scanning, or while VPN Start is on
+                        enabled = !isScanning && !CoreServiceManager.isRunning(),
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_cloud_download_24dp),
+                            contentDescription = stringResource(R.string.server_lab_cf_ip_scan)
+                        )
+                    }
+                }
+                if (isScanning) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        LinearProgressIndicator(
+                            progress = { scanProgress },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Text(
+                            text = scanStatus.ifBlank { stringResource(R.string.toast_cf_ip_scanning) },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            } else {
+                FormTextField(
+                    stringResource(R.string.server_lab_address),
+                    state.address,
+                    { state.address = it }
+                )
+            }
             if (showPort) {
                 FormTextField(
                     stringResource(R.string.server_lab_port),

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">Please test before deleting! Confirm delete ?</string>
     <string name="server_lab_remarks">ملاحظات</string>
     <string name="server_lab_address">العنوان</string>
+    <string name="server_lab_cf_ip_scan">الحصول على IP نظيف لـ CF</string>
+    <string name="toast_cf_ip_scanning">جارٍ فحص عناوين Cloudflare (بينغ + تنزيل)...</string>
+    <string name="toast_cf_ip_scan_success">تم تعبئة أسرع عنوان Cloudflare في حقل العنوان</string>
+    <string name="toast_cf_ip_scan_failed">فشل فحص عناوين Cloudflare. أوقف VPN ثم أعد المحاولة.</string>
+    <string name="toast_cf_ip_scan_stop_vpn">أوقف زر Start/VPN قبل الفحص</string>
+    <string name="toast_cf_ip_scan_data_warning">الفحص الكامل يشمل اختبار التنزيل وقد يستهلك بيانات كثيرة</string>
+    <string name="cf_ip_status_fetching">جارٍ جلب نطاقات عناوين Cloudflare...</string>
+    <string name="cf_ip_status_ping">جارٍ اختبار البينغ...</string>
+    <string name="cf_ip_status_download">جارٍ اختبار سرعة التنزيل...</string>
+    <string name="cf_ip_status_testing">جارٍ الاختبار...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">المنفذ</string>
     <string name="server_lab_id">المعرف</string>
     <string name="server_lab_alterid">AlterId</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">Please test before deleting! Confirm delete ?</string>
     <string name="server_lab_remarks">মন্তব্য</string>
     <string name="server_lab_address">ঠিকানা</string>
+    <string name="server_lab_cf_ip_scan">পরিষ্কার CF IP নিন</string>
+    <string name="toast_cf_ip_scanning">Cloudflare IP স্ক্যান হচ্ছে (পিং + ডাউনলোড)...</string>
+    <string name="toast_cf_ip_scan_success">সবচেয়ে দ্রুত Cloudflare IP ঠিকানায় বসানো হয়েছে</string>
+    <string name="toast_cf_ip_scan_failed">Cloudflare IP স্ক্যান ব্যর্থ। VPN বন্ধ করে আবার চেষ্টা করুন।</string>
+    <string name="toast_cf_ip_scan_stop_vpn">স্ক্যানের আগে Start/VPN বাটন বন্ধ করুন</string>
+    <string name="toast_cf_ip_scan_data_warning">পূর্ণ স্ক্যানে ডাউনলোড পরীক্ষা আছে এবং অনেক ডেটা খরচ হতে পারে</string>
+    <string name="cf_ip_status_fetching">Cloudflare IP রেঞ্জ আনা হচ্ছে...</string>
+    <string name="cf_ip_status_ping">পিং পরীক্ষা চলছে...</string>
+    <string name="cf_ip_status_download">ডাউনলোড গতি পরীক্ষা চলছে...</string>
+    <string name="cf_ip_status_testing">পরীক্ষা চলছে...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">পোর্ট</string>
     <string name="server_lab_id">আইডি</string>
     <string name="server_lab_alterid">অলটারআইডি</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">پؽش ز پاک کردن، پینگ بگرین! الن اخۊین پاک کۊنین؟</string>
     <string name="server_lab_remarks">نیشتنا</string>
     <string name="server_lab_address">نشۊوی</string>
+    <string name="server_lab_cf_ip_scan">گرفتن IP پاک CF</string>
+    <string name="toast_cf_ip_scanning">داره IPهای Cloudflare اسکن ابۊ (پینگ + دانلود)...</string>
+    <string name="toast_cf_ip_scan_success">سریع‌ترین IP کلودفلر وه نشۊوی نیشته بیه</string>
+    <string name="toast_cf_ip_scan_failed">اسکن IP کلودفلر شکست خوارد. VPN ره خاموش کۊنین و دوواره امتحان کۊنین.</string>
+    <string name="toast_cf_ip_scan_stop_vpn">قبل از اسکن، دکمه Start/VPN ره خاموش کۊنین</string>
+    <string name="toast_cf_ip_scan_data_warning">اسکن کامل پینگ و تست دانلود داره و ممکنه اینترنت زیاتی بخوره</string>
+    <string name="cf_ip_status_fetching">داره بازه‌های IP کلودفلر بیاره...</string>
+    <string name="cf_ip_status_ping">داره پینگ تست ابۊ...</string>
+    <string name="cf_ip_status_download">داره سرعت دانلود تست ابۊ...</string>
+    <string name="cf_ip_status_testing">داره تست ابۊ...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">پورت</string>
     <string name="server_lab_id">نوم منتوری</string>
     <string name="server_lab_alterid">شناسه جایگۊزین</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">لطفاً قبل از حذف، پینگ بگیرید! آیا از حذف اطمینان دارید؟</string>
     <string name="server_lab_remarks">ملاحظات</string>
     <string name="server_lab_address">نشانی</string>
+    <string name="server_lab_cf_ip_scan">دریافت IP تمیز CF</string>
+    <string name="toast_cf_ip_scanning">در حال اسکن IPهای Cloudflare (پینگ + دانلود)...</string>
+    <string name="toast_cf_ip_scan_success">سریع‌ترین IP کلودفلر در آدرس قرار گرفت</string>
+    <string name="toast_cf_ip_scan_failed">اسکن IP کلودفلر ناموفق بود. VPN را خاموش کنید و دوباره تلاش کنید.</string>
+    <string name="toast_cf_ip_scan_stop_vpn">قبل از اسکن، دکمه Start/VPN را خاموش کنید</string>
+    <string name="toast_cf_ip_scan_data_warning">اسکن کامل شامل پینگ و تست دانلود است و ممکن است اینترنت زیادی مصرف کند</string>
+    <string name="cf_ip_status_fetching">در حال دریافت بازه‌های IP کلودفلر...</string>
+    <string name="cf_ip_status_ping">در حال تست پینگ...</string>
+    <string name="cf_ip_status_download">در حال تست سرعت دانلود...</string>
+    <string name="cf_ip_status_testing">در حال تست...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">پورت</string>
     <string name="server_lab_id">شناسه</string>
     <string name="server_lab_alterid">شناسه جایگزین</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">Выполните проверку перед удалением! Подтверждаете удаление?</string>
     <string name="server_lab_remarks">Название</string>
     <string name="server_lab_address">Адрес</string>
+    <string name="server_lab_cf_ip_scan">Получить чистый CF IP</string>
+    <string name="toast_cf_ip_scanning">Сканирование IP Cloudflare (пинг + загрузка)...</string>
+    <string name="toast_cf_ip_scan_success">Самый быстрый IP Cloudflare записан в адрес</string>
+    <string name="toast_cf_ip_scan_failed">Сканирование IP Cloudflare не удалось. Отключите VPN и повторите.</string>
+    <string name="toast_cf_ip_scan_stop_vpn">Перед сканированием выключите кнопку Start/VPN</string>
+    <string name="toast_cf_ip_scan_data_warning">Полный тест включает загрузку и может израсходовать много трафика</string>
+    <string name="cf_ip_status_fetching">Загрузка диапазонов IP Cloudflare...</string>
+    <string name="cf_ip_status_ping">Тест пинга...</string>
+    <string name="cf_ip_status_download">Тест скорости загрузки...</string>
+    <string name="cf_ip_status_testing">Тестирование...</string>
+    <string name="cf_ip_ping_ms">%d мс</string>
     <string name="server_lab_port">Порт</string>
     <string name="server_lab_id">ID</string>
     <string name="server_lab_alterid">Альтернативный ID</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">Please test before deleting! Confirm delete ?</string>
     <string name="server_lab_remarks">Tên cấu hình</string>
     <string name="server_lab_address">Địa chỉ</string>
+    <string name="server_lab_cf_ip_scan">Lấy IP CF sạch</string>
+    <string name="toast_cf_ip_scanning">Đang quét IP Cloudflare (ping + tải xuống)...</string>
+    <string name="toast_cf_ip_scan_success">Đã điền IP Cloudflare nhanh nhất vào địa chỉ</string>
+    <string name="toast_cf_ip_scan_failed">Quét IP Cloudflare thất bại. Tắt VPN rồi thử lại.</string>
+    <string name="toast_cf_ip_scan_stop_vpn">Tắt nút Start/VPN trước khi quét</string>
+    <string name="toast_cf_ip_scan_data_warning">Quét đầy đủ gồm kiểm tra tải xuống và có thể tốn nhiều dữ liệu</string>
+    <string name="cf_ip_status_fetching">Đang lấy dải IP Cloudflare...</string>
+    <string name="cf_ip_status_ping">Đang kiểm tra ping...</string>
+    <string name="cf_ip_status_download">Đang kiểm tra tốc độ tải...</string>
+    <string name="cf_ip_status_testing">Đang kiểm tra...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">Cổng</string>
     <string name="server_lab_id">ID</string>
     <string name="server_lab_alterid">ID bổ sung (AlterID)</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">删除前请先测试！确认删除？</string>
     <string name="server_lab_remarks">别名 (remarks)</string>
     <string name="server_lab_address">地址 (address)</string>
+    <string name="server_lab_cf_ip_scan">获取优选 CF IP</string>
+    <string name="toast_cf_ip_scanning">正在扫描 Cloudflare IP（延迟+下载）...</string>
+    <string name="toast_cf_ip_scan_success">已将最快的 Cloudflare IP 填入地址</string>
+    <string name="toast_cf_ip_scan_failed">Cloudflare IP 扫描失败。请关闭 VPN 后重试。</string>
+    <string name="toast_cf_ip_scan_stop_vpn">扫描前请先关闭开始/VPN 按钮</string>
+    <string name="toast_cf_ip_scan_data_warning">完整测速包含延迟与下载测试，可能消耗较多流量</string>
+    <string name="cf_ip_status_fetching">正在获取 Cloudflare IP 段...</string>
+    <string name="cf_ip_status_ping">正在 Ping 测试...</string>
+    <string name="cf_ip_status_download">正在下载测速...</string>
+    <string name="cf_ip_status_testing">正在测试...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">端口 (port)</string>
     <string name="server_lab_id">用户 ID (id)</string>
     <string name="server_lab_alterid">额外 ID (alterId)</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -43,6 +43,17 @@
     <string name="del_invalid_config_comfirm">刪除前請先測試！確認刪除？</string>
     <string name="server_lab_remarks">備註</string>
     <string name="server_lab_address">位址</string>
+    <string name="server_lab_cf_ip_scan">取得優選 CF IP</string>
+    <string name="toast_cf_ip_scanning">正在掃描 Cloudflare IP（延遲+下載）...</string>
+    <string name="toast_cf_ip_scan_success">已將最快的 Cloudflare IP 填入位址</string>
+    <string name="toast_cf_ip_scan_failed">Cloudflare IP 掃描失敗。請關閉 VPN 後重試。</string>
+    <string name="toast_cf_ip_scan_stop_vpn">掃描前請先關閉開始/VPN 按鈕</string>
+    <string name="toast_cf_ip_scan_data_warning">完整測速包含延遲與下載測試，可能消耗較多流量</string>
+    <string name="cf_ip_status_fetching">正在取得 Cloudflare IP 段...</string>
+    <string name="cf_ip_status_ping">正在 Ping 測試...</string>
+    <string name="cf_ip_status_download">正在下載測速...</string>
+    <string name="cf_ip_status_testing">正在測試...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">埠</string>
     <string name="server_lab_id">使用者 ID</string>
     <string name="server_lab_alterid">alterId</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -44,6 +44,17 @@
     <string name="del_invalid_config_comfirm">Please test before deleting! Confirm delete ?</string>
     <string name="server_lab_remarks">remarks</string>
     <string name="server_lab_address">address</string>
+    <string name="server_lab_cf_ip_scan">Get clean CF IP</string>
+    <string name="toast_cf_ip_scanning">Scanning Cloudflare IPs (ping + download)...</string>
+    <string name="toast_cf_ip_scan_success">Fastest Cloudflare IP filled into address</string>
+    <string name="toast_cf_ip_scan_failed">Cloudflare IP scan failed. Turn off VPN and try again.</string>
+    <string name="toast_cf_ip_scan_stop_vpn">Turn off the Start/VPN button before scanning</string>
+    <string name="toast_cf_ip_scan_data_warning">Full scan uses ping + download test and may consume significant data</string>
+    <string name="cf_ip_status_fetching">Fetching Cloudflare IP ranges...</string>
+    <string name="cf_ip_status_ping">Ping testing...</string>
+    <string name="cf_ip_status_download">Download speed testing...</string>
+    <string name="cf_ip_status_testing">Testing...</string>
+    <string name="cf_ip_ping_ms">%d ms</string>
     <string name="server_lab_port">port</string>
     <string name="server_lab_id">id</string>
     <string name="server_lab_alterid">alterId</string>


### PR DESCRIPTION
## Summary

Branch: `feature/cf-clean-ip-scanner`

Helps users automatically find and apply a **clean, low-latency Cloudflare IP** for CDN-based **VLESS / VMESS / Trojan** configs, improving connection success and speed without leaving the app.

Adds a Cloudflare clean-IP scanner next to the **address** field:

- Cloud button starts a full ping + download scan
- Progress bar shows live status (localized to app language)
- Fastest IP is written into **address**
- Measured latency is shown next to address (e.g. `30 ms`)
- Scan button is disabled while scanning
- Scan is blocked while VPN/Start is running

### Scope

| Config | CF scan |
|--------|---------|
| VLESS | Yes |
| VMESS | Yes |
| Trojan | Yes |
| Other types | No |

### Behavior

1. Open VLESS / VMESS / Trojan editor
2. Tap cloud icon next to **address**
3. If VPN is on → toast asks to turn Start/VPN off
4. Scan runs (ping 100 IPs + download-test top 20)
5. Best IP fills **address**; ping shown as `N ms`
6. Keep existing host/SNI/domain unchanged

---

## Benefits of a clean Cloudflare IP

- **Better connectivity:** avoids blocked/unstable CF edges on local ISP
- **Lower latency:** picks a responsive edge (e.g. `30 ms`)
- **Higher real speed:** download stage prefers better throughput
- **Easier CDN setups:** IP in address, domain in ws host/SNI
- **Less trial-and-error:** no need for external CF IP tools
- **More accurate when VPN is off:** scan blocked while Start/VPN is running

---

## Implementation notes

- Package: `com.v2ray.ang.cfscan`
- UI: `BaseServerActivity.CommonBasicFields()`
- Localized strings for app languages
- Credits (code only): https://github.com/Murtaza-codes/cf-scanner-android
- Engine logic based on: https://github.com/Hsia97/CFSTAPP (GPL-3.0)

## Test plan

- [ ] VLESS / VMESS / Trojan show CF button
- [ ] Other protocols do not show CF button
- [ ] VPN on → scan blocked
- [ ] VPN off → scan fills address + shows ping
- [ ] Manual address edit clears ping label
- [ ] During scan, button stays disabled
- [ ] App language matches status/toasts

## Fork / branch

- Fork: https://github.com/Murtaza-codes/v2rayNG

<img width="323" height="588" alt="Screenshot 2026-07-25 011237" src="https://github.com/user-attachments/assets/f46ab44e-0a62-4762-bae3-053ff238af1a" />


<img width="351" height="607" alt="Screenshot" src="https://github.com/user-attachments/assets/9ef605a7-9323-4903-95c9-63e7347d615d" />
attachments/assets/aa753de5-eac3-437f-93c2-7b9939a50a21" />

- Branch: `feature/cf-clean-ip-scanner`