### PR TITLE
Allow cancelling batch tests from the status bar

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -35,6 +35,7 @@ import com.v2ray.ang.ui.compose.colorFabInactiveLight
 fun MainBottomBar(
     displayText: String,
     isRunning: Boolean,
+    isTesting: Boolean,
     isDarkTheme: Boolean,
     onAction: (MainAction) -> Unit
 ) {
@@ -46,7 +47,7 @@ fun MainBottomBar(
                     .fillMaxWidth()
                     .windowInsetsPadding(WindowInsets.navigationBars)
                     .height(64.dp)
-                    .clickable(onClick = { onAction(MainAction.TestCurrentServer) }),
+                    .clickable { onAction(if (isTesting) MainAction.CancelTesting else MainAction.TestCurrentServer) },
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 0.dp
             ) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -35,7 +35,7 @@ import com.v2ray.ang.ui.compose.colorFabInactiveLight
 fun MainBottomBar(
     displayText: String,
     isRunning: Boolean,
-    isTesting: Boolean,
+    isBatchTesting: Boolean,
     isDarkTheme: Boolean,
     onAction: (MainAction) -> Unit
 ) {
@@ -47,7 +47,7 @@ fun MainBottomBar(
                     .fillMaxWidth()
                     .windowInsetsPadding(WindowInsets.navigationBars)
                     .height(64.dp)
-                    .clickable { onAction(if (isTesting) MainAction.CancelTesting else MainAction.TestCurrentServer) },
+                    .clickable { onAction(if (isBatchTesting) MainAction.CancelTesting else MainAction.TestCurrentServer) },
                 color = MaterialTheme.colorScheme.surface,
                 tonalElevation = 0.dp
             ) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -11,7 +11,7 @@ data class MainUiState(
     val selectedGroupId: String = "",
     val selectedGuid: String? = null,
     val isRunning: Boolean = false,
-    val isTesting: Boolean = false,
+    val isBatchTesting: Boolean = false,
     val statusText: String = "",
     val locateTarget: LocateTarget? = null,
     val confirmRemove: Boolean = false,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -226,6 +226,7 @@ fun MainScreen(
                 MainBottomBar(
                     displayText = displayText,
                     isRunning = isRunning,
+                    isTesting = uiState.isTesting,
                     isDarkTheme = isDarkTheme,
                     onAction = onAction
                 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -226,7 +226,7 @@ fun MainScreen(
                 MainBottomBar(
                     displayText = displayText,
                     isRunning = isRunning,
-                    isTesting = uiState.isTesting,
+                    isBatchTesting = uiState.isBatchTesting,
                     isDarkTheme = isDarkTheme,
                     onAction = onAction
                 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -129,7 +129,7 @@ class MainViewModel(
             }
 
             is MainServiceEvent.MeasureConfigNotify -> {
-                if (!uiState.value.isTesting) return
+                if (!uiState.value.isBatchTesting) return
                 _uiState.update {
                     it.copy(
                         statusText = dataSource.getString(
@@ -667,7 +667,7 @@ class MainViewModel(
         testingGroupId = null
         _uiState.update {
             it.copy(
-                isTesting = false,
+                isBatchTesting = false,
                 statusText = if (it.isRunning) connectedText else disconnectedText
             )
         }
@@ -679,13 +679,13 @@ class MainViewModel(
         val servers = currentServers()
         dataSource.clearAllTestDelayResults(servers.map { it.guid })
         if (servers.isEmpty()) {
-            _uiState.update { it.copy(isTesting = false) }
+            _uiState.update { it.copy(isBatchTesting = false) }
             return
         }
         testingGroupId = groupId
         _uiState.update {
             it.copy(
-                isTesting = true,
+                isBatchTesting = true,
                 statusText = dataSource.getString(R.string.connection_test_testing_tap_to_stop)
             )
         }
@@ -717,7 +717,7 @@ class MainViewModel(
             testingGroupId = null
             _uiState.update {
                 it.copy(
-                    isTesting = false,
+                    isBatchTesting = false,
                     statusText = if (it.isRunning) connectedText else disconnectedText
                 )
             }
@@ -754,7 +754,7 @@ class MainViewModel(
         _uiState.update { state ->
             state.copy(
                 isRunning = running,
-                statusText = if (!clearTestingText && state.isTesting) state.statusText
+                statusText = if (!clearTestingText && state.isBatchTesting) state.statusText
                 else if (running) connectedText else disconnectedText
             )
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -129,10 +129,11 @@ class MainViewModel(
             }
 
             is MainServiceEvent.MeasureConfigNotify -> {
+                if (!uiState.value.isTesting) return
                 _uiState.update {
                     it.copy(
                         statusText = dataSource.getString(
-                            R.string.connection_runing_task_left,
+                            R.string.connection_running_tasks_tap_to_stop,
                             event.progress
                         )
                     )
@@ -685,7 +686,7 @@ class MainViewModel(
         _uiState.update {
             it.copy(
                 isTesting = true,
-                statusText = dataSource.getString(R.string.connection_test_testing)
+                statusText = dataSource.getString(R.string.connection_test_testing_tap_to_stop)
             )
         }
         viewModelScope.launch(ioDispatcher) {

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -359,6 +359,7 @@
 
     <string name="connection_test_pending">التحقق من الاتصال</string>
     <string name="connection_test_testing">يجري الاختبار…</string>
+    <string name="connection_test_testing_tap_to_stop">يجري الاختبار… انقر للإيقاف</string>
     <string name="connection_test_testing_count">Testing %d configurations…</string>
     <string name="connection_test_available">نجاح: استغرق اتصال HTTP %dms</string>
     <string name="connection_test_error">فشل اكتشاف اتصال الإنترنت: %s</string>
@@ -367,6 +368,7 @@
     <string name="connection_connected">متصل، انقر للتحقق من الاتصال</string>
     <string name="connection_not_connected">غير متصل</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">عدد مهام الاختبار قيد التشغيل: %s. انقر للإيقاف</string>
 
     <string name="import_subscription_success">تم استيراد الاشتراك بنجاح</string>
     <string name="import_subscription_failure">فشل استيراد الاشتراك</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -358,6 +358,7 @@
 
     <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
     <string name="connection_test_testing">পরীক্ষা চলছে…</string>
+    <string name="connection_test_testing_tap_to_stop">পরীক্ষা চলছে… থামাতে ট্যাপ করুন</string>
     <string name="connection_test_testing_count">Testing %d configurations…</string>
     <string name="connection_test_available">সফল: HTTP সংযোগ নিয়েছে %dms</string>
     <string name="connection_test_error">ইন্টারনেট সংযোগ সনাক্ত করতে ব্যর্থ: %s</string>
@@ -366,6 +367,7 @@
     <string name="connection_connected">সংযুক্ত, সংযোগ পরীক্ষা করতে ট্যাপ করুন</string>
     <string name="connection_not_connected">সংযুক্ত নয়</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">চলমান পরীক্ষার কাজের সংখ্যা: %s। থামাতে ট্যাপ করুন</string>
 
     <string name="import_subscription_success">সাবস্ক্রিপশন সফলভাবে আমদানি করা হয়েছে</string>
     <string name="import_subscription_failure">সাবস্ক্রিপশন আমদানি ব্যর্থ</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -364,6 +364,7 @@
 
     <string name="connection_test_pending">منپیزن واجۊری کوݩ</string>
     <string name="connection_test_testing">هونی آزمایش ابۊ…</string>
+    <string name="connection_test_testing_tap_to_stop">هونی آزمایش ابۊ… برای توقف ضربه بزنید</string>
     <string name="connection_test_testing_count">%d کانفیگ هونی آزمایش ابۊ...</string>
     <string name="connection_test_available">مووفق بی: منپیز %dms تۊل کشی</string>
     <string name="connection_test_error">منپیز و اینترنتن نجوست: %s</string>
@@ -372,6 +373,7 @@
     <string name="connection_connected">منپیز هڌ، سی واجۊری کیلیک کوݩ</string>
     <string name="connection_not_connected">منپیز نؽڌ</string>
     <string name="connection_runing_task_left">تعداد وزیفه یل آزمایشی ک ره اۊفتانه: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">تعداد وزیفه یل آزمایشی ک ره اۊفتانه: %s. برای توقف ضربه بزنید</string>
 
     <string name="import_subscription_success">اشتراک وا مووفقیت زفت وابی</string>
     <string name="import_subscription_failure">اشتراک زفت نوابی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -355,6 +355,7 @@
 
     <string name="connection_test_pending">اتصال را بررسی کنید</string>
     <string name="connection_test_testing">در حال آزمایش...</string>
+    <string name="connection_test_testing_tap_to_stop">در حال آزمایش… برای توقف ضربه بزنید</string>
     <string name="connection_test_testing_count">تست کردن %d کانفیگ…</string>
     <string name="connection_test_available">موفقیت: اتصال %dms طول کشید</string>
     <string name="connection_test_error">اتصال به اینترنت شناسایی نشد: %s</string>
@@ -363,6 +364,7 @@
     <string name="connection_connected">متصل است، برای بررسی اتصال ضربه بزنید</string>
     <string name="connection_not_connected">متصل نیست</string>
     <string name="connection_runing_task_left">تعداد وظایف آزمایشی در حال اجرا: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">تعداد وظایف آزمایشی در حال اجرا: %s. برای توقف ضربه بزنید</string>
 
     <string name="import_subscription_success">اشتراک با موفقیت ذخیره شد</string>
     <string name="import_subscription_failure">ذخیره اشتراک ناموفق بود</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -370,6 +370,7 @@
 
     <string name="connection_test_pending">Проверить соединение</string>
     <string name="connection_test_testing">Проверка…</string>
+    <string name="connection_test_testing_tap_to_stop">Проверка… Нажмите, чтобы остановить</string>
     <string name="connection_test_testing_count">Проверка профилей (%d)</string>
     <string name="connection_test_available">Успешно: соединение заняло %d мс</string>
     <string name="connection_test_error">Сбой проверки интернет-соединения: %s</string>
@@ -378,6 +379,7 @@
     <string name="connection_connected">Соединено, нажмите для проверки</string>
     <string name="connection_not_connected">Нет соединения</string>
     <string name="connection_runing_task_left">Запущено проверок: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">Запущено проверок: %s. Нажмите, чтобы остановить</string>
 
     <string name="import_subscription_success">Подписка импортирована</string>
     <string name="import_subscription_failure">Невозможно импортировать подписку</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -359,6 +359,7 @@
 
     <string name="connection_test_pending">Kiểm tra kết nối</string>
     <string name="connection_test_testing">Đang kiểm tra kết nối mạng...</string>
+    <string name="connection_test_testing_tap_to_stop">Đang kiểm tra… Nhấn để dừng</string>
     <string name="connection_test_testing_count">Testing %d configurations…</string>
     <string name="connection_test_available">Kiểm tra thành công: thời gian truy cập Google là %d ms</string>
     <string name="connection_test_error">Lỗi kết nối mạng, hãy thử đổi cấu hình hoặc kiểm tra lại! Mã lỗi: %s</string>
@@ -367,6 +368,7 @@
     <string name="connection_connected">Đã kết nối, nhấn để kiểm tra kết nối mạng!</string>
     <string name="connection_not_connected">Chưa kết nối</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">Số tác vụ kiểm tra đang chạy: %s. Nhấn để dừng</string>
 
     <string name="import_subscription_success">Nhập gói đăng ký thành công!</string>
     <string name="import_subscription_failure">Nhập gói đăng ký không thành công!</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -372,6 +372,7 @@
 
     <string name="connection_test_pending">"检查网络连接"</string>
     <string name="connection_test_testing">"测试中…"</string>
+    <string name="connection_test_testing_tap_to_stop">测试中… 点按可停止</string>
     <string name="connection_test_testing_count">测试 %d 个配置中…</string>
     <string name="connection_test_available">"连接成功：延时 %d 毫秒"</string>
     <string name="connection_test_error">"失败：%s"</string>
@@ -380,6 +381,7 @@
     <string name="connection_connected">"已连接，点击测试连接"</string>
     <string name="connection_not_connected">"未连接"</string>
     <string name="connection_runing_task_left">运行中的测试任务数：%s</string>
+    <string name="connection_running_tasks_tap_to_stop">运行中的测试任务数：%s。点按可停止</string>
 
     <string name="import_subscription_success">订阅导入成功</string>
     <string name="import_subscription_failure">导入订阅失败</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -370,6 +370,7 @@
 
     <string name="connection_test_pending">"測試連線能力"</string>
     <string name="connection_test_testing">"測試中……"</string>
+    <string name="connection_test_testing_tap_to_stop">測試中… 輕觸可停止</string>
     <string name="connection_test_testing_count">測試 %d 個配置中…</string>
     <string name="connection_test_available">"成功：%d ms延遲"</string>
     <string name="connection_test_error">"測試網際網路連線失敗：%s"</string>
@@ -378,6 +379,7 @@
     <string name="connection_connected">"已連線，輕觸以檢查連線能力"</string>
     <string name="connection_not_connected">"未連線"</string>
     <string name="connection_runing_task_left">運行中的測試任務數：%s</string>
+    <string name="connection_running_tasks_tap_to_stop">執行中的測試工作數：%s。輕觸可停止</string>
 
     <string name="import_subscription_success">匯入訂閱成功</string>
     <string name="import_subscription_failure">匯入訂閱失敗</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -379,6 +379,7 @@
 
     <string name="connection_test_pending">Check Connectivity</string>
     <string name="connection_test_testing">Testing…</string>
+    <string name="connection_test_testing_tap_to_stop">Testing… Tap to stop</string>
     <string name="connection_test_testing_count">Testing %d configs…</string>
     <string name="connection_test_available">Success: Connection took %dms</string>
     <string name="connection_test_error">Fail to detect internet connection: %s</string>
@@ -387,6 +388,7 @@
     <string name="connection_connected">Connected, tap to check connection</string>
     <string name="connection_not_connected">Not connected</string>
     <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_tasks_tap_to_stop">Number of running test tasks: %s. Tap to stop</string>
 
     <string name="import_subscription_success">Subscription imported Successfully</string>
     <string name="import_subscription_failure">Import subscription failed</string>


### PR DESCRIPTION
## Summary

- make the bottom status area cancel an active batch latency test instead of starting a current-server connectivity check
- show live test-task progress together with a localized “Tap to stop” hint
- ignore queued progress updates after cancellation so the normal connection status remains visible
- add the new status text to every existing locale

## Why

Issue #5979 describes accidentally starting **Real delay config** for very large profile groups, with no obvious way to stop the lengthy operation.

The test service and view model already supported cancellation, but the bottom status area always dispatched `TestCurrentServer`. This change uses the existing `isTesting` state to route that same status-area tap to `CancelTesting` only while a batch test is active. Normal status taps keep their current connectivity-check behavior.

This addresses the cancellable batch-test part of #5979 without changing how latency tests are scheduled or executed.