### PR TITLE
Fix QR scanning with padded CameraX image rows

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ScannerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/ScannerActivity.kt
@@ -69,6 +69,7 @@ import com.v2ray.ang.ui.base.HelperBaseComponentActivity
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.QRCodeDecoder
+import java.nio.ByteBuffer
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import android.util.Size as TargetSize
@@ -410,15 +411,14 @@ private fun processImageProxy(
         return
     }
     try {
-        val buffer = imageProxy.planes[0].buffer
-        val bytes = ByteArray(buffer.remaining())
-        buffer.get(bytes)
         val width = imageProxy.width
         val height = imageProxy.height
-        val source = PlanarYUVLuminanceSource(
-            bytes, width, height,
-            0, 0, width, height,
-            false
+        val yPlane = imageProxy.planes[0]
+        val source = createYPlaneLuminanceSource(
+            buffer = yPlane.buffer,
+            width = width,
+            height = height,
+            rowStride = yPlane.rowStride,
         )
         val binaryBitmap = BinaryBitmap(HybridBinarizer(source))
         val hints = mapOf(
@@ -436,4 +436,27 @@ private fun processImageProxy(
     } finally {
         imageProxy.close()
     }
+}
+
+internal fun createYPlaneLuminanceSource(
+    buffer: ByteBuffer,
+    width: Int,
+    height: Int,
+    rowStride: Int,
+): PlanarYUVLuminanceSource {
+    val bufferCopy = buffer.duplicate()
+    val bytes = ByteArray(bufferCopy.remaining())
+    bufferCopy.get(bytes)
+    // Camera HALs may pad each Y row. ZXing advances rows by dataWidth, so the
+    // reported row stride must be used instead of the visible image width.
+    return PlanarYUVLuminanceSource(
+        bytes,
+        rowStride,
+        height,
+        0,
+        0,
+        width,
+        height,
+        false,
+    )
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/ScannerActivityTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/ScannerActivityTest.kt
@@ -1,0 +1,48 @@
+package com.v2ray.ang.ui
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
+import com.google.zxing.common.HybridBinarizer
+import com.google.zxing.qrcode.QRCodeWriter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.nio.ByteBuffer
+
+class ScannerActivityTest {
+
+    @Test
+    fun paddedCameraRowsDecodeQrCode() {
+        val payload = "vless://00000000-0000-4000-8000-000000006007@example.com:443" +
+            "?encryption=none&security=tls&type=tcp#issue-6007-gallery"
+        val width = 320
+        val height = 320
+        val rowStride = width + 32
+        val qrCode = QRCodeWriter().encode(payload, BarcodeFormat.QR_CODE, width, height)
+        val paddedYPlane = ByteArray(rowStride * height)
+
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                paddedYPlane[y * rowStride + x] = if (qrCode[x, y]) 0 else 0xFF.toByte()
+            }
+            for (x in width until rowStride) {
+                paddedYPlane[y * rowStride + x] = (x + y).toByte()
+            }
+        }
+
+        val source = createYPlaneLuminanceSource(
+            buffer = ByteBuffer.wrap(paddedYPlane),
+            width = width,
+            height = height,
+            rowStride = rowStride,
+        )
+        val hints = mapOf(
+            DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE),
+            DecodeHintType.TRY_HARDER to true,
+        )
+        val result = MultiFormatReader().decode(BinaryBitmap(HybridBinarizer(source)), hints)
+
+        assertEquals(payload, result.text)
+    }
+}


### PR DESCRIPTION
## Summary

- Respect the CameraX Y plane's reported `rowStride` when constructing ZXing's luminance source.
- Add a regression test that decodes a valid VLESS profile from a Y plane with 32 bytes of padding after each visible row.

## Context and root cause

#6007 reports that the camera preview opens but no QR code is detected on an OPPO A36 and a realme V25 after upgrading from 2.2.6 to the Compose-based 2.3.x scanner.

The Compose migration in #5866 replaced Quickie with direct CameraX/ZXing frame processing. The previous `quickie-foss` 1.14.0 analyzer already contained an explicit compatibility path for this case: it copied each luminance pixel using `y * rowStride + x * pixelStride` before giving the compact image to ZXing. Its source documents CameraX/ZXing detection failures on some phones, especially OnePlus devices, and links the original Aegis padding fix.

The migrated scanner copied the raw Y plane buffer but passed the visible image width to `PlanarYUVLuminanceSource` as the row pitch. When a camera buffer has padded rows (`rowStride > width`), ZXing consequently starts every row at the wrong offset after the first one and sees a progressively shifted image rather than the QR code.

Supporting references:

- The exact [Quickie 1.14.0 analyzer used by v2rayNG 2.2.6](https://github.com/T8RIN/QuickieExtended/blob/1.14.0/quickie-foss/src/main/kotlin/io/github/g00fy2/quickie/QRCodeAnalyzer.kt#L155-L183) strips Y-plane padding before ZXing and calls out affected OnePlus phones.
- The linked [Aegis fix](https://github.com/beemdevelopment/Aegis/commit/fb58c877d1b305b1c66db497880da5651dda78d7) fixed the same raw-buffer assumption for reports on a [Samsung S20 FE](https://github.com/beemdevelopment/Aegis/issues/726) and [Xiaomi Poco M3](https://github.com/beemdevelopment/Aegis/issues/657).
- Android defines [`Image.Plane.getRowStride()`](https://developer.android.com/reference/android/media/Image.Plane#getRowStride()) as the distance between the starts of consecutive rows. The official [Android camera sample](https://github.com/android/camera-samples/blob/3bb48e81487a9f97c0359fa3c1bae6e1ee311519/CameraUtils/lib/src/main/java/com/example/android/camera/utils/Yuv.kt#L748-L847) explicitly removes padding when `rowStride > width`, and [Camera CTS](https://android.googlesource.com/platform/cts/+/master/tests/camera/utils/src/android/hardware/camera2/cts/CameraTestUtils.java#1554) advances over the remainder of each row stride.
- An independent Camera2 report measured an [OPPO K3 frame with width 1520 and row stride 1536](https://www.cnblogs.com/bodaren/p/11156756.html#330), demonstrating the layout on an OPPO device.

## Scope

This potentially addresses the live-camera no-detection regression in #6007. It does not change gallery or clipboard import. The gallery decoder is materially unchanged from 2.2.6 and decoded a PNG containing the same valid test profile in an API 33 instrumentation check. The clipboard failure reported in #6008 therefore appears to be a separate payload/import-path issue; an exact failing QR image or sanitized payload is still needed to diagnose that part.

Direct confirmation on the OPPO A36 and realme V25 is still requested.