### PR TITLE
fix: make service starts and restarts lifecycle-safe

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -189,7 +189,8 @@ object AppConfig {
     const val MSG_SUB_UPDATE_CANCEL = 81
 
     /** Notification channel IDs and names. */
-    const val RAY_NG_CHANNEL_ID = "CORE_M_CH_ID"
+    // Use a new ID because Android does not let an app raise an existing channel's importance.
+    const val RAY_NG_CHANNEL_ID = "CORE_M_CH_ID_V2"
     const val RAY_NG_CHANNEL_NAME = "Core Background Service"
 
     /** Protocols Scheme **/

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.core
 
+import android.app.Activity
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -117,6 +118,20 @@ object CoreServiceManager {
     /** Requests a daemon-owned restart after the running core is fully stopped. */
     fun restartVService(context: Context) {
         MessageUtil.sendMsg2Service(context, AppConfig.MSG_STATE_RESTART, "")
+    }
+
+    /**
+     * Restarts the daemon when it is running, or invokes [startIfStopped] when no daemon handled
+     * the request. The daemon acknowledgement avoids relying on stale app-process UI state.
+     */
+    fun restartVServiceOrStart(context: Context, startIfStopped: () -> Unit) {
+        MessageUtil.sendMsg2ServiceForResult(
+            context,
+            AppConfig.MSG_STATE_RESTART,
+            ""
+        ) { handled ->
+            if (!handled) startIfStopped()
+        }
     }
 
     /**
@@ -557,6 +572,9 @@ object CoreServiceManager {
 
                 AppConfig.MSG_STATE_RESTART -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart service")
+                    if (isOrderedBroadcast) {
+                        resultCode = Activity.RESULT_OK
+                    }
                     restartAfterServiceStop = true
                     serviceControl.stopService()
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -36,6 +36,7 @@ import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
@@ -50,6 +51,8 @@ object CoreServiceManager {
     private var currentConfig: ProfileItem? = null
     private var processFinder: XrayProcessFinder? = null
     private var browserDialer: IDialerService? = null
+    private var pendingCoreStop: Job? = null
+    private var restartAfterServiceStop = false
 
     var serviceControl: SoftReference<ServiceControl>? = null
         set(value) {
@@ -111,6 +114,11 @@ object CoreServiceManager {
         MessageUtil.sendMsg2Service(context, AppConfig.MSG_STATE_STOP, "")
     }
 
+    /** Requests a daemon-owned restart after the running core is fully stopped. */
+    fun restartVService(context: Context) {
+        MessageUtil.sendMsg2Service(context, AppConfig.MSG_STATE_RESTART, "")
+    }
+
     /**
      * Checks if the V2Ray service is running.
      * @return True if the service is running, false otherwise.
@@ -127,17 +135,15 @@ object CoreServiceManager {
      * Starts the context service for V2Ray.
      * Chooses between VPN service or Proxy-only service based on user settings.
      * @param context The context from which the service is started.
-     * @throws IllegalStateException if the core is already running, no server is selected,
-     *   server config cannot be decoded, or server configuration is invalid.
+     * @throws IllegalStateException if no server is selected, the server config cannot be
+     *   decoded, or the server configuration is invalid.
      * @throws Exception if the foreground service fails to start.
      */
     @Throws(Exception::class)
     private fun startContextService(context: Context) {
-        if (coreController.isRunning) {
-            LogUtil.w(AppConfig.TAG, "StartCore-Manager: Core already running")
-            return
-        }
-
+        // The app and daemon processes each have their own CoreServiceManager instance.
+        // Only the daemon can reliably decide whether this is a duplicate start, so always
+        // dispatch the command and let the selected service handle it idempotently.
         val guid = MmkvManager.getSelectServer()
             ?: run {
                 LogUtil.e(AppConfig.TAG, "StartCore-Manager: No server selected")
@@ -308,8 +314,8 @@ object CoreServiceManager {
     fun stopCoreLoop(): Boolean {
         val service = getService() ?: return false
 
-        if (coreController.isRunning) {
-            CoroutineScope(Dispatchers.IO).launch {
+        if (pendingCoreStop == null && coreController.isRunning) {
+            pendingCoreStop = CoroutineScope(Dispatchers.IO).launch {
                 try {
                     coreController.stopLoop()
                 } catch (e: Exception) {
@@ -335,6 +341,24 @@ object CoreServiceManager {
         }
 
         return true
+    }
+
+    /**
+     * Defers a requested restart until both the Android service and its asynchronous core
+     * stop have finished, so the old core cannot retain ports needed by the new instance.
+     * The detached coroutine intentionally outlives the destroyed service.
+     */
+    fun onServiceDestroyed(context: Context) {
+        val stopJob = pendingCoreStop
+        val shouldRestart = restartAfterServiceStop
+        pendingCoreStop = null
+        restartAfterServiceStop = false
+        if (!shouldRestart) return
+        val appContext = context.applicationContext
+        CoroutineScope(Dispatchers.IO).launch {
+            stopJob?.join()
+            startVService(appContext)
+        }
     }
 
     /**
@@ -533,9 +557,8 @@ object CoreServiceManager {
 
                 AppConfig.MSG_STATE_RESTART -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart service")
+                    restartAfterServiceStop = true
                     serviceControl.stopService()
-                    Thread.sleep(500L)
-                    startVService(serviceControl.getService())
                 }
 
                 AppConfig.MSG_MEASURE_DELAY -> {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -93,8 +93,8 @@ object NotificationManager {
 
         mBuilder = NotificationCompat.Builder(service, channelId)
             .setSmallIcon(R.drawable.ic_stat_name)
-            .setContentTitle(currentConfig?.remarks)
-            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setContentTitle(currentConfig?.remarks ?: service.getString(R.string.app_name))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
             .setShowWhen(false)
             .setOnlyAlertOnce(true)
@@ -113,6 +113,17 @@ object NotificationManager {
         //mBuilder?.setDefaults(NotificationCompat.FLAG_ONLY_ALERT_ONCE)
 
         service.startForeground(NOTIFICATION_ID, mBuilder?.build())
+    }
+
+    /**
+     * Fulfills or refreshes the foreground-service contract before a start command can
+     * return early. A duplicate startForegroundService call still requires the service
+     * to enter foreground state promptly, even when the core is already running.
+     */
+    fun ensureForeground() {
+        val service = getService() ?: return
+        val notification = mBuilder?.build()
+        if (notification == null) showNotification(null) else service.startForeground(NOTIFICATION_ID, notification)
     }
 
     /**
@@ -147,12 +158,9 @@ object NotificationManager {
     private fun createNotificationChannel(): String {
         val channelId = AppConfig.RAY_NG_CHANNEL_ID
         val channelName = AppConfig.RAY_NG_CHANNEL_NAME
-        val chan = NotificationChannel(
-            channelId,
-            channelName, NotificationManager.IMPORTANCE_HIGH
-        )
+        // Foreground-service notifications must remain visible; LOW is silent but valid.
+        val chan = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW)
         chan.lightColor = Color.DKGRAY
-        chan.importance = NotificationManager.IMPORTANCE_NONE
         chan.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
         getNotificationManager()?.createNotificationChannel(chan)
         return channelId

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
@@ -7,6 +7,7 @@ import android.os.IBinder
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.MyContextWrapper
@@ -30,7 +31,12 @@ class CoreProxyOnlyService : Service(), ServiceControl {
      * @return The start mode.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationManager.ensureForeground()
         LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Service command received")
+        if (CoreServiceManager.isRunning()) {
+            LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Core is already running")
+            return START_STICKY
+        }
         CoreServiceManager.startCoreLoop(null)
         return START_STICKY
     }
@@ -41,6 +47,7 @@ class CoreProxyOnlyService : Service(), ServiceControl {
     override fun onDestroy() {
         super.onDestroy()
         CoreServiceManager.stopCoreLoop()
+        CoreServiceManager.onServiceDestroyed(this)
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
@@ -7,6 +7,7 @@ import android.os.IBinder
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.root.RootProxyManager
 import com.v2ray.ang.util.LogUtil
@@ -39,7 +40,13 @@ class CoreRootService : Service(), ServiceControl {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationManager.ensureForeground()
         LogUtil.i(AppConfig.TAG, "StartCore-Root: command received")
+
+        if (CoreServiceManager.isRunning()) {
+            LogUtil.i(AppConfig.TAG, "StartCore-Root: Core is already running")
+            return START_STICKY
+        }
 
         // Start the in-process core first (this also posts the foreground notification),
         // then install the root routing off the main thread.
@@ -71,6 +78,7 @@ class CoreRootService : Service(), ServiceControl {
         // to a dead listener. Synchronous on purpose — leaving rules behind breaks the net.
         RootProxyManager.stop(this)
         CoreServiceManager.stopCoreLoop()
+        CoreServiceManager.onServiceDestroyed(this)
     }
 
     override fun getService(): Service = this

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -59,6 +59,12 @@ class CoreTestService : Service() {
      * @return The start mode.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationHelper.startForeground(
+            this,
+            NotificationChannelType.CORE_TEST,
+            getString(R.string.app_name),
+            getString(R.string.title_real_ping_all_server)
+        )
         val message = intent?.serializable<TestServiceMessage>("content")
         if (message == null) {
             stopSelf(startId)
@@ -77,13 +83,6 @@ class CoreTestService : Service() {
 
     private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
         LogUtil.i(AppConfig.TAG, "CoreTestService starting worker   subscription ${message.subscriptionId}")
-
-        NotificationHelper.startForeground(
-            this,
-            NotificationChannelType.CORE_TEST,
-            getString(R.string.app_name),
-            getString(R.string.title_real_ping_all_server)
-        )
 
         val guidsList = when {
             message.serverGuids.isNotEmpty() -> message.serverGuids

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -26,6 +26,7 @@ import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.root.RootLanSharing
 import com.v2ray.ang.util.LogUtil
+import com.v2ray.ang.util.MessageUtil
 import com.v2ray.ang.util.MyContextWrapper
 import com.v2ray.ang.util.Utils
 import java.lang.ref.SoftReference
@@ -113,29 +114,37 @@ class CoreVpnService : VpnService(), ServiceControl {
 
         unlockStart()
         NotificationManager.cancelNotification()
+        CoreServiceManager.onServiceDestroyed(this)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        // Always-on VPN restarts from OS deliver intent.action == SERVICE_INTERFACE or null intent.
-        // Reset any stuck start lock left by a killed process to allow setupVpnService() to run.
-        val isSystemVpnStart = intent == null || intent.action == SERVICE_INTERFACE
-        if (isSystemVpnStart) {
-            unlockStart()
+        NotificationManager.ensureForeground()
+        if (isRunning || CoreServiceManager.isRunning()) {
+            LogUtil.i(AppConfig.TAG, "StartCore-VPN: Core is already running")
+            return START_STICKY
         }
         if (!tryLockStart()) {
             LogUtil.w(AppConfig.TAG, "StartCore-VPN: Start already in progress")
-            return START_NOT_STICKY
+            return START_STICKY
         }
-        LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received, systemVpnStart=$isSystemVpnStart")
-        NotificationManager.showNotification(null)
-        if (!setupVpnService()) {
+        return try {
+            LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received")
+            if (!setupVpnService()) {
+                stopSelf()
+                START_NOT_STICKY
+            } else {
+                startService()
+                if (isRunning && CoreServiceManager.isRunning()) START_STICKY else START_NOT_STICKY
+            }
+        } catch (e: Exception) {
+            val message = e.message?.takeUnless { it.isBlank() } ?: e.javaClass.simpleName
+            LogUtil.e(AppConfig.TAG, "StartCore-VPN: $message", e)
+            stopAllService()
+            MessageUtil.sendMsg2UI(this, AppConfig.MSG_STATE_START_FAILURE, message)
+            START_NOT_STICKY
+        } finally {
             unlockStart()
-            // Stop service if setup fails to avoid infinite restart loops (START_STICKY)
-            stopSelf()
-            return START_NOT_STICKY
         }
-        startService()
-        return START_STICKY
     }
 
     override fun getService(): Service {
@@ -415,13 +424,13 @@ class CoreVpnService : VpnService(), ServiceControl {
         }
     }
 
-    fun tryLockStart(): Boolean {
-        LogUtil.w(AppConfig.TAG, "StartCore-VPN: tryLockStart: ${isStartingLock.get()}")
+    private fun tryLockStart(): Boolean {
+        LogUtil.d(AppConfig.TAG, "StartCore-VPN: tryLockStart: ${isStartingLock.get()}")
         return isStartingLock.compareAndSet(false, true)
     }
 
-    fun unlockStart() {
+    private fun unlockStart() {
         isStartingLock.set(false)
-        LogUtil.w(AppConfig.TAG, "StartCore-VPN: unlockStart")
+        LogUtil.d(AppConfig.TAG, "StartCore-VPN: unlockStart")
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -130,8 +130,9 @@ class CoreVpnService : VpnService(), ServiceControl {
         return try {
             LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received")
             if (!setupVpnService()) {
-                stopSelf()
+                stopSelf(startId)
                 START_NOT_STICKY
+            }
             } else {
                 startService()
                 if (isRunning && CoreServiceManager.isRunning()) START_STICKY else START_NOT_STICKY

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -132,7 +132,6 @@ class CoreVpnService : VpnService(), ServiceControl {
             if (!setupVpnService()) {
                 stopSelf(startId)
                 START_NOT_STICKY
-            }
             } else {
                 startService()
                 if (isRunning && CoreServiceManager.isRunning()) START_STICKY else START_NOT_STICKY

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
@@ -57,6 +57,12 @@ class SubscriptionUpdateService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationHelper.startForeground(
+            this,
+            NotificationChannelType.SUBSCRIPTION_UPDATE,
+            getString(R.string.title_pref_auto_update_subscription),
+            getString(R.string.app_name)
+        )
         val message = intent?.serializable<SubscriptionUpdateMessage>("content")
         if (message == null) {
             stopSelf(startId)
@@ -80,13 +86,6 @@ class SubscriptionUpdateService : Service() {
 
     private fun handleUpdateStart(message: SubscriptionUpdateMessage) {
         LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService starting update task for ${message.subIds.size} subscriptions")
-
-        NotificationHelper.startForeground(
-            this,
-            NotificationChannelType.SUBSCRIPTION_UPDATE,
-            getString(R.string.title_pref_auto_update_subscription),
-            getString(R.string.app_name)
-        )
 
         runningTasks.incrementAndGet()
         serviceScope.launch {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -191,10 +191,10 @@ class MainActivity : HelperBaseComponentActivity() {
     }
 
     private fun restartV2Ray() {
-        if (mainViewModel.uiState.value.isRunning) CoreServiceManager.stopVService(this)
-        lifecycleScope.launch {
-            kotlinx.coroutines.delay(500)
+        if (!mainViewModel.uiState.value.isRunning) {
             startV2Ray()
+        } else {
+            CoreServiceManager.restartVService(this)
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -71,13 +71,15 @@ class MainActivity : HelperBaseComponentActivity() {
             if (action != ProfileEditorResult.ACTION_SAVED &&
                 action != ProfileEditorResult.ACTION_DELETED
             ) return@registerForActivityResult
+            val changedGuid = data.getStringExtra(ProfileEditorResult.EXTRA_GUID)
+            val selectedProfileSaved =
+                action == ProfileEditorResult.ACTION_SAVED &&
+                    changedGuid == mainViewModel.uiState.value.selectedGuid
             val restartService = data.getBooleanExtra(
                 ProfileEditorResult.EXTRA_RESTART_SERVICE, false
-            )
+            ) || selectedProfileSaved
             mainViewModel.onAction(MainAction.RefreshGroups)
-            if (restartService && mainViewModel.uiState.value.isRunning) {
-                restartV2Ray()
-            }
+            if (restartService) CoreServiceManager.restartVService(this)
         }
 
     private val settingsActivityLauncher =
@@ -86,7 +88,7 @@ class MainActivity : HelperBaseComponentActivity() {
             val refreshGroups = SettingsChangeManager.consumeSetupGroupTab()
             mainViewModel.refreshUiSettings()
             if (refreshGroups) mainViewModel.onAction(MainAction.RefreshGroups)
-            if (restartService && mainViewModel.uiState.value.isRunning) restartV2Ray()
+            if (restartService) CoreServiceManager.restartVService(this)
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -108,7 +110,7 @@ class MainActivity : HelperBaseComponentActivity() {
                     MainAction.ImportClipboard -> importClipboard()
                     MainAction.ImportConfigLocal -> importConfigLocal()
                     is MainAction.ImportManually -> importManually(action.type)
-                    MainAction.RestartService -> restartV2Ray()
+                    MainAction.RestartService -> restartOrStartV2Ray()
                     MainAction.LocateSelectedServer -> mainViewModel.triggerLocateSelectedServer()
                     is MainAction.SelectServer -> setSelectServer(action.guid)
                     is MainAction.EditServer -> editServer(action.guid, action.profile)
@@ -190,12 +192,8 @@ class MainActivity : HelperBaseComponentActivity() {
         CoreServiceManager.startVService(this)
     }
 
-    private fun restartV2Ray() {
-        if (!mainViewModel.uiState.value.isRunning) {
-            startV2Ray()
-        } else {
-            CoreServiceManager.restartVService(this)
-        }
+    private fun restartOrStartV2Ray() {
+        CoreServiceManager.restartVServiceOrStart(this, ::startV2Ray)
     }
 
     private fun importManually(createConfigType: Int) {
@@ -277,7 +275,7 @@ class MainActivity : HelperBaseComponentActivity() {
         val selected = mainViewModel.uiState.value.selectedGuid
         if (guid != selected) {
             mainViewModel.updateSelectedGuid(guid)
-            if (mainViewModel.uiState.value.isRunning) restartV2Ray()
+            CoreServiceManager.restartVService(this)
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/MessageUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/MessageUtil.kt
@@ -1,5 +1,7 @@
 package com.v2ray.ang.util
 
+import android.app.Activity
+import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -24,6 +26,40 @@ object MessageUtil {
      */
     fun sendMsg2Service(ctx: Context, what: Int, content: Serializable) {
         sendMsg(ctx, AppConfig.BROADCAST_ACTION_SERVICE, what, content)
+    }
+
+    /**
+     * Sends an ordered message to the service and reports whether a running daemon handled it.
+     *
+     * The final receiver runs on the context's main thread. A missing daemon receiver leaves the
+     * initial result unchanged, allowing callers to safely choose a fallback without consulting
+     * app-process service state.
+     */
+    fun sendMsg2ServiceForResult(
+        ctx: Context,
+        what: Int,
+        content: Serializable,
+        onResult: (handled: Boolean) -> Unit
+    ) {
+        val resultReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                onResult(resultCode == Activity.RESULT_OK)
+            }
+        }
+        try {
+            ctx.sendOrderedBroadcast(
+                messageIntent(AppConfig.BROADCAST_ACTION_SERVICE, what, content),
+                null,
+                resultReceiver,
+                null,
+                Activity.RESULT_CANCELED,
+                null,
+                null
+            )
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to send ordered message to service", e)
+            onResult(false)
+        }
     }
 
     /**
@@ -114,14 +150,16 @@ object MessageUtil {
      */
     private fun sendMsg(ctx: Context, action: String, what: Int, content: Serializable) {
         try {
-            val intent = Intent()
-            intent.action = action
-            intent.`package` = AppConfig.ANG_PACKAGE
-            intent.putExtra("key", what)
-            intent.putExtra("content", content)
-            ctx.sendBroadcast(intent)
+            ctx.sendBroadcast(messageIntent(action, what, content))
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to send message with action: $action", e)
         }
     }
+
+    private fun messageIntent(action: String, what: Int, content: Serializable): Intent =
+        Intent(action).apply {
+            `package` = AppConfig.ANG_PACKAGE
+            putExtra("key", what)
+            putExtra("content", content)
+        }
 }


### PR DESCRIPTION
Extracted small part of the work I've done during TV UI development that is outside the scope of TV UI.
This is the result of trying to make the service more reliable on a low-CPU/low-memory device with aggressive optimizations.

## Problem

v2rayNG runs its UI and core services in separate processes. Each process has its own `CoreServiceManager`, so checking `coreController.isRunning` in the app process cannot reliably determine whether the core is already running in the daemon process.

This caused several related reliability problems:

- Duplicate foreground-service starts could be rejected using stale app-process state.
- An early return from `onStartCommand()` could occur before refreshing the foreground notification.
- Exceptions during VPN startup could leave the start guard locked, blocking later attempts.
- Service restart used a fixed 500 ms delay, which could start a new core before the old asynchronous core shutdown released its ports (especially on a slow hardware).
- The core foreground-service notification channel used `IMPORTANCE_NONE`, which is unsafe for a required foreground notification, especially on vendor-modified Android builds (optimizer ignored `IMPORTANCE_NONE` channel and killed the service).

## Changes

### Make duplicate starts daemon-owned

Always dispatch start requests to the selected Android service.

The VPN, proxy-only, and root services now decide whether a start is a duplicate using the core state in the daemon process, where the real `CoreController` instance lives.

Duplicate starts are treated as successful idempotent starts and return `START_STICKY` without creating a second core.

### Fulfil the foreground-service contract before early returns

Every foreground service now calls or refreshes `startForeground()` at the beginning of `onStartCommand()`:

- `CoreVpnService`
- `CoreProxyOnlyService`
- `CoreRootService`
- `CoreTestService`
- `SubscriptionUpdateService`

This includes duplicate starts, missing-message paths, and start-lock early returns.

### Always release the VPN start guard

VPN startup is wrapped in `try`/`catch`/`finally`, with the start guard released in `finally`.

This prevents setup failures, network changes, or unexpected exceptions from leaving the service permanently stuck in an “already starting” state.

Startup exceptions now also stop partial service state and report the failure to the UI.

### Replace delayed restarts with daemon-owned restart sequencing

Both UI and notification restart actions now use the same daemon-owned restart command.

The daemon:

1. Records the asynchronous core-stop job.
2. Stops the Android service.
3. Waits for the core-stop job to finish.
4. Starts the service again.

Repeated stop callbacks no longer overwrite an existing stop job.

This removes the fixed 500 ms delay and avoids restarting while the previous core still owns its ports.

### Use a valid foreground-service notification channel

The core notification now uses `IMPORTANCE_LOW` and `PRIORITY_LOW`.

A new channel ID, `CORE_M_CH_ID_V2`, is required because Android does not allow an application to raise the importance of an already-created channel that previously used `IMPORTANCE_NONE`.

The notification remains silent but visible and valid for foreground-service use.