### PR TITLE
fix: sanitize shell/subprocess call in RootShell.kt

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/root/RootShell.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/root/RootShell.kt
@@ -26,10 +26,11 @@ object RootShell {
             writeText(script)
             setExecutable(true, false)
         }
-        return exec("sh ${file.absolutePath}")
+        val safePath = file.absolutePath.replace("'", "'\\''")
+        return exec("sh '$safePath'")
     }
 
-    fun exec(command: String, timeoutSeconds: Long = 30): Result {
+    private fun exec(command: String, timeoutSeconds: Long = 30): Result {
         return try {
             val process = ProcessBuilder("su", "-c", command)
                 .redirectErrorStream(true)


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `V2rayNG/app/src/main/java/com/v2ray/ang/root/RootShell.kt`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `V2rayNG/app/src/main/java/com/v2ray/ang/root/RootShell.kt:34` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The RootShell.exec() method accepts a `command` string parameter and passes it directly to `ProcessBuilder("su", "-c", command)`. When `su -c` receives a single string argument, it is interpreted by a shell, meaning shell metacharacters in the command string will be interpreted. The public `exec(command)` method accepts any string, and if any caller passes user-influenced data into this method, it results in root-level command injection.

## Evidence

**Exploitation scenario**: An attacker who can influence the `command` parameter passed to RootShell.exec() (e.g., through manipulated configuration or IPC) could inject shell metacharacters.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `V2rayNG/app/src/main/java/com/v2ray/ang/root/RootShell.kt`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
