### PR TITLE
Add Cancel action to batch-test notification

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/NotificationHelper.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/NotificationHelper.kt
@@ -77,15 +77,18 @@ object NotificationHelper {
      * @param channelType The notification channel type
      * @param title The notification title
      * @param content The notification content text
+     * @param action An optional action retained when the notification is updated
      */
     fun startForeground(
         service: Service,
         channelType: NotificationChannelType,
         title: String,
-        content: String
+        content: String,
+        action: NotificationCompat.Action? = null
     ) {
         ensureChannelCreated(channelType, service)
-        val builder = buildNotificationBuilder(channelType, service, title, content)
+        val builder = buildNotificationBuilder(channelType, service, title, content, action)
+        builderCache[channelType.notificationId] = builder
         service.startForeground(channelType.notificationId, builder.build())
     }
 
@@ -141,7 +144,8 @@ object NotificationHelper {
         channelType: NotificationChannelType,
         context: Context,
         title: String,
-        content: String
+        content: String,
+        action: NotificationCompat.Action? = null
     ): NotificationCompat.Builder {
         val channelId = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             channelType.channelId
@@ -158,5 +162,6 @@ object NotificationHelper {
             .setOnlyAlertOnce(true)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .apply { action?.let(::addAction) }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -1,8 +1,10 @@
 package com.v2ray.ang.service
 
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreNativeManager
@@ -21,6 +23,23 @@ class CoreTestService : Service() {
 
     // manage active batch workers so each batch is independent and cancellable
     private val activeWorkers = Collections.synchronizedList(mutableListOf<RealPingWorkerService>())
+    private val cancelAction by lazy {
+        val intent = Intent(this, CoreTestService::class.java).putExtra(
+            "content",
+            TestServiceMessage(AppConfig.MSG_MEASURE_CONFIG_CANCEL)
+        )
+        val pendingIntent = PendingIntent.getService(
+            this,
+            NotificationChannelType.CORE_TEST.notificationId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        NotificationCompat.Action.Builder(
+            R.drawable.ic_stop_24dp,
+            getString(android.R.string.cancel),
+            pendingIntent
+        ).build()
+    }
 
     /**
      * Initializes the V2Ray environment.
@@ -64,7 +83,8 @@ class CoreTestService : Service() {
             this,
             NotificationChannelType.CORE_TEST,
             getString(R.string.app_name),
-            getString(R.string.title_real_ping_all_server)
+            getString(R.string.title_real_ping_all_server),
+            cancelAction
         )
         val message = intent?.serializable<TestServiceMessage>("content")
         if (message == null) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -140,9 +140,7 @@ class MainViewModel(
             }
 
             is MainServiceEvent.MeasureConfigFinish -> {
-                if (event.finishedCount == "0") {
-                    onTestsFinished()
-                }
+                onTestsFinished()
             }
         }
     }


### PR DESCRIPTION
## Summary

- add a **Cancel** action to the foreground notification shown during a batch Real delay config test
- route the action through the test service's existing cancellation command
- retain the action while notification progress is updated
- clear the UI testing state when the service reports either normal completion or cancellation

## Why

[#5979](https://github.com/2dust/v2rayNG/issues/5979) describes accidentally starting **Real delay config** for a very large profile group, after which the lengthy operation has no obvious way to stop it.

The test service already supports cancellation, but that operation was not exposed through its system notification. This change makes the existing capability accessible without changing how latency tests are scheduled or executed.

This supersedes the status-area approach in #5984 and follows the recommendation there to place cancellation in the system notification. It does not change notification-channel importance, add status-bar behavior, or introduce new localized resources; the action uses Android's generic **Cancel** string.