### PR TITLE
Stabilize profile editor IME scrolling

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -3,14 +3,13 @@ package com.v2ray.ang.ui.server
 import android.os.Bundle
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -431,10 +430,10 @@ abstract class BaseServerActivity : BaseComponentActivity() {
     protected fun ServerEditorScaffold(
         title: String,
         onSaveClick: () -> Unit,
-        content: LazyListScope.() -> Unit
+        content: @Composable ColumnScope.() -> Unit
     ) {
         var showDeleteDialog by rememberSaveable { mutableStateOf(false) }
-        val listState = rememberLazyListState()
+        val scrollState = rememberScrollState()
         Scaffold(
             contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
             topBar = {
@@ -460,15 +459,15 @@ abstract class BaseServerActivity : BaseComponentActivity() {
                 )
             }
         ) { innerPadding ->
-            LazyColumn(
-                state = listState,
+            Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
                     .consumeWindowInsets(innerPadding)
                     .imePadding()
-                    .verticalScrollbar(listState),
-                contentPadding = PaddingValues(bottom = 36.dp),
+                    .verticalScroll(scrollState)
+                    .verticalScrollbar(scrollState)
+                    .padding(bottom = 36.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
                 content = content
             )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerHttpActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerHttpActivity.kt
@@ -27,8 +27,8 @@ class ServerHttpActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { HttpProtocolFields(uiState) }
+            CommonBasicFields(uiState)
+            HttpProtocolFields(uiState)
 
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerHysteria2Activity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerHysteria2Activity.kt
@@ -31,8 +31,8 @@ class ServerHysteria2Activity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState, showPort = false) }
-            item { Hysteria2ProtocolFields(uiState) }
+            CommonBasicFields(uiState, showPort = false)
+            Hysteria2ProtocolFields(uiState)
 
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerShadowsocksActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerShadowsocksActivity.kt
@@ -32,17 +32,15 @@ class ServerShadowsocksActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { ShadowsocksProtocolFields(uiState, securityOptions) }
-            item { CommonNetworkFields(uiState, options) }
-            item {
-                CommonStreamSecurityFields(
-                    state = uiState,
-                    options = options,
-                    scope = scope,
-                    buildProfileItem = { uiState.toProfileItem(initialConfig) }
-                )
-            }
+            CommonBasicFields(uiState)
+            ShadowsocksProtocolFields(uiState, securityOptions)
+            CommonNetworkFields(uiState, options)
+            CommonStreamSecurityFields(
+                state = uiState,
+                options = options,
+                scope = scope,
+                buildProfileItem = { uiState.toProfileItem(initialConfig) }
+            )
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerSocksActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerSocksActivity.kt
@@ -27,8 +27,8 @@ class ServerSocksActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { SocksProtocolFields(uiState) }
+            CommonBasicFields(uiState)
+            SocksProtocolFields(uiState)
 
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerTrojanActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerTrojanActivity.kt
@@ -30,17 +30,15 @@ class ServerTrojanActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { TrojanProtocolFields(uiState) }
-            item { CommonNetworkFields(uiState, options) }
-            item {
-                CommonStreamSecurityFields(
-                    state = uiState,
-                    options = options,
-                    scope = scope,
-                    buildProfileItem = { uiState.toProfileItem(initialConfig) }
-                )
-            }
+            CommonBasicFields(uiState)
+            TrojanProtocolFields(uiState)
+            CommonNetworkFields(uiState, options)
+            CommonStreamSecurityFields(
+                state = uiState,
+                options = options,
+                scope = scope,
+                buildProfileItem = { uiState.toProfileItem(initialConfig) }
+            )
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerVlessActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerVlessActivity.kt
@@ -33,17 +33,15 @@ class ServerVlessActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { VlessProtocolFields(uiState, flowOptions) }
-            item { CommonNetworkFields(uiState, options) }
-            item {
-                CommonStreamSecurityFields(
-                    state = uiState,
-                    options = options,
-                    scope = scope,
-                    buildProfileItem = { uiState.toProfileItem(initialConfig) }
-                )
-            }
+            CommonBasicFields(uiState)
+            VlessProtocolFields(uiState, flowOptions)
+            CommonNetworkFields(uiState, options)
+            CommonStreamSecurityFields(
+                state = uiState,
+                options = options,
+                scope = scope,
+                buildProfileItem = { uiState.toProfileItem(initialConfig) }
+            )
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerVmessActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerVmessActivity.kt
@@ -33,17 +33,15 @@ class ServerVmessActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { VmessProtocolFields(uiState, securityOptions) }
-            item { CommonNetworkFields(uiState, options) }
-            item {
-                CommonStreamSecurityFields(
-                    state = uiState,
-                    options = options,
-                    scope = scope,
-                    buildProfileItem = { uiState.toProfileItem(initialConfig) }
-                )
-            }
+            CommonBasicFields(uiState)
+            VmessProtocolFields(uiState, securityOptions)
+            CommonNetworkFields(uiState, options)
+            CommonStreamSecurityFields(
+                state = uiState,
+                options = options,
+                scope = scope,
+                buildProfileItem = { uiState.toProfileItem(initialConfig) }
+            )
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerWireguardActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerWireguardActivity.kt
@@ -28,8 +28,8 @@ class ServerWireguardActivity : BaseServerActivity() {
             title = serverConfigType.toString(),
             onSaveClick = { saveServer(uiState) }
         ) {
-            item { CommonBasicFields(uiState) }
-            item { WireguardProtocolFields(uiState) }
+            CommonBasicFields(uiState)
+            WireguardProtocolFields(uiState)
 
         }
     }


### PR DESCRIPTION
## Summary

- Replace the profile editor's `LazyColumn` with a vertically scrollable `Column`.
- Change `ServerEditorScaffold` from a `LazyListScope` content API to a composable `ColumnScope` and remove the now-unnecessary `item {}` wrappers from the eight protocol editors.
- Preserve the existing field spacing, IME padding, scrollbar, and bottom padding.

## Why

These server edit screens are bounded configuration forms, not unbounded or dynamically paged data lists. They render a modest, fixed number of inexpensive fields and therefore do not materially benefit from `LazyList` virtualization.

Keeping the whole form composed also gives its focused field a stable place in the layout while the on-screen keyboard changes the available height. This is particularly important for lower and multiline fields that need to remain visible during editing.

## Root cause

With a `LazyColumn`, keyboard-driven viewport changes can repeatedly remeasure lazy item boundaries or detach and reattach item content. That can make the focused field's position unstable, producing visible scrolling jitter or leaving the field partially obscured by the IME, requiring fragile workarounds to counteract that.

Using one scrollable `Column` keeps the bounded form hierarchy continuously composed while normal scrolling and IME padding adjust the viewport.

## Impact

There is no intended visual or data-model change. The tradeoff is eager composition of the profile form, which is appropriate here because each screen contains only a limited number of lightweight fields.
