### PR TITLE
Parse Xray TLS parameters in Shadowsocks links

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/fmt/ShadowsocksFmt.kt
@@ -50,6 +50,7 @@ object ShadowsocksFmt : FmtBase() {
 
         if (!uri.rawQuery.isNullOrEmpty()) {
             val queryParam = getQueryParam(uri)
+            getItemFormQuery(config, queryParam)
             if (queryParam["plugin"]?.contains("obfs=http") == true) {
                 val queryPairs = HashMap<String, String>()
                 for (pair in queryParam["plugin"]?.split(";") ?: listOf()) {

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/fmt/ShadowsocksFmtTest.kt
@@ -139,6 +139,8 @@ class ShadowsocksFmtTest {
         assertEquals("8388", result?.serverPort)
         assertEquals("aes-256-gcm", result?.method)
         assertEquals("my-secret-password", result?.password)
+        assertNull(result?.security)
+        assertNull(result?.sni)
     }
 
     @Test
@@ -167,6 +169,38 @@ class ShadowsocksFmtTest {
 
         assertNotNull(result)
         assertEquals("chacha20-ietf-poly1305", result?.method)
+    }
+
+    @Test
+    fun test_parseSip002_preservesXrayTlsQueryParameters() {
+        val ssUrl =
+            "ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpzZWNyZXRwYXNz@example.com:443" +
+                "?alpn=h2%2Chttp%2F1.1&fp=firefox&security=tls&sni=example.com&type=tcp#TLS"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("tcp", result?.network)
+        assertEquals("tls", result?.security)
+        assertEquals("example.com", result?.sni)
+        assertEquals("h2,http/1.1", result?.alpn)
+        assertEquals("firefox", result?.fingerPrint)
+    }
+
+    @Test
+    fun test_parseSip002_preservesObfsLocalPluginMapping() {
+        val ssUrl =
+            "ss://YWVzLTI1Ni1nY206c2VjcmV0@example.com:8388" +
+                "?plugin=obfs-local%3Bobfs%3Dhttp%3Bobfs-host%3Dcdn.example.com%3Bpath%3D%2Fws#Obfs"
+
+        val result = ShadowsocksFmt.parseSip002(ssUrl)
+
+        assertNotNull(result)
+        assertEquals("tcp", result?.network)
+        assertEquals("http", result?.headerType)
+        assertEquals("cdn.example.com", result?.host)
+        assertEquals("/ws", result?.path)
+        assertNull(result?.security)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- parse Xray transport and TLS query parameters from modern Shadowsocks URIs
- keep the existing SIP003 `plugin=obfs-local;obfs=http` mapping intact
- add regression coverage for Xray-native TLS, standard SIP002 links, and obfs-local links

## Root cause

`ShadowsocksFmt.parseSip002` decoded the query only for the `plugin` key. It ignored `type`, `security`, `sni`, `alpn`, and `fp`, even though `ProfileItem` already has those fields and `CoreOutboundBuilder.toOutboundShadowsocks` already consumes them when building `streamSettings`.

As a result, a link generated for a Shadowsocks inbound with Xray-native TLS was imported as plain Shadowsocks and failed during the TLS handshake.

This change reuses the same `getItemFormQuery` mapping already used by other Xray-aware URI parsers. Standard SIP002 links without these query parameters remain unchanged. The additional keys are treated as an explicit Xray extension; they are not claimed to be part of SIP002.

## Validation

- TDD regression: the TLS import test failed before the parser change and passed afterward
- `ShadowsocksFmtTest`: 17/17 passed for `fdroidDebug`
- `ShadowsocksFmtTest`: 17/17 passed for `playstoreDebug`
- `assembleFdroidDebug`: passed
- `./gradlew test --continue`: the project compiles and the new tests pass; the command still reports the same two pre-existing `UtilsTest` failures in each flavor (`test_isIpAddress` and `test_IsIpInCidr`) that were present on the untouched upstream baseline

## Related issue

Client-side counterpart to https://github.com/MHSanaei/3x-ui/issues/6094. That issue also tracks 3x-ui's own lossy Shadowsocks importer and raw-export compatibility behavior, which remain separate from this v2rayNG parser fix.
