### PR TITLE
fix: tunnel dying some time after a network handover

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -250,7 +250,7 @@ object CoreServiceManager {
         if (!isRunning()) return false
 
         return try {
-            val tunFd = tunFdForCore()
+            val tunFd = currentVpnInterface
 
             isReloading = true
             LogUtil.i(AppConfig.TAG, "StartCore-Manager: Core reload start...")
@@ -267,23 +267,6 @@ object CoreServiceManager {
             false
         } finally {
             isReloading = false
-        }
-    }
-
-    /**
-     * Returns the tun descriptor to hand to the core on a reload.
-     *
-     * With hev-socks5-tunnel the core is started without a tun and never touches the descriptor.
-     * Otherwise it closes the one it was given when it stops, which would take the VPN interface
-     * down, so it gets a duplicate to close instead.
-     */
-    private fun tunFdForCore(): ParcelFileDescriptor? {
-        val vpnInterface = currentVpnInterface ?: return null
-        return try {
-            if (SettingsManager.isUsingHevTun()) vpnInterface else vpnInterface.dup()
-        } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to duplicate VPN interface", e)
-            throw e
         }
     }
 


### PR DESCRIPTION
Introduced in my last commit `tunFdForCore()` hands the core `vpnInterface.dup()` on the premise that the core closes the descriptor it was given and would otherwise take the VPN interface down. That premise does not hold. In the pinned xray-core, `AndroidTun.Close()` (`proxy/tun/tun_android.go`) returns `nil` without touching the fd and the gVisor `fdbased` endpoint it is passed to has an empty `Close()` reading stops through `Attach(nil)` → `dispatcher.Stop()` → `Wait()`. Nothing closes it so the duplicate just becomes a `ParcelFileDescriptor` nobody keeps a reference to and its finalizer performs the only close that fd ever gets at whatever point the GC runs, on a descriptor the running core is still dispatching on. From then on nothing arrives from the tun and every app hangs while the core stays up and only restarting the service recovers. Because the timing is the GC's the failure is not aligned with the handover that caused it which is what makes it hard to trace