### PR TITLE
fix(speed): resolve 0 B/s speed notification counters for custom subscription profiles

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -86,6 +86,7 @@ object CoreConfigManager {
 
         val json = JsonUtil.parseString(raw)?.takeIf { it.isJsonObject }?.asJsonObject ?: return result
 
+        // Inject or remove traffic statistics configuration based on user preference
         if (MmkvManager.decodeSettingsBool(AppConfig.PREF_SPEED_ENABLED) == true) {
             if (!json.has("stats")) {
                 json.add("stats", JsonObject())

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.core
 import android.content.Context
 import android.text.TextUtils
 import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.dto.ConfigResult
 import com.v2ray.ang.dto.CoreConfigContext
@@ -82,11 +83,29 @@ object CoreConfigManager {
         val raw = MmkvManager.decodeServerRaw(configContext.guid)
             ?: return ConfigResult(status = false, guid = configContext.guid, errorMessage = "Custom config is empty")
         val result = ConfigResult(true, configContext.guid, raw)
-        if (!needTun()) {
-            return result
-        }
 
         val json = JsonUtil.parseString(raw)?.takeIf { it.isJsonObject }?.asJsonObject ?: return result
+
+        if (MmkvManager.decodeSettingsBool(AppConfig.PREF_SPEED_ENABLED) == true) {
+            if (!json.has("stats")) {
+                json.add("stats", JsonObject())
+            }
+            if (!json.has("policy")) {
+                val policyObj = JsonObject()
+                val systemObj = JsonObject()
+                systemObj.addProperty("statsOutboundUplink", true)
+                systemObj.addProperty("statsOutboundDownlink", true)
+                policyObj.add("system", systemObj)
+                json.add("policy", policyObj)
+            }
+        } else {
+            json.remove("stats")
+            json.remove("policy")
+        }
+
+        if (!needTun()) {
+            return JsonUtil.toJsonPretty(json)?.let { ConfigResult(true, configContext.guid, it) } ?: result
+        }
 
         // Check whether package names need to be replaced with UIDs
         if (SettingsManager.canUseProcessRouting()) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -240,7 +240,7 @@ object NotificationManager {
                     }
                 }
 
-                stat.tag.startsWith(AppConfig.TAG_PROXY) -> {
+                stat.tag != AppConfig.TAG_BLOCKED -> {
                     when (stat.direction) {
                         AppConfig.UPLINK -> proxyUplink += stat.value
                         AppConfig.DOWNLINK -> proxyDownlink += stat.value

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/NotificationManager.kt
@@ -240,6 +240,7 @@ object NotificationManager {
                     }
                 }
 
+                // Accumulate stats for all proxy outbounds (including custom subscription tags)
                 stat.tag != AppConfig.TAG_BLOCKED -> {
                     when (stat.direction) {
                         AppConfig.UPLINK -> proxyUplink += stat.value


### PR DESCRIPTION
### Summary of Problem
When the **"Show speed"** option (`PREF_SPEED_ENABLED`) is enabled in Settings, the notification widget speed counters for download/upload remain at **0 B/s** when connected using imported custom subscription profiles (`EConfigType.CUSTOM`).

#### Root Causes:
1. **Outbound Tag Filtering Mismatch**: `NotificationManager.kt` hardcoded the proxy tag filter to `stat.tag.startsWith(AppConfig.TAG_PROXY)` ("proxy"). Custom subscription profiles retain custom outbound tag names (e.g., `"node-1"`, `"vless-hk"`, `"auto"`), causing all traffic stats for custom outbounds to be ignored by the filter.
2. **Missing Stats Configuration in Custom Configs**: `CoreConfigManager.buildV2rayCustomConfig()` did not inject `"stats": {}` and `"policy": { "system": { "statsOutboundUplink": true, "statsOutboundDownlink": true } }` into custom JSON objects when `PREF_SPEED_ENABLED` was enabled.

---

### Changes Proposed

1. **`NotificationManager.kt`**:
   - Updated outbound traffic stat tag check from `stat.tag.startsWith(AppConfig.TAG_PROXY)` to `stat.tag != AppConfig.TAG_BLOCKED`.
   - All active non-direct and non-blocked outbound tags are now correctly accumulated into proxy uplink / downlink speed counters.

2. **`CoreConfigManager.kt`**:
   - Modified `buildV2rayCustomConfig()` to inject `stats` and `policy` system configuration into custom JSON configs when `PREF_SPEED_ENABLED == true`, and strip them when `false` (for both TUN and Proxy-Only modes).

---

### Testing & Verification
- Tested locally and verified on an Android device running v2.2.6 with custom subscription profiles.
- Notification widget now accurately displays non-zero upload/download speeds for all custom subscription outbounds.

> **Note for Fork Testers**: When running GitHub Actions (`build.yml`) in a fork without keystore secrets (`APP_KEYSTORE_BASE64`), temporary workflow adjustments to assemble debug builds (`./gradlew assembleFdroidDebug assemblePlaystoreDebug`) can be used for artifact testing.