### PR TITLE
Fix silent drop of configs with illegal URI fragments

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -243,8 +243,7 @@ object AngConfigManager {
 
             // Parse all configs first (no I/O during parsing)
             val configs = mutableListOf<ProfileItem>()
-            servers.lines()
-                .distinct()
+            Utils.splitConfigEntries(servers)
                 .reversed()
                 .forEach {
                     val config = parseConfig(it, subid, subItem)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -458,15 +458,76 @@ object Utils {
     fun getSysLocale(): Locale = LocaleList.getDefault().get(0) ?: Locale.getDefault()
 
     /**
-     * Fix illegal characters in a URL.
+     * Escape illegal fragment characters in a URI so [java.net.URI] can parse it.
      *
-     * @param str The URL string.
-     * @return The URL string with illegal characters replaced.
+     * Only the fragment (after the first `#`) is rewritten; existing `%XX` escapes are kept
+     * so the call is idempotent, and a string without `#` is returned unchanged.
+     *
+     * @param str The raw URI string, possibly with illegal fragment characters.
+     * @return A URI string safe to pass to [java.net.URI].
      */
     fun fixIllegalUrl(str: String): String {
-        return str.replace(" ", "%20")
-            .replace("|", "%7C")
+        val base = str.replace(" ", "%20").replace("|", "%7C")
+        val hash = base.indexOf('#')
+        if (hash < 0) return base
+
+        val out = StringBuilder(base.length).append(base, 0, hash + 1)
+        val frag = base.substring(hash + 1)
+        var i = 0
+        while (i < frag.length) {
+            // already-escaped %XX, copy as-is
+            if (frag[i] == '%' && i + 2 < frag.length && frag[i + 1].isHex() && frag[i + 2].isHex()) {
+                out.append(frag, i, i + 3)
+                i += 3
+                continue
+            }
+            val cp = frag.codePointAt(i)
+            if (cp.isFragmentSafe()) {
+                out.append(cp.toChar())
+            } else {
+                for (b in String(Character.toChars(cp)).toByteArray(Charsets.UTF_8)) {
+                    out.append('%').append("%02X".format(b.toInt() and 0xFF))
+                }
+            }
+            i += Character.charCount(cp)
+        }
+        return out.toString()
     }
+
+    private const val FRAGMENT_SAFE_PUNCT = "-._~!\$&'()*+,;=:@/?"
+
+    private fun Char.isHex() = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+
+    private fun Int.isFragmentSafe() =
+        this <= 0x7F && (toChar().isLetterOrDigit() || toChar() in FRAGMENT_SAFE_PUNCT)
+
+    // schemes that begin a new entry - keep in sync with configFmtParsers in
+    // AngConfigManager (can't derive: it imports Utils, would be circular).
+    // http(s):// left out on purpose, those are sub urls for isValidSubUrl.
+    private val CONFIG_SCHEMES = listOf(
+        AppConfig.VMESS, AppConfig.SHADOWSOCKS, AppConfig.SOCKS, AppConfig.SOCKS4,
+        AppConfig.SOCKS5, AppConfig.TROJAN, AppConfig.VLESS, AppConfig.WIREGUARD,
+        AppConfig.HYSTERIA2, AppConfig.HY2, AppConfig.V2RAYNFMTS,
+    )
+
+    private val CONFIG_SCHEME_BOUNDARY = Regex(
+        "\\n|\\s+(?=(?:${CONFIG_SCHEMES.joinToString("|")}))",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /**
+     * Split a pasted or subscribed blob into individual config entries.
+     *
+     * Handles both newline-separated and single-line space-separated blobs.
+     *
+     * @param text The raw pasted or subscribed blob.
+     * @return The trimmed, non-empty, de-duplicated config entries.
+     */
+    fun splitConfigEntries(text: String): List<String> =
+        text.trim().split(CONFIG_SCHEME_BOUNDARY)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .distinct()
 
     /**
      * Find a free port from a list of ports.

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/UtilsTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/UtilsTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.net.URI
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -59,4 +60,106 @@ class UtilsTest {
         assertFalse(Utils.isIpInCidr("192.168.1.1", "invalid-cidr"))
     }
 
+    @Test
+    fun test_fixIllegalUrl_noFragment_byteIdentical() {
+        assertEquals("http://1.2.3.4/path", Utils.fixIllegalUrl("http://1.2.3.4/path"))
+        assertEquals("https://example.com/to/abc", Utils.fixIllegalUrl("https://example.com/to/abc"))
+        assertEquals("vless://uuid@1.2.3.4:443?enc=none", Utils.fixIllegalUrl("vless://uuid@1.2.3.4:443?enc=none"))
+        assertEquals("vless://uuid@1.2.3.4:443?enc=a%20b", Utils.fixIllegalUrl("vless://uuid@1.2.3.4:443?enc=a b"))
+    }
+
+    @Test
+    fun test_fixIllegalUrl_innerHashRemark_makesUriParseable() {
+        val raw =
+            "vless://11111111-2222-3333-4444-555555555555@10.0.0.1:443" +
+                "?encryption=none&type=grpc&security=reality&sni=example.com&fp=qq" +
+                "&pbk=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0&sid=1111111111111111" +
+                "&serviceName=grpc#\uD83C\uDDF7\uD83C\uDDFA \u0411\u0435\u043B\u044B\u0439 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442 #1 | \u0412\u0441\u0435 \u043E\u043F\u0435\u0440\u0430\u0442\u043E\u0440\u044B"
+        val fixed = Utils.fixIllegalUrl(raw)
+        val uri = URI(fixed)
+        assertEquals("vless", uri.scheme)
+        assertEquals("10.0.0.1", uri.host)
+        assertEquals(443, uri.port)
+        val decoded = java.net.URLDecoder.decode(uri.rawFragment ?: "", "UTF-8")
+        assertEquals("\uD83C\uDDF7\uD83C\uDDFA \u0411\u0435\u043B\u044B\u0439 \u0438\u043D\u0442\u0435\u0440\u043D\u0435\u0442 #1 | \u0412\u0441\u0435 \u043E\u043F\u0435\u0440\u0430\u0442\u043E\u0440\u044B", decoded)
+    }
+
+    @Test
+    fun test_fixIllegalUrl_alreadyEncodedIdempotent() {
+        val pre = "vless://uuid@host:443?encryption=none#%D0%91%D0%B5%D0%BB%D1%8B%D0%B9%20Plain%20%231"
+        assertEquals(pre, Utils.fixIllegalUrl(pre))
+        val realRaw =
+            "hysteria2://11111111-2222-3333-4444-555555555555@10.0.0.2:443?sni=example.com&fp=firefox&alpn=h3" +
+                "#\uD83C\uDDF7\uD83C\uDDFA \u041F\u0438\u043D\u0433 #7 | \u041E\u043F\u0435\u0440\u0430\u0442\u043E\u0440"
+        val once = Utils.fixIllegalUrl(realRaw)
+        val twice = Utils.fixIllegalUrl(once)
+        assertEquals(once, twice)
+    }
+
+    @Test
+    fun test_fixIllegalUrl_barePercentInRemark_escapedToPct25() {
+        val raw = "vless://uuid@1.2.3.4:443?enc=none#Save 50% off"
+        val uri = URI(Utils.fixIllegalUrl(raw))
+        assertEquals("Save 50% off", java.net.URLDecoder.decode(uri.rawFragment ?: "", "UTF-8"))
+    }
+
+    @Test
+    fun test_fixIllegalUrl_legacySpacePipeEscapePreserved() {
+        assertEquals("ss://a%20b@1.2.3.4:c%7Cd", Utils.fixIllegalUrl("ss://a b@1.2.3.4:c|d"))
+    }
+
+    @Test
+    fun test_splitConfigEntries_newlineJoined_identicalToLines() {
+        val blob = "vless://uuid@h1:443#a\nvmess://uuid@h2:443#b\nss://pass@h3:c#t"
+        assertEquals(listOf("vless://uuid@h1:443#a", "vmess://uuid@h2:443#b", "ss://pass@h3:c#t"), Utils.splitConfigEntries(blob))
+    }
+
+    @Test
+    fun test_splitConfigEntries_spaceJoined_splitsAllSchemes() {
+        val blob = buildString {
+            append("vless://uuid@1.2.3.4:443?a=1#rv1")
+            append(" vmess://uuid@5.6.7.8:443#nl2")
+            append(" trojan://u:p@9.10.11.12:443#us3")
+            append(" hysteria2://u@13.14.15.16:443?sni=x#de4")
+            append(" hy2://u@17.18.19.20:443#fr5")
+            append(" ss://c:D2@21.22.23.24:8388#jp6")
+            append(" socks4://p@25.26.27.28:1080#uk7")
+            append(" socks5://p@29.30.31.32:1080#ch8")
+            append(" socks://p@41.42.43.44:1080#bare10")
+            append(" wireguard://u@33.34.35.36:51820?pk=Q#se9")
+            append(" v2rayn://xyz@37.38.39.40:443#custom")
+        }
+        val out = Utils.splitConfigEntries(blob)
+        assertEquals(11, out.size)
+        assertTrue(out[0].startsWith("vless://"))
+        assertTrue(out[3].startsWith("hysteria2://"))
+        assertTrue(out[4].startsWith("hy2://"))
+        assertTrue(out[7].startsWith("socks5://"))
+        assertTrue(out[8].startsWith("socks://"))
+        assertTrue(out[10].startsWith("v2rayn://"))
+    }
+
+    @Test
+    fun test_splitConfigEntries_httpNotSplit_subscriptionUrlsIntact() {
+        val subBlob = "https://sub.example.com/list1 http://sub.example.com/list2"
+        val out = Utils.splitConfigEntries(subBlob)
+        assertEquals(1, out.size)
+        assertEquals(subBlob, out[0])
+    }
+
+    @Test
+    fun test_splitConfigEntries_blankTrimmed_distinctFiltered() {
+        val blob = "  vless://a@1.2.3.4:443#x\n\n  \n vless://a@1.2.3.4:443#x  \nss://b@c:1#y"
+        assertEquals(listOf("vless://a@1.2.3.4:443#x", "ss://b@c:1#y"), Utils.splitConfigEntries(blob))
+    }
+
+    @Test
+    fun test_splitConfigEntries_interspersedCommentLine_keepsConfigsSeparate() {
+        val blob = "vless://uuid@h1:443?enc=none\n# provider note\nvmess://uuid@h2:443?enc=none#b"
+        assertEquals(
+            listOf("vless://uuid@h1:443?enc=none", "# provider note", "vmess://uuid@h2:443?enc=none#b"),
+            Utils.splitConfigEntries(blob)
+        )
+        URI(Utils.fixIllegalUrl("vless://uuid@h1:443?enc=none"))
+    }
 }


### PR DESCRIPTION
Foreign subscriptions and clipboard pastes often leave raw characters in the remark (the part after `#`) that a URI can't hold: spaces, a second `#`, `|`, cyrillic, emoji. `java.net.URI` throws on those, the per-protocol parsers catch it and return null, and the whole batch of configs disappears with nothing shown to the user.

An example that gets dropped right now:

```
vless://uuid@host:443?type=grpc&security=reality#🇷🇺 Белый интернет #1 | Все операторы
```

Second problem: some panels hand configs out space-separated on one line instead of one per line. `lines()` sees that as a single entry, so everything after the first config is lost.

The fix touches two things in `Utils`:

`fixIllegalUrl` only rewrites the fragment now. Anything that isn't valid in an RFC 3986 fragment gets percent-encoded (non-ascii as utf-8), and existing `%XX` is left as-is so re-running it is a no-op. A url without `#` comes out unchanged, so subscription-url checks aren't affected. Since every uri-based protocol (vmess, vless, trojan, ss, socks, wireguard, hysteria2) goes through this, one place covers all of them.

`splitConfigEntries` replaces `lines()` on the config-import path. It splits on newlines and on whitespace before a known scheme, so both newline- and space-separated blobs end up as the same list. `http(s)://` is skipped on purpose so subscription urls stay in one piece.

Added tests in `UtilsTest` for the remark round-trip (emoji/cyrillic/inner-`#`/`|`), idempotency, a bare `%`, and the split cases. The app's own exports already percent-encode the remark, so they still round-trip fine.