### PR TITLE
Fulfill foreground service notification contract

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -189,7 +189,8 @@ object AppConfig {
     const val MSG_SUB_UPDATE_CANCEL = 81
 
     /** Notification channel IDs and names. */
-    const val RAY_NG_CHANNEL_ID = "CORE_M_CH_ID"
+    // Use a new ID because Android does not let an app raise an existing channel's importance.
+    const val RAY_NG_CHANNEL_ID = "CORE_M_CH_ID_V2"
     const val RAY_NG_CHANNEL_NAME = "Core Background Service"
 
     /** Protocols Scheme **/

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -93,8 +93,8 @@ object NotificationManager {
 
         mBuilder = NotificationCompat.Builder(service, channelId)
             .setSmallIcon(R.drawable.ic_stat_name)
-            .setContentTitle(currentConfig?.remarks)
-            .setPriority(NotificationCompat.PRIORITY_MIN)
+            .setContentTitle(currentConfig?.remarks ?: service.getString(R.string.app_name))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
             .setShowWhen(false)
             .setOnlyAlertOnce(true)
@@ -113,6 +113,17 @@ object NotificationManager {
         //mBuilder?.setDefaults(NotificationCompat.FLAG_ONLY_ALERT_ONCE)
 
         service.startForeground(NOTIFICATION_ID, mBuilder?.build())
+    }
+
+    /**
+     * Fulfills or refreshes the foreground-service contract before a start command can
+     * return early. A duplicate startForegroundService call still requires the service
+     * to enter foreground state promptly, even when the core is already running.
+     */
+    fun ensureForeground() {
+        val service = getService() ?: return
+        val notification = mBuilder?.build()
+        if (notification == null) showNotification(null) else service.startForeground(NOTIFICATION_ID, notification)
     }
 
     /**
@@ -147,12 +158,9 @@ object NotificationManager {
     private fun createNotificationChannel(): String {
         val channelId = AppConfig.RAY_NG_CHANNEL_ID
         val channelName = AppConfig.RAY_NG_CHANNEL_NAME
-        val chan = NotificationChannel(
-            channelId,
-            channelName, NotificationManager.IMPORTANCE_HIGH
-        )
+        // Foreground-service notifications must remain visible; LOW is silent but valid.
+        val chan = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW)
         chan.lightColor = Color.DKGRAY
-        chan.importance = NotificationManager.IMPORTANCE_NONE
         chan.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
         getNotificationManager()?.createNotificationChannel(chan)
         return channelId

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
@@ -7,6 +7,7 @@ import android.os.IBinder
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.MyContextWrapper
@@ -30,6 +31,7 @@ class CoreProxyOnlyService : Service(), ServiceControl {
      * @return The start mode.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationManager.ensureForeground()
         LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Service command received")
 
         if (!CoreServiceManager.startCoreLoop(null)) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
@@ -7,6 +7,7 @@ import android.os.IBinder
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.core.CoreServiceManager
+import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.root.RootProxyManager
 import com.v2ray.ang.util.LogUtil
@@ -39,6 +40,7 @@ class CoreRootService : Service(), ServiceControl {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationManager.ensureForeground()
         LogUtil.i(AppConfig.TAG, "StartCore-Root: command received")
 
         // Start the in-process core first (this also posts the foreground notification),

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -59,6 +59,12 @@ class CoreTestService : Service() {
      * @return The start mode.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationHelper.startForeground(
+            this,
+            NotificationChannelType.CORE_TEST,
+            getString(R.string.app_name),
+            getString(R.string.title_real_ping_all_server)
+        )
         val message = intent?.serializable<TestServiceMessage>("content")
         if (message == null) {
             stopSelf(startId)
@@ -77,13 +83,6 @@ class CoreTestService : Service() {
 
     private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
         LogUtil.i(AppConfig.TAG, "CoreTestService starting worker   subscription ${message.subscriptionId}")
-
-        NotificationHelper.startForeground(
-            this,
-            NotificationChannelType.CORE_TEST,
-            getString(R.string.app_name),
-            getString(R.string.title_real_ping_all_server)
-        )
 
         val guidsList = when {
             message.serverGuids.isNotEmpty() -> message.serverGuids

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -116,6 +116,7 @@ class CoreVpnService : VpnService(), ServiceControl {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationManager.ensureForeground()
         // Always-on VPN restarts from OS deliver intent.action == SERVICE_INTERFACE or null intent.
         // Reset any stuck start lock left by a killed process to allow setupVpnService() to run.
         val isSystemVpnStart = intent == null || intent.action == SERVICE_INTERFACE
@@ -127,7 +128,6 @@ class CoreVpnService : VpnService(), ServiceControl {
             return START_NOT_STICKY
         }
         LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received, systemVpnStart=$isSystemVpnStart")
-        NotificationManager.showNotification(null)
         if (!setupVpnService()) {
             unlockStart()
             // Stop service if setup fails to avoid infinite restart loops (START_STICKY)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
@@ -57,6 +57,12 @@ class SubscriptionUpdateService : Service() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        NotificationHelper.startForeground(
+            this,
+            NotificationChannelType.SUBSCRIPTION_UPDATE,
+            getString(R.string.title_pref_auto_update_subscription),
+            getString(R.string.app_name)
+        )
         val message = intent?.serializable<SubscriptionUpdateMessage>("content")
         if (message == null) {
             stopSelf(startId)
@@ -80,13 +86,6 @@ class SubscriptionUpdateService : Service() {
 
     private fun handleUpdateStart(message: SubscriptionUpdateMessage) {
         LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService starting update task for ${message.subIds.size} subscriptions")
-
-        NotificationHelper.startForeground(
-            this,
-            NotificationChannelType.SUBSCRIPTION_UPDATE,
-            getString(R.string.title_pref_auto_update_subscription),
-            getString(R.string.app_name)
-        )
 
         runningTasks.incrementAndGet()
         serviceScope.launch {


### PR DESCRIPTION
## Summary

This PR extracts the foreground-notification lifecycle fixes from #5967, as requested in the review of that PR.

It makes every foreground service establish or refresh its foreground notification before `onStartCommand()` can return early, and changes the core notification channel from hidden `IMPORTANCE_NONE` to silent but valid `IMPORTANCE_LOW`.

## Why this is necessary

Android foreground-service startup has two parts: the app calls `startForegroundService()`, then the service must promptly call `startForeground()` with a valid notification. Android also requires foreground-service notifications to use `PRIORITY_LOW` or higher.

Several existing paths could return before that happened:

- VPN startup could exit because another start was already in progress.
- Proxy-only and root startup could fail before the core posted its notification.
- Test and subscription-update services parsed and dispatched their command before entering foreground state, including missing or unsupported command paths.

The core channel was also created with `IMPORTANCE_NONE`, and the pre-Android 8 notification used `PRIORITY_MIN`. Both rank below the documented level for a foreground-service notification.

This matters particularly on some Android TV firmware with aggressive background-process and memory management. These systems may treat a process without a credible foreground-service notification as unimportant and kill it under pressure, interrupting an active VPN connection. This change does not attempt to bypass vendor power-management policy; it makes v2rayNG consistently present the standards-compliant foreground signal that the OS and vendor optimizers are expected to recognize.

Android guidance: https://developer.android.com/develop/background-work/services/fgs/launch

## Changes

- Add `NotificationManager.ensureForeground()` to reuse the current notification or create the initial fallback notification.
- Call or refresh foreground state at the beginning of every relevant `onStartCommand()`:
  - `CoreVpnService`
  - `CoreProxyOnlyService`
  - `CoreRootService`
  - `CoreTestService`
  - `SubscriptionUpdateService`
- Use `IMPORTANCE_LOW` and `PRIORITY_LOW`, which remain silent while meeting the foreground-notification requirement.
- Use the app name when no profile remark is available.
- Use a new channel ID because Android does not allow an app to raise the importance of an already-created notification channel.

## Scope

This PR contains only notification and foreground-service lifecycle changes. It deliberately excludes the daemon restart coordination, duplicate-core handling, and VPN start-lock recovery from #5967.

## Validation

- `:app:compilePlaystoreDebugKotlin`

