### PR TITLE
feat: force disable skip certificate verification for subscription nodes

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -193,6 +193,10 @@ object AngConfigManager {
             updateConfigViaSubAll()
         }
 
+        if (count > 0) {
+            forceDisableInsecure(subid)
+        }
+
         return count to countSub
     }
 
@@ -298,6 +302,24 @@ object AngConfigManager {
         // Write serverList once
         MmkvManager.encodeServerList(serverList, subid)
         return keyToProfile
+    }
+
+    /**
+     * Force-disables the "skip certificate verification" flag for every node in a subscription.
+     * Only writes back nodes whose insecure is currently true (no redundant IO).
+     * CUSTOM nodes are skipped because their runtime config comes from raw JSON.
+     *
+     * @param subId The subscription ID.
+     */
+    private fun forceDisableInsecure(subId: String) {
+        MmkvManager.decodeServerList(subId).forEach { guid ->
+            val profile = MmkvManager.decodeServerConfig(guid) ?: return@forEach
+            if (profile.configType == EConfigType.CUSTOM) return@forEach
+            if (profile.insecure == true) {
+                profile.insecure = false
+                MmkvManager.encodeProfileDirect(guid, JsonUtil.toJson(profile))
+            }
+        }
     }
 
     /**
@@ -601,6 +623,7 @@ object AngConfigManager {
             if (count > 0) {
                 it.subscription.lastUpdated = System.currentTimeMillis()
                 MmkvManager.encodeSubscription(it.guid, it.subscription)
+                forceDisableInsecure(it.guid)
                 LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")
                 return SubscriptionUpdateResult(
                     configCount = count,


### PR DESCRIPTION
## Background

Xray-core v26.2.6 removed the `allowInsecure` TLS parameter and migrated it to `pinnedPeerCertSha256` (see [discussion #9460](https://github.com/2dust/v2rayN/discussions/9460)).

Since **June 1, 2026**, any subscription node config that still contains `allowInsecure: true` without certificate pinning causes the Xray core to **fail to start** with:

```
The feature "allowInsecure" has been removed and migrated to "pinnedPeerCertSha256".
Please update your config(s) according to release note and documentation.
```

Keeping `allowInsecure: true` also disables TLS certificate verification entirely, exposing users to MITM attacks.

## Change

This PR adds `forceDisableInsecure()` which is invoked after each subscription update. It:
- Iterates all nodes in the subscription
- Skips `CUSTOM` type nodes (their runtime config comes from raw JSON)
- Sets `insecure = false` on any node currently carrying `insecure: true`
- Writes back only changed nodes (no redundant I/O)

This prevents subscription nodes with the obsolete `allowInsecure` flag from crashing the Xray core on startup.