### PR TITLE
Use typed actions for Compose menus and Material 3 drawer components

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/enums/RoutingType.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/enums/RoutingType.kt
@@ -5,18 +5,5 @@ enum class RoutingType(val fileName: String) {
     BLACK("custom_routing_black"),
     GLOBAL("custom_routing_global"),
     WHITE_IRAN("custom_routing_white_iran"),
-    WHITE_RUSSIA("custom_routing_white_russia");
-
-    companion object {
-        fun fromIndex(index: Int): RoutingType {
-            return when (index) {
-                0 -> WHITE
-                1 -> BLACK
-                2 -> GLOBAL
-                3 -> WHITE_IRAN
-                4 -> WHITE_RUSSIA
-                else -> WHITE
-            }
-        }
-    }
+    WHITE_RUSSIA("custom_routing_white_russia")
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -62,12 +62,11 @@ object SettingsManager {
     /**
      * Get preset routing rulesets.
      * @param context The application context.
-     * @param index The index of the routing type.
+     * @param type The routing preset type.
      * @return A mutable list of RulesetItem.
      */
-    private fun getPresetRoutingRulesets(context: Context, index: Int = 0): MutableList<RulesetItem>? {
-        val fileName = RoutingType.fromIndex(index).fileName
-        val assets = Utils.readTextFromAssets(context, fileName)
+    private fun getPresetRoutingRulesets(context: Context, type: RoutingType = RoutingType.WHITE): MutableList<RulesetItem>? {
+        val assets = Utils.readTextFromAssets(context, type.fileName)
         if (TextUtils.isEmpty(assets)) {
             return null
         }
@@ -78,10 +77,10 @@ object SettingsManager {
     /**
      * Reset routing rulesets from presets.
      * @param context The application context.
-     * @param index The index of the routing type.
+     * @param type The routing preset type.
      */
-    fun resetRoutingRulesetsFromPresets(context: Context, index: Int) {
-        val rulesetList = getPresetRoutingRulesets(context, index) ?: return
+    fun resetRoutingRulesetsFromPresets(context: Context, type: RoutingType) {
+        val rulesetList = getPresetRoutingRulesets(context, type) ?: return
         resetRoutingRulesetsCommon(rulesetList)
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/apppicker/AppPickerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/apppicker/AppPickerActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -11,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -34,9 +34,15 @@ import com.v2ray.ang.R
 import com.v2ray.ang.dto.AppInfo
 import com.v2ray.ang.ui.base.BaseComponentActivity
 import com.v2ray.ang.ui.compose.AppListItem
+import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.verticalScrollbar
+
+private enum class AppPickerMenuAction(@StringRes val labelRes: Int) {
+    SelectAll(R.string.menu_item_select_all),
+    InvertSelection(R.string.menu_item_invert_selection)
+}
 
 class AppPickerActivity : BaseComponentActivity() {
 
@@ -161,14 +167,13 @@ fun AppPickerScreen(
                             onDismissRequest = { showMenu = false },
                             containerColor = MaterialTheme.colorScheme.surface
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_select_all)) },
-                                onClick = { showMenu = false; onSelectAll() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_invert_selection)) },
-                                onClick = { showMenu = false; onInvertSelection() }
-                            )
+                            AppDropdownMenuItems(AppPickerMenuAction.entries, { it.labelRes }) { action ->
+                                showMenu = false
+                                when (action) {
+                                    AppPickerMenuAction.SelectAll -> onSelectAll()
+                                    AppPickerMenuAction.InvertSelection -> onInvertSelection()
+                                }
+                            }
                         }
                     }
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/apppicker/AppPickerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/apppicker/AppPickerActivity.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -107,7 +106,6 @@ class AppPickerActivity : BaseComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppPickerScreen(
     title: String,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -48,15 +49,14 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-enum class BackupLocation { Local, WebDav }
+enum class BackupLocation(@StringRes val labelRes: Int) {
+    Local(R.string.backup_location_local),
+    WebDav(R.string.backup_location_webdav)
+}
 
 class BackupActivity : HelperBaseComponentActivity() {
 
     private val viewModel: BackupViewModel by viewModels()
-
-    private val configBackupOptions: Array<out String> by lazy {
-        resources.getStringArray(R.array.config_backup_options)
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -92,7 +92,6 @@ class BackupActivity : HelperBaseComponentActivity() {
         BackupScreen(
             isLoadingState = viewModel.isLoading,
             webDavConfigState = viewModel.webDavConfig,
-            storageOptions = configBackupOptions.toList(),
             onBackupOptionSelected = { location ->
                 when (location) {
                     BackupLocation.Local -> backupViaLocal()
@@ -184,7 +183,6 @@ class BackupActivity : HelperBaseComponentActivity() {
 fun BackupScreen(
     isLoadingState: StateFlow<Boolean>,
     webDavConfigState: StateFlow<WebDavConfig?>,
-    storageOptions: List<String>,
     onBackupOptionSelected: (BackupLocation) -> Unit,
     onShareClick: () -> Unit,
     onRestoreOptionSelected: (BackupLocation) -> Unit,
@@ -243,10 +241,11 @@ fun BackupScreen(
     if (showBackupDialog) {
         SelectListDialog(
             title = stringResource(R.string.title_configuration_backup),
-            options = storageOptions,
-            onSelected = { index, _ ->
+            options = BackupLocation.entries,
+            optionText = { stringResource(it.labelRes) },
+            onSelected = { location ->
                 showBackupDialog = false
-                onBackupOptionSelected(BackupLocation.entries[index])
+                onBackupOptionSelected(location)
             },
             onDismiss = { showBackupDialog = false }
         )
@@ -254,10 +253,11 @@ fun BackupScreen(
     if (showRestoreDialog) {
         SelectListDialog(
             title = stringResource(R.string.title_configuration_restore),
-            options = storageOptions,
-            onSelected = { index, _ ->
+            options = BackupLocation.entries,
+            optionText = { stringResource(it.labelRes) },
+            onSelected = { location ->
                 showRestoreDialog = false
-                onRestoreOptionSelected(BackupLocation.entries[index])
+                onRestoreOptionSelected(location)
             },
             onDismiss = { showRestoreDialog = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupActivity.kt
@@ -48,6 +48,8 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
 
+enum class BackupLocation { Local, WebDav }
+
 class BackupActivity : HelperBaseComponentActivity() {
 
     private val viewModel: BackupViewModel by viewModels()
@@ -90,19 +92,18 @@ class BackupActivity : HelperBaseComponentActivity() {
         BackupScreen(
             isLoadingState = viewModel.isLoading,
             webDavConfigState = viewModel.webDavConfig,
-            backupOptions = configBackupOptions.toList(),
-            onBackupOptionSelected = { which ->
-                when (which) {
-                    0 -> backupViaLocal()
-                    1 -> viewModel.backupViaWebDav(cacheDir, getString(R.string.app_name))
+            storageOptions = configBackupOptions.toList(),
+            onBackupOptionSelected = { location ->
+                when (location) {
+                    BackupLocation.Local -> backupViaLocal()
+                    BackupLocation.WebDav -> viewModel.backupViaWebDav(cacheDir, getString(R.string.app_name))
                 }
             },
             onShareClick = { viewModel.shareBackup(cacheDir, getString(R.string.app_name)) },
-            restoreOptions = configBackupOptions.toList(),
-            onRestoreOptionSelected = { which ->
-                when (which) {
-                    0 -> restoreViaLocal()
-                    1 -> viewModel.restoreViaWebDav(cacheDir)
+            onRestoreOptionSelected = { location ->
+                when (location) {
+                    BackupLocation.Local -> restoreViaLocal()
+                    BackupLocation.WebDav -> viewModel.restoreViaWebDav(cacheDir)
                 }
             },
             onWebDavSave = { config -> viewModel.saveWebDavConfig(config) },
@@ -183,11 +184,10 @@ class BackupActivity : HelperBaseComponentActivity() {
 fun BackupScreen(
     isLoadingState: StateFlow<Boolean>,
     webDavConfigState: StateFlow<WebDavConfig?>,
-    backupOptions: List<String>,
-    onBackupOptionSelected: (Int) -> Unit,
+    storageOptions: List<String>,
+    onBackupOptionSelected: (BackupLocation) -> Unit,
     onShareClick: () -> Unit,
-    restoreOptions: List<String>,
-    onRestoreOptionSelected: (Int) -> Unit,
+    onRestoreOptionSelected: (BackupLocation) -> Unit,
     onWebDavSave: (WebDavConfig) -> Unit,
     onBackClick: () -> Unit
 ) {
@@ -243,10 +243,10 @@ fun BackupScreen(
     if (showBackupDialog) {
         SelectListDialog(
             title = stringResource(R.string.title_configuration_backup),
-            options = backupOptions,
+            options = storageOptions,
             onSelected = { index, _ ->
                 showBackupDialog = false
-                onBackupOptionSelected(index)
+                onBackupOptionSelected(BackupLocation.entries[index])
             },
             onDismiss = { showBackupDialog = false }
         )
@@ -254,10 +254,10 @@ fun BackupScreen(
     if (showRestoreDialog) {
         SelectListDialog(
             title = stringResource(R.string.title_configuration_restore),
-            options = restoreOptions,
+            options = storageOptions,
             onSelected = { index, _ ->
                 showRestoreDialog = false
-                onRestoreOptionSelected(index)
+                onRestoreOptionSelected(BackupLocation.entries[index])
             },
             onDismiss = { showRestoreDialog = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Dialog.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Dialog.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.ui.compose
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,7 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -34,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
@@ -192,38 +194,44 @@ fun QRCodeDialog(
  * The selectedOption parameter is used to highlight the selected item only when showRadio is true.
  */
 @Composable
-fun SelectListDialog(
-    title: String? = null,
-    options: List<String>,
-    selectedOption: String = "",
-    onSelected: (Int, String) -> Unit,
+fun <T> SelectListDialog(
+    options: List<T>,
+    optionText: @Composable (T) -> String,
+    onSelected: (T) -> Unit,
     onDismiss: () -> Unit,
+    title: String? = null,
+    selectedOption: T? = null,
     showRadio: Boolean = false
 ) {
-    val selectedIndex = if (showRadio) options.indexOf(selectedOption) else -1
-
     AlertDialog(
         onDismissRequest = onDismiss,
         title = title?.let { { Text(it) } },
         text = {
             LazyColumn {
-                itemsIndexed(options) { index, option ->
+                items(options) { option ->
+                    val isSelected = option == selectedOption
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onSelected(index, option) }
+                            .then(
+                                if (showRadio) Modifier.selectable(
+                                    selected = isSelected,
+                                    onClick = { onSelected(option) },
+                                    role = Role.RadioButton
+                                ) else Modifier.clickable { onSelected(option) }
+                            )
                             .padding(vertical = 4.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         if (showRadio) {
                             RadioButton(
-                                selected = index == selectedIndex,
-                                onClick = { onSelected(index, option) }
+                                selected = isSelected,
+                                onClick = null
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                         }
                         Text(
-                            text = option,
+                            text = optionText(option),
                             style = MaterialTheme.typography.bodyMedium,
                             modifier = if (!showRadio)
                                 Modifier

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Menu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Menu.kt
@@ -1,6 +1,5 @@
 package com.v2ray.ang.ui.compose
 
-import androidx.annotation.StringRes
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -9,7 +8,7 @@ import androidx.compose.ui.res.stringResource
 @Composable
 fun <T> AppDropdownMenuItems(
     items: List<T>,
-    @StringRes labelRes: (T) -> Int,
+    labelRes: (T) -> Int,
     onSelected: (T) -> Unit
 ) {
     items.forEach { item ->

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Menu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Menu.kt
@@ -1,0 +1,21 @@
+package com.v2ray.ang.ui.compose
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+@Composable
+fun <T> AppDropdownMenuItems(
+    items: List<T>,
+    @StringRes labelRes: (T) -> Int,
+    onSelected: (T) -> Unit
+) {
+    items.forEach { item ->
+        DropdownMenuItem(
+            text = { Text(stringResource(labelRes(item))) },
+            onClick = { onSelected(item) }
+        )
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/SettingsItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/SettingsItem.kt
@@ -184,8 +184,9 @@ fun SettingsListItem(
     enabled: Boolean = true
 ) {
     var showDialog by remember { mutableStateOf(false) }
-    val selectedIndex = values.indexOf(selectedValue).let { if (it >= 0) it else 0 }
-    val summary = entries.getOrNull(selectedIndex).orEmpty()
+    val options = entries.zip(values)
+    val selectedOption = options.find { it.second == selectedValue } ?: options.firstOrNull()
+    val summary = selectedOption?.first.orEmpty()
 
     SettingsItemRow(
         icon = icon,
@@ -201,11 +202,12 @@ fun SettingsListItem(
     if (showDialog) {
         SelectListDialog(
             title = title,
-            options = entries,
-            selectedOption = summary,
-            onSelected = { index, _ ->
+            options = options,
+            optionText = { it.first },
+            selectedOption = selectedOption,
+            onSelected = { option ->
                 showDialog = false
-                values.getOrNull(index)?.let(onSelected)
+                onSelected(option.second)
             },
             onDismiss = { showDialog = false },
             showRadio = true

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -134,26 +134,24 @@ class MainActivity : HelperBaseComponentActivity() {
         }
     }
 
-    private fun navigateTo(destination: String) {
+    private fun navigateTo(destination: MainDestination) {
         val intent = when (destination) {
-            "sub_setting" -> Intent(this, SubSettingActivity::class.java)
-            "per_app_proxy" -> Intent(this, PerAppProxyActivity::class.java)
-            "routing_setting" -> Intent(this, RoutingSettingActivity::class.java)
-            "user_asset" -> Intent(this, UserAssetActivity::class.java)
-            "settings" -> Intent(this, SettingsActivity::class.java)
-            "logcat" -> Intent(this, LogcatActivity::class.java)
-            "check_update" -> Intent(this, CheckUpdateActivity::class.java)
-            "backup_restore" -> Intent(this, BackupActivity::class.java)
-            "about" -> Intent(this, AboutActivity::class.java)
-            "promotion" -> {
+            MainDestination.Subscriptions -> Intent(this, SubSettingActivity::class.java)
+            MainDestination.PerAppProxy -> Intent(this, PerAppProxyActivity::class.java)
+            MainDestination.Routing -> Intent(this, RoutingSettingActivity::class.java)
+            MainDestination.UserAssets -> Intent(this, UserAssetActivity::class.java)
+            MainDestination.Settings -> Intent(this, SettingsActivity::class.java)
+            MainDestination.Logcat -> Intent(this, LogcatActivity::class.java)
+            MainDestination.CheckUpdate -> Intent(this, CheckUpdateActivity::class.java)
+            MainDestination.BackupRestore -> Intent(this, BackupActivity::class.java)
+            MainDestination.About -> Intent(this, AboutActivity::class.java)
+            MainDestination.Promotion -> {
                 Utils.openUri(
                     this,
                     "${Utils.decode(AppConfig.APP_PROMOTION_URL)}?t=${System.currentTimeMillis()}"
                 )
                 return
             }
-
-            else -> return
         }
         settingsActivityLauncher.launch(intent)
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -5,6 +5,7 @@ import android.net.VpnService
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import androidx.activity.compose.BackHandler
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
@@ -98,6 +99,7 @@ class MainActivity : HelperBaseComponentActivity() {
 
     @Composable
     override fun ScreenContent() {
+        BackHandler { moveTaskToBack(false) }
         MainScreen(
             mainViewModel = mainViewModel,
             onAction = { action ->
@@ -278,7 +280,7 @@ class MainActivity : HelperBaseComponentActivity() {
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_BUTTON_B) {
+        if (keyCode == KeyEvent.KEYCODE_BUTTON_B) {
             moveTaskToBack(false)
             return true
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.DrawerState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
@@ -62,20 +62,16 @@ private val drawerItems = primaryDrawerItems + listOf(
 )
 
 @Composable
-fun MainDrawerContent(onNavigate: (MainDestination) -> Unit) {
+fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) -> Unit) {
     val drawerScrollState = rememberScrollState()
 
     ModalDrawerSheet(
-        modifier = Modifier
-            .fillMaxWidth(0.75f)
-            .navigationBarsPadding(),
+        drawerState = drawerState,
+        modifier = Modifier.fillMaxWidth(0.75f),
         drawerContainerColor = MaterialTheme.colorScheme.surface
     ) {
         Column(
-            modifier = Modifier
-                .verticalScroll(drawerScrollState)
-                .verticalScrollbar(drawerScrollState)
-                .padding(bottom = 80.dp)
+            modifier = Modifier.verticalScroll(drawerScrollState).verticalScrollbar(drawerScrollState)
         ) {
             Surface(
                 modifier = Modifier

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
@@ -1,5 +1,7 @@
 package com.v2ray.ang.ui.main
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -37,8 +39,37 @@ import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.AppDivider
 import com.v2ray.ang.ui.compose.verticalScrollbar
 
+enum class MainDestination(@DrawableRes val iconRes: Int, @StringRes val labelRes: Int) {
+    Subscriptions(R.drawable.ic_subscriptions_24dp, R.string.title_sub_setting),
+    PerAppProxy(R.drawable.ic_per_apps_24dp, R.string.per_app_proxy_settings),
+    Routing(R.drawable.ic_routing_24dp, R.string.routing_settings_title),
+    UserAssets(R.drawable.ic_file_24dp, R.string.title_user_asset_setting),
+    Settings(R.drawable.ic_settings_24dp, R.string.title_settings),
+    Promotion(R.drawable.ic_promotion_24dp, R.string.title_pref_promotion),
+    Logcat(R.drawable.ic_logcat_24dp, R.string.title_logcat),
+    CheckUpdate(R.drawable.ic_check_update_24dp, R.string.update_check_for_update),
+    BackupRestore(R.drawable.ic_restore_24dp, R.string.title_configuration_backup_restore),
+    About(R.drawable.ic_about_24dp, R.string.title_about)
+}
+
+private val primaryDrawerItems = listOf(
+    MainDestination.Subscriptions,
+    MainDestination.PerAppProxy,
+    MainDestination.Routing,
+    MainDestination.UserAssets,
+    MainDestination.Settings
+)
+
+private val drawerItems = primaryDrawerItems + listOf(
+    MainDestination.Promotion,
+    MainDestination.Logcat,
+    MainDestination.CheckUpdate,
+    MainDestination.BackupRestore,
+    MainDestination.About
+)
+
 @Composable
-fun MainDrawerContent(onNavigate: (String) -> Unit) {
+fun MainDrawerContent(onNavigate: (MainDestination) -> Unit) {
     val drawerScrollState = rememberScrollState()
 
     ModalDrawerSheet(
@@ -75,48 +106,15 @@ fun MainDrawerContent(onNavigate: (String) -> Unit) {
                     )
                 }
             }
-            DrawerMenuGroup(
-                items = listOf(
-                    DrawerMenuItemData(R.drawable.ic_subscriptions_24dp, R.string.title_sub_setting, "sub_setting"),
-                    DrawerMenuItemData(R.drawable.ic_per_apps_24dp, R.string.per_app_proxy_settings, "per_app_proxy"),
-                    DrawerMenuItemData(R.drawable.ic_routing_24dp, R.string.routing_settings_title, "routing_setting"),
-                    DrawerMenuItemData(R.drawable.ic_file_24dp, R.string.title_user_asset_setting, "user_asset"),
-                    DrawerMenuItemData(R.drawable.ic_settings_24dp, R.string.title_settings, "settings")
-                ),
-                onNavigate = onNavigate
-            )
-            AppDivider()
-            DrawerMenuGroup(
-                items = listOf(
-                    DrawerMenuItemData(R.drawable.ic_promotion_24dp, R.string.title_pref_promotion, "promotion"),
-                    DrawerMenuItemData(R.drawable.ic_logcat_24dp, R.string.title_logcat, "logcat"),
-                    DrawerMenuItemData(R.drawable.ic_check_update_24dp, R.string.update_check_for_update, "check_update"),
-                    DrawerMenuItemData(R.drawable.ic_restore_24dp, R.string.title_configuration_backup_restore, "backup_restore"),
-                    DrawerMenuItemData(R.drawable.ic_about_24dp, R.string.title_about, "about")
-                ),
-                onNavigate = onNavigate
-            )
+            drawerItems.forEachIndexed { index, item ->
+                if (index == primaryDrawerItems.size) AppDivider()
+                DrawerMenuItem(
+                    icon = painterResource(item.iconRes),
+                    label = stringResource(item.labelRes),
+                    onClick = { onNavigate(item) }
+                )
+            }
         }
-    }
-}
-
-data class DrawerMenuItemData(
-    val iconRes: Int,
-    val labelRes: Int,
-    val route: String
-)
-
-@Composable
-private fun DrawerMenuGroup(
-    items: List<DrawerMenuItemData>,
-    onNavigate: (String) -> Unit
-) {
-    items.forEach { item ->
-        DrawerMenuItem(
-            icon = painterResource(item.iconRes),
-            label = stringResource(item.labelRes),
-            onClick = { onNavigate(item.route) }
-        )
     }
 }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
@@ -2,32 +2,25 @@ package com.v2ray.ang.ui.main
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
@@ -108,47 +101,14 @@ fun MainDrawerContent(onNavigate: (MainDestination) -> Unit) {
             }
             drawerItems.forEachIndexed { index, item ->
                 if (index == primaryDrawerItems.size) AppDivider()
-                DrawerMenuItem(
-                    icon = painterResource(item.iconRes),
-                    label = stringResource(item.labelRes),
-                    onClick = { onNavigate(item) }
+                NavigationDrawerItem(
+                    label = { Text(stringResource(item.labelRes)) },
+                    selected = false,
+                    onClick = { onNavigate(item) },
+                    icon = { Icon(painterResource(item.iconRes), contentDescription = null) },
+                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
                 )
             }
         }
-    }
-}
-
-@Composable
-fun DrawerMenuItem(
-    icon: Painter,
-    label: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    selected: Boolean = false
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .heightIn(min = 48.dp)
-            .clickable(onClick = onClick)
-            .background(
-                if (selected) MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f)
-                else Color.Transparent
-            )
-            .padding(horizontal = 16.dp, vertical = 0.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            painter = icon,
-            contentDescription = null,
-            modifier = Modifier.size(24.dp),
-            tint = MaterialTheme.colorScheme.onSurface
-        )
-        Spacer(modifier = Modifier.width(12.dp))
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
@@ -1,15 +1,43 @@
 package com.v2ray.ang.ui.main
 
 import androidx.annotation.StringRes
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.extension.isComplexType
+import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.SelectListDialog
+
+private enum class ImportMenuAction(@StringRes val labelRes: Int, val action: MainAction) {
+    QRCode(R.string.menu_item_import_config_qrcode, MainAction.ImportQRcode),
+    Clipboard(R.string.menu_item_import_config_clipboard, MainAction.ImportClipboard),
+    LocalFile(R.string.menu_item_import_config_local, MainAction.ImportConfigLocal),
+    PolicyGroup(R.string.menu_item_import_config_policy_group, MainAction.ImportManually(EConfigType.POLICYGROUP.value)),
+    ProxyChain(R.string.menu_item_import_config_proxy_chain, MainAction.ImportManually(EConfigType.PROXYCHAIN.value)),
+    Vmess(R.string.menu_item_import_config_manually_vmess, MainAction.ImportManually(EConfigType.VMESS.value)),
+    Vless(R.string.menu_item_import_config_manually_vless, MainAction.ImportManually(EConfigType.VLESS.value)),
+    Shadowsocks(R.string.menu_item_import_config_manually_ss, MainAction.ImportManually(EConfigType.SHADOWSOCKS.value)),
+    Socks(R.string.menu_item_import_config_manually_socks, MainAction.ImportManually(EConfigType.SOCKS.value)),
+    Http(R.string.menu_item_import_config_manually_http, MainAction.ImportManually(EConfigType.HTTP.value)),
+    Trojan(R.string.menu_item_import_config_manually_trojan, MainAction.ImportManually(EConfigType.TROJAN.value)),
+    WireGuard(R.string.menu_item_import_config_manually_wireguard, MainAction.ImportManually(EConfigType.WIREGUARD.value)),
+    Hysteria2(R.string.menu_item_import_config_manually_hysteria2, MainAction.ImportManually(EConfigType.HYSTERIA2.value))
+}
+
+enum class MainMoreMenuAction(@StringRes val labelRes: Int) {
+    RestartService(R.string.title_service_restart),
+    DeleteAll(R.string.title_del_all_config),
+    DeleteDuplicate(R.string.title_del_duplicate_config),
+    DeleteInvalid(R.string.title_del_invalid_config),
+    ExportAll(R.string.title_export_all),
+    LocateSelected(R.string.title_locate_selected_config),
+    SortByTestResults(R.string.title_sort_by_test_results),
+    TestAll(R.string.title_ping_all_server),
+    TestAllRealPing(R.string.title_real_ping_all_server),
+    UpdateSubscriptions(R.string.title_sub_update)
+}
 
 internal enum class ServerMenuAction(
     @StringRes val labelRes: Int,
@@ -31,111 +59,18 @@ internal fun serverMenuActions(
 }
 
 @Composable
-fun ImportMenuContent(
-    onAction: (MainAction) -> Unit
-) {
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_qrcode)) },
-        onClick = { onAction(MainAction.ImportQRcode) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_clipboard)) },
-        onClick = { onAction(MainAction.ImportClipboard) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_local)) },
-        onClick = { onAction(MainAction.ImportConfigLocal) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_policy_group)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.POLICYGROUP.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_proxy_chain)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.PROXYCHAIN.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_vmess)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.VMESS.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_vless)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.VLESS.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_ss)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.SHADOWSOCKS.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_socks)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.SOCKS.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_http)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.HTTP.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_trojan)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.TROJAN.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_wireguard)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.WIREGUARD.value)) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.menu_item_import_config_manually_hysteria2)) },
-        onClick = { onAction(MainAction.ImportManually(EConfigType.HYSTERIA2.value)) }
-    )
-}
+fun ImportMenuContent(onAction: (MainAction) -> Unit) = AppDropdownMenuItems(
+    items = ImportMenuAction.entries,
+    labelRes = { it.labelRes },
+    onSelected = { onAction(it.action) }
+)
 
 @Composable
-fun MoreMenuContent(
-    onAction: (MainAction) -> Unit,
-    onDelAllConfig: () -> Unit,
-    onDelDuplicateConfig: () -> Unit,
-    onDelInvalidConfig: () -> Unit
-) {
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_service_restart)) },
-        onClick = { onAction(MainAction.RestartService) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_del_all_config)) },
-        onClick = onDelAllConfig
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_del_duplicate_config)) },
-        onClick = onDelDuplicateConfig
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_del_invalid_config)) },
-        onClick = onDelInvalidConfig
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_export_all)) },
-        onClick = { onAction(MainAction.ExportAll) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_locate_selected_config)) },
-        onClick = { onAction(MainAction.LocateSelectedServer) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_sort_by_test_results)) },
-        onClick = { onAction(MainAction.SortByTestResults) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_ping_all_server)) },
-        onClick = { onAction(MainAction.TestAllServers) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_real_ping_all_server)) },
-        onClick = { onAction(MainAction.TestRealAllServers) }
-    )
-    DropdownMenuItem(
-        text = { Text(stringResource(R.string.title_sub_update)) },
-        onClick = { onAction(MainAction.UpdateSubscriptions) }
-    )
-}
+fun MoreMenuContent(onSelected: (MainMoreMenuAction) -> Unit) = AppDropdownMenuItems(
+    items = MainMoreMenuAction.entries,
+    labelRes = { it.labelRes },
+    onSelected = onSelected
+)
 
 @Composable
 fun ShareMethodDialog(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
@@ -86,10 +86,11 @@ fun ShareMethodDialog(
         includeManagementActions = more,
     )
     SelectListDialog(
-        options = menuActions.map { stringResource(it.labelRes) },
-        onSelected = { index, _ ->
+        options = menuActions,
+        optionText = { stringResource(it.labelRes) },
+        onSelected = { action ->
             onDismiss()
-            when (menuActions[index]) {
+            when (action) {
                 ServerMenuAction.ShareQRCode -> onAction(MainAction.ShareQRCode(guid))
                 ServerMenuAction.ShareClipboard -> onAction(MainAction.ShareClipboard(guid))
                 ServerMenuAction.ShareFullContent -> onAction(MainAction.ShareFullContent(guid))

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 fun MainScreen(
     mainViewModel: MainViewModel,
     onAction: (MainAction) -> Unit,
-    onNavigate: (String) -> Unit,
+    onNavigate: (MainDestination) -> Unit,
 ) {
     val uiState by mainViewModel.uiState.collectAsStateWithLifecycle()
     val groups = uiState.groups
@@ -217,9 +217,20 @@ fun MainScreen(
                     onSearchToggle = { show: Boolean -> showSearch = show },
                     onMenuClick = { scope.launch { drawerState.open() } },
                     onAction = onAction,
-                    onDelAllConfig = { showDelAllConfirm = true },
-                    onDelDuplicateConfig = { showDelDuplicateConfirm = true },
-                    onDelInvalidConfig = { showDelInvalidConfirm = true }
+                    onMoreMenuAction = { action ->
+                        when (action) {
+                            MainMoreMenuAction.RestartService -> onAction(MainAction.RestartService)
+                            MainMoreMenuAction.DeleteAll -> showDelAllConfirm = true
+                            MainMoreMenuAction.DeleteDuplicate -> showDelDuplicateConfirm = true
+                            MainMoreMenuAction.DeleteInvalid -> showDelInvalidConfirm = true
+                            MainMoreMenuAction.ExportAll -> onAction(MainAction.ExportAll)
+                            MainMoreMenuAction.LocateSelected -> onAction(MainAction.LocateSelectedServer)
+                            MainMoreMenuAction.SortByTestResults -> onAction(MainAction.SortByTestResults)
+                            MainMoreMenuAction.TestAll -> onAction(MainAction.TestAllServers)
+                            MainMoreMenuAction.TestAllRealPing -> onAction(MainAction.TestRealAllServers)
+                            MainMoreMenuAction.UpdateSubscriptions -> onAction(MainAction.UpdateSubscriptions)
+                        }
+                    }
                 )
             },
             bottomBar = {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.v2ray.ang.ui.main
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,7 +9,6 @@ import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
@@ -36,7 +34,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
     mainViewModel: MainViewModel,
@@ -188,12 +185,11 @@ fun MainScreen(
         QRCodeDialog(bitmap = shareQRCodeBitmap, onDismiss = { onAction(MainAction.DismissQRCodeDialog) })
     }
 
-    BackHandler(enabled = drawerState.isOpen) { scope.launch { drawerState.close() } }
-
     ModalNavigationDrawer(
         drawerState = drawerState,
         drawerContent = {
             MainDrawerContent(
+                drawerState = drawerState,
                 onNavigate = { route ->
                     scope.launch { drawerState.close() }
                     onNavigate(route)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.ui.main
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -186,6 +187,8 @@ fun MainScreen(
     if (shareQRCodeBitmap != null) {
         QRCodeDialog(bitmap = shareQRCodeBitmap, onDismiss = { onAction(MainAction.DismissQRCodeDialog) })
     }
+
+    BackHandler(enabled = drawerState.isOpen) { scope.launch { drawerState.close() } }
 
     ModalNavigationDrawer(
         drawerState = drawerState,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
@@ -39,9 +39,7 @@ fun MainTopBar(
     onSearchToggle: (Boolean) -> Unit,
     onMenuClick: () -> Unit,
     onAction: (MainAction) -> Unit,
-    onDelAllConfig: () -> Unit,
-    onDelDuplicateConfig: () -> Unit,
-    onDelInvalidConfig: () -> Unit
+    onMoreMenuAction: (MainMoreMenuAction) -> Unit
 ) {
     var showImportMenu by remember { mutableStateOf(false) }
     var showMenu by remember { mutableStateOf(false) }
@@ -111,15 +109,10 @@ fun MainTopBar(
                         .heightIn(max = maxMenuHeight)
                         .verticalScrollbar(moreMenuScrollState)
                 ) {
-                    MoreMenuContent(
-                        onAction = { action ->
-                            showMenu = false
-                            onAction(action)
-                        },
-                        onDelAllConfig = { showMenu = false; onDelAllConfig() },
-                        onDelDuplicateConfig = { showMenu = false; onDelDuplicateConfig() },
-                        onDelInvalidConfig = { showMenu = false; onDelInvalidConfig() }
-                    )
+                    MoreMenuContent { action ->
+                        showMenu = false
+                        onMoreMenuAction(action)
+                    }
                 }
             }
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -28,7 +27,6 @@ import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.verticalScrollbar
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainTopBar(
     isLoading: Boolean,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/perappproxy/PerAppProxyActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/perappproxy/PerAppProxyActivity.kt
@@ -2,6 +2,7 @@ package com.v2ray.ang.ui.perappproxy
 
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,7 +16,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -46,12 +46,21 @@ import com.v2ray.ang.extension.toastInfo
 import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.ui.base.BaseComponentActivity
 import com.v2ray.ang.ui.compose.AppDivider
+import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppListItem
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.colorFabActive
 import com.v2ray.ang.ui.compose.verticalScrollbar
 import com.v2ray.ang.util.Utils
+
+private enum class PerAppMenuAction(@StringRes val labelRes: Int) {
+    SelectAll(R.string.menu_item_select_all),
+    InvertSelection(R.string.menu_item_invert_selection),
+    SelectProxyApps(R.string.menu_item_select_proxy_app),
+    ImportSelection(R.string.menu_item_import_proxy_app),
+    ExportSelection(R.string.menu_item_export_proxy_app)
+}
 
 class PerAppProxyActivity : BaseComponentActivity() {
 
@@ -167,26 +176,16 @@ fun PerAppProxyScreen(
                             onDismissRequest = { showMenu = false },
                             containerColor = MaterialTheme.colorScheme.surface
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_select_all)) },
-                                onClick = { showMenu = false; onSelectAll() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_invert_selection)) },
-                                onClick = { showMenu = false; onInvertSelection() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_select_proxy_app)) },
-                                onClick = { showMenu = false; onSelectProxyAuto() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_import_proxy_app)) },
-                                onClick = { showMenu = false; onImportProxyApp() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_export_proxy_app)) },
-                                onClick = { showMenu = false; onExportProxyApp() }
-                            )
+                            AppDropdownMenuItems(PerAppMenuAction.entries, { it.labelRes }) { action ->
+                                showMenu = false
+                                when (action) {
+                                    PerAppMenuAction.SelectAll -> onSelectAll()
+                                    PerAppMenuAction.InvertSelection -> onInvertSelection()
+                                    PerAppMenuAction.SelectProxyApps -> onSelectProxyAuto()
+                                    PerAppMenuAction.ImportSelection -> onImportProxyApp()
+                                    PerAppMenuAction.ExportSelection -> onExportProxyApp()
+                                }
+                            }
                         }
                     }
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/perappproxy/PerAppProxyActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/perappproxy/PerAppProxyActivity.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -109,7 +108,6 @@ class PerAppProxyActivity : BaseComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PerAppProxyScreen(
     apps: List<AppInfo>,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.ui.routing
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -51,6 +51,7 @@ import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.base.HelperBaseComponentActivity
+import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.ReorderableListItem
@@ -68,6 +69,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
+
+private enum class RoutingMenuAction(@StringRes val labelRes: Int) {
+    ImportPredefined(R.string.routing_settings_import_predefined_rulesets),
+    ImportClipboard(R.string.routing_settings_import_rulesets_from_clipboard),
+    ImportQRCode(R.string.routing_settings_import_rulesets_from_qrcode),
+    ExportClipboard(R.string.routing_settings_export_rulesets_to_clipboard)
+}
 
 class RoutingSettingActivity : HelperBaseComponentActivity() {
     private val viewModel: RoutingSettingsViewModel by viewModels()
@@ -227,22 +235,15 @@ fun RoutingSettingScreen(
                             onDismissRequest = { showMenu = false },
                             containerColor = MaterialTheme.colorScheme.surface
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.routing_settings_import_predefined_rulesets)) },
-                                onClick = { showMenu = false; showPresetDialog = true }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.routing_settings_import_rulesets_from_clipboard)) },
-                                onClick = { showMenu = false; onImportClipboard() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.routing_settings_import_rulesets_from_qrcode)) },
-                                onClick = { showMenu = false; onImportQRcode() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.routing_settings_export_rulesets_to_clipboard)) },
-                                onClick = { showMenu = false; onExportClipboard() }
-                            )
+                            AppDropdownMenuItems(RoutingMenuAction.entries, { it.labelRes }) { action ->
+                                showMenu = false
+                                when (action) {
+                                    RoutingMenuAction.ImportPredefined -> showPresetDialog = true
+                                    RoutingMenuAction.ImportClipboard -> onImportClipboard()
+                                    RoutingMenuAction.ImportQRCode -> onImportQRcode()
+                                    RoutingMenuAction.ExportClipboard -> onExportClipboard()
+                                }
+                            }
                         }
                     }
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -46,6 +45,7 @@ import androidx.lifecycle.lifecycleScope
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.entities.RulesetItem
+import com.v2ray.ang.enums.RoutingType
 import com.v2ray.ang.extension.toastError
 import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.handler.MmkvManager
@@ -77,6 +77,14 @@ private enum class RoutingMenuAction(@StringRes val labelRes: Int) {
     ExportClipboard(R.string.routing_settings_export_rulesets_to_clipboard)
 }
 
+private enum class RoutingPreset(val type: RoutingType, @StringRes val labelRes: Int) {
+    ChinaWhitelist(RoutingType.WHITE, R.string.routing_preset_china_whitelist),
+    ChinaBlacklist(RoutingType.BLACK, R.string.routing_preset_china_blacklist),
+    Global(RoutingType.GLOBAL, R.string.routing_preset_global),
+    IranWhitelist(RoutingType.WHITE_IRAN, R.string.routing_preset_iran_whitelist),
+    RussiaWhitelist(RoutingType.WHITE_RUSSIA, R.string.routing_preset_russia_whitelist)
+}
+
 class RoutingSettingActivity : HelperBaseComponentActivity() {
     private val viewModel: RoutingSettingsViewModel by viewModels()
     private val domainStrategyState = MutableStateFlow("")
@@ -100,7 +108,7 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
                 MmkvManager.encodeSettings(AppConfig.PREF_ROUTING_DOMAIN_STRATEGY, value)
                 domainStrategyState.value = value
             },
-            onImportPredefined = { index -> importPredefined(index) },
+            onImportPredefined = { type -> importPredefined(type) },
             onImportClipboard = { importFromClipboard() },
             onImportQRcode = { importQRcode() },
             onExportClipboard = { export2Clipboard() }
@@ -117,10 +125,10 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
         return MmkvManager.decodeSettingsString(AppConfig.PREF_ROUTING_DOMAIN_STRATEGY) ?: strategies.first()
     }
 
-    private fun importPredefined(index: Int) {
+    private fun importPredefined(type: RoutingType) {
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                SettingsManager.resetRoutingRulesetsFromPresets(this@RoutingSettingActivity, index)
+                SettingsManager.resetRoutingRulesetsFromPresets(this@RoutingSettingActivity, type)
                 launch(Dispatchers.Main) {
                     viewModel.reload()
                     toastSuccess(R.string.toast_success)
@@ -180,7 +188,6 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RoutingSettingScreen(
     viewModel: RoutingSettingsViewModel,
@@ -189,7 +196,7 @@ fun RoutingSettingScreen(
     onAddRule: () -> Unit,
     onEditRule: (Int) -> Unit,
     onDomainStrategySelected: (String) -> Unit,
-    onImportPredefined: (Int) -> Unit,
+    onImportPredefined: (RoutingType) -> Unit,
     onImportClipboard: () -> Unit,
     onImportQRcode: () -> Unit,
     onExportClipboard: () -> Unit
@@ -200,8 +207,6 @@ fun RoutingSettingScreen(
     var showPresetDialog by remember { mutableStateOf(false) }
 
     val domainStrategies = stringArrayResource(R.array.routing_domain_strategy).toList()
-    val presetRulesets = stringArrayResource(R.array.preset_rulesets).toList()
-
     val lazyListState = rememberLazyListState()
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
         // Lazy list indices include the preceding non-rule content, so resolve the stable rule keys.
@@ -302,10 +307,11 @@ fun RoutingSettingScreen(
     if (showPresetDialog) {
         SelectListDialog(
             title = stringResource(R.string.routing_settings_import_predefined_rulesets),
-            options = presetRulesets,
-            onSelected = { index, _ ->
+            options = RoutingPreset.entries,
+            optionText = { stringResource(it.labelRes) },
+            onSelected = { preset ->
                 showPresetDialog = false
-                onImportPredefined(index)
+                onImportPredefined(preset.type)
             },
             onDismiss = { showPresetDialog = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -15,7 +16,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -58,7 +58,10 @@ import com.v2ray.ang.util.Utils
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
-private enum class SubscriptionShareAction { QRCode, Clipboard }
+private enum class SubscriptionShareAction(@StringRes val labelRes: Int) {
+    QRCode(R.string.share_subscription_qrcode),
+    Clipboard(R.string.share_subscription_clipboard)
+}
 
 class SubSettingActivity : BaseComponentActivity() {
     private val viewModel: SubscriptionsViewModel by viewModels()
@@ -84,8 +87,7 @@ class SubSettingActivity : BaseComponentActivity() {
             onShareClipboard = { url ->
                 Utils.setClipboard(this, url)
                 toast(getString(R.string.toast_success))
-            },
-            shareSubMethodEntries = resources.getStringArray(R.array.share_sub_method).toList()
+            }
         )
     }
 
@@ -99,7 +101,6 @@ class SubSettingActivity : BaseComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SubSettingScreen(
     viewModel: SubscriptionsViewModel,
@@ -110,8 +111,7 @@ fun SubSettingScreen(
     onEditSub: (String) -> Unit,
     onRemoveSub: (String) -> Unit,
     onShareQRCode: (String) -> Bitmap?,
-    onShareClipboard: (String) -> Unit,
-    shareSubMethodEntries: List<String>
+    onShareClipboard: (String) -> Unit
 ) {
     val subscriptions by viewModel.subsFlow.collectAsStateWithLifecycle()
     var showUpdateDialog by remember { mutableStateOf(false) }
@@ -248,10 +248,11 @@ fun SubSettingScreen(
     if (shareTarget != null) {
         val (_, url) = shareTarget!!
         SelectListDialog(
-            options = shareSubMethodEntries,
-            onSelected = { index, _ ->
+            options = SubscriptionShareAction.entries,
+            optionText = { stringResource(it.labelRes) },
+            onSelected = { action ->
                 shareTarget = null
-                when (SubscriptionShareAction.entries[index]) {
+                when (action) {
                     SubscriptionShareAction.QRCode -> showQRCodeBitmap = onShareQRCode(url)
                     SubscriptionShareAction.Clipboard -> onShareClipboard(url)
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
@@ -58,6 +58,8 @@ import com.v2ray.ang.util.Utils
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
+private enum class SubscriptionShareAction { QRCode, Clipboard }
+
 class SubSettingActivity : BaseComponentActivity() {
     private val viewModel: SubscriptionsViewModel by viewModels()
 
@@ -249,16 +251,9 @@ fun SubSettingScreen(
             options = shareSubMethodEntries,
             onSelected = { index, _ ->
                 shareTarget = null
-                when (index) {
-                    0 -> {
-                        // QRCode
-                        showQRCodeBitmap = onShareQRCode(url)
-                    }
-
-                    1 -> {
-                        // Export to clipboard
-                        onShareClipboard(url)
-                    }
+                when (SubscriptionShareAction.entries[index]) {
+                    SubscriptionShareAction.QRCode -> showQRCodeBitmap = onShareQRCode(url)
+                    SubscriptionShareAction.Clipboard -> onShareClipboard(url)
                 }
             },
             onDismiss = { shareTarget = null }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -245,7 +244,6 @@ class UserAssetActivity : HelperBaseComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UserAssetScreen(
     viewModel: UserAssetViewModel,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
 import androidx.activity.viewModels
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,7 +21,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -54,6 +54,7 @@ import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.base.HelperBaseComponentActivity
+import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 import com.v2ray.ang.ui.compose.ItemDivider
@@ -68,6 +69,12 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.DateFormat
 import java.util.Date
+
+private enum class AddAssetMenuAction(@StringRes val labelRes: Int) {
+    File(R.string.menu_item_add_file),
+    Url(R.string.menu_item_add_url),
+    QRCode(R.string.menu_item_scan_qrcode)
+}
 
 class UserAssetActivity : HelperBaseComponentActivity() {
 
@@ -284,18 +291,14 @@ fun UserAssetScreen(
                             offset = DpOffset(x = 0.dp, y = 0.dp),
                             modifier = Modifier.wrapContentWidth(Alignment.End)
                         ) {
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_add_file)) },
-                                onClick = { showAddMenu = false; onAddFileClick() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_add_url)) },
-                                onClick = { showAddMenu = false; onAddUrlClick() }
-                            )
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.menu_item_scan_qrcode)) },
-                                onClick = { showAddMenu = false; onAddQrcodeClick() }
-                            )
+                            AppDropdownMenuItems(AddAssetMenuAction.entries, { it.labelRes }) { action ->
+                                showAddMenu = false
+                                when (action) {
+                                    AddAssetMenuAction.File -> onAddFileClick()
+                                    AddAssetMenuAction.Url -> onAddUrlClick()
+                                    AddAssetMenuAction.QRCode -> onAddQrcodeClick()
+                                }
+                            }
                         }
                     }
                     IconButton(onClick = onDownloadClick) {

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -423,10 +423,8 @@
     <string name="action_delete">حذف</string>
     <string name="action_close">إغلاق</string>
 
-    <string-array name="share_sub_method">
-        <item>رمز استجابة سريعة (QRcode)</item>
-        <item>تصدير إلى الحافظة</item>
-    </string-array>
+    <string name="share_subscription_qrcode">رمز استجابة سريعة (QRcode)</string>
+    <string name="share_subscription_clipboard">تصدير إلى الحافظة</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -457,9 +455,7 @@
         <item>Round Robin</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>Local</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">Local</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -422,10 +422,8 @@
     <string name="action_delete">মুছুন</string>
     <string name="action_close">বন্ধ করুন</string>
 
-    <string-array name="share_sub_method">
-        <item>QR কোড</item>
-        <item>ক্লিপবোর্ডে রপ্তানি করুন</item>
-    </string-array>
+    <string name="share_subscription_qrcode">QR কোড</string>
+    <string name="share_subscription_clipboard">ক্লিপবোর্ডে রপ্তানি করুন</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -437,13 +435,11 @@
         <item>লাইট</item>
         <item>ডার্ক</item>
     </string-array>
-    <string-array name="preset_rulesets">
-        <item>চায়না হোয়াইটলিস্ট</item>
-        <item>চায়না ব্ল্যাকলিস্ট</item>
-        <item>গ্লোবাল</item>
-        <item>ইরান হোয়াইটলিস্ট</item>
-        <item>রাশিয়া হোয়াইটলিস্ট</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">চায়না হোয়াইটলিস্ট</string>
+    <string name="routing_preset_china_blacklist">চায়না ব্ল্যাকলিস্ট</string>
+    <string name="routing_preset_global">গ্লোবাল</string>
+    <string name="routing_preset_iran_whitelist">ইরান হোয়াইটলিস্ট</string>
+    <string name="routing_preset_russia_whitelist">রাশিয়া হোয়াইটলিস্ট</string>
 
     <string-array name="vpn_bypass_lan">
         <item>Follow config</item>
@@ -463,9 +459,7 @@
         <item>Round Robin</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>Local</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">Local</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -428,10 +428,8 @@
     <string name="action_delete">پاک کردن</string>
     <string name="action_close">بستن</string>
 
-    <string-array name="share_sub_method">
-        <item>QRcode</item>
-        <item>و در کشیڌن من کلیپ بورد</item>
-    </string-array>
+    <string name="share_subscription_qrcode">QRcode</string>
+    <string name="share_subscription_clipboard">و در کشیڌن من کلیپ بورد</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -444,13 +442,11 @@
         <item>تاریک</item>
     </string-array>
 
-    <string-array name="preset_rulesets">
-        <item>نومگه اسبؽڌ چین</item>
-        <item>نومگه شه چین</item>
-        <item>جهۊوی (Global)</item>
-        <item>نومگه اسبؽڌ ایران</item>
-        <item>نومگه اسبؽڌ رۊسیه</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">نومگه اسبؽڌ چین</string>
+    <string name="routing_preset_china_blacklist">نومگه شه چین</string>
+    <string name="routing_preset_global">جهۊوی (Global)</string>
+    <string name="routing_preset_iran_whitelist">نومگه اسبؽڌ ایران</string>
+    <string name="routing_preset_russia_whitelist">نومگه اسبؽڌ رۊسیه</string>
 
     <string-array name="vpn_bypass_lan">
         <item>پؽش فرز کانفیگ</item>
@@ -470,9 +466,7 @@
         <item>گردشی</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>مهلی</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">مهلی</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -419,10 +419,8 @@
     <string name="action_delete">حذف</string>
     <string name="action_close">بستن</string>
 
-    <string-array name="share_sub_method">
-        <item>QRcode</item>
-        <item>خروجی گرفتن در کلیپ‌ بورد</item>
-    </string-array>
+    <string name="share_subscription_qrcode">QRcode</string>
+    <string name="share_subscription_clipboard">خروجی گرفتن در کلیپ‌ بورد</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -437,13 +435,11 @@
         <item>تاریک</item>
     </string-array>
 
-    <string-array name="preset_rulesets">
-        <item>لیست سفید چین ( دور زدن سرزمین اصلی )</item>
-        <item>لیست سیاه چین</item>
-        <item>جهانی(GLOBAL)</item>
-        <item>ایران</item>
-        <item>لیست سفید روسیه</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">لیست سفید چین ( دور زدن سرزمین اصلی )</string>
+    <string name="routing_preset_china_blacklist">لیست سیاه چین</string>
+    <string name="routing_preset_global">جهانی(GLOBAL)</string>
+    <string name="routing_preset_iran_whitelist">ایران</string>
+    <string name="routing_preset_russia_whitelist">لیست سفید روسیه</string>
 
     <string-array name="vpn_bypass_lan">
         <item>پیش فرض کانفیگ</item>
@@ -463,9 +459,7 @@
         <item>گردشی</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>محلی</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">محلی</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -435,10 +435,8 @@
     <string name="action_delete">Удалить</string>
     <string name="action_close">Закрыть</string>
 
-    <string-array name="share_sub_method">
-        <item>QR-код</item>
-        <item>Экспорт в буфер обмена</item>
-    </string-array>
+    <string name="share_subscription_qrcode">QR-код</string>
+    <string name="share_subscription_clipboard">Экспорт в буфер обмена</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -457,13 +455,11 @@
         <item>Тёмная</item>
     </string-array>
 
-    <string-array name="preset_rulesets">
-        <item>Белый список Китая</item>
-        <item>Чёрный список Китая</item>
-        <item>Общие</item>
-        <item>Белый список Ирана</item>
-        <item>Белый список России</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">Белый список Китая</string>
+    <string name="routing_preset_china_blacklist">Чёрный список Китая</string>
+    <string name="routing_preset_global">Общие</string>
+    <string name="routing_preset_iran_whitelist">Белый список Ирана</string>
+    <string name="routing_preset_russia_whitelist">Белый список России</string>
 
     <string-array name="vpn_bypass_lan">
         <item>Как в профиле</item>
@@ -484,9 +480,7 @@
         <item>По очереди</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>Локально</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">Локально</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -424,10 +424,8 @@
     <string name="action_delete">Xoá</string>
     <string name="action_close">Đóng</string>
 
-    <string-array name="share_sub_method">
-        <item>Xuất gói ra mã QR (Chụp màn hình để lưu)</item>
-        <item>Xuất gói vào Clipboard</item>
-    </string-array>
+    <string name="share_subscription_qrcode">Xuất gói ra mã QR (Chụp màn hình để lưu)</string>
+    <string name="share_subscription_clipboard">Xuất gói vào Clipboard</string>
 
     <string-array name="mode_entries">
         <item>Chế độ VPN</item>
@@ -459,9 +457,7 @@
         <item>Round Robin</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>Local</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">Local</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -438,10 +438,8 @@
     <string name="action_delete">删除</string>
     <string name="action_close">关闭</string>
 
-    <string-array name="share_sub_method">
-        <item>二维码</item>
-        <item>导出至剪贴板</item>
-    </string-array>
+    <string name="share_subscription_qrcode">二维码</string>
+    <string name="share_subscription_clipboard">导出至剪贴板</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -454,13 +452,11 @@
         <item>深色</item>
     </string-array>
 
-    <string-array name="preset_rulesets">
-        <item>绕过大陆 (Whitelist)</item>
-        <item>黑名单 (Blacklist)</item>
-        <item>全局 (Global)</item>
-        <item>伊朗 (Iran)</item>
-        <item>俄罗斯白名单 (Russia Whitelist)</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">绕过大陆 (Whitelist)</string>
+    <string name="routing_preset_china_blacklist">黑名单 (Blacklist)</string>
+    <string name="routing_preset_global">全局 (Global)</string>
+    <string name="routing_preset_iran_whitelist">伊朗 (Iran)</string>
+    <string name="routing_preset_russia_whitelist">俄罗斯白名单 (Russia Whitelist)</string>
 
     <string-array name="vpn_bypass_lan">
         <item>跟随配置</item>
@@ -480,9 +476,7 @@
         <item>轮询</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>本地</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">本地</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -436,10 +436,8 @@
     <string name="action_delete">刪除</string>
     <string name="action_close">關閉</string>
 
-    <string-array name="share_sub_method">
-        <item>二維碼</item>
-        <item>匯出至剪貼簿</item>
-    </string-array>
+    <string name="share_subscription_qrcode">二維碼</string>
+    <string name="share_subscription_clipboard">匯出至剪貼簿</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -452,13 +450,11 @@
         <item>深色</item>
     </string-array>
 
-    <string-array name="preset_rulesets">
-        <item>繞過大陸 (Whitelist)</item>
-        <item>黑名單 (Blacklist)</item>
-        <item>全域 (Global)</item>
-        <item>伊朗 (Iran)</item>
-        <item>俄羅斯白名單 (Russia Whitelist)</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">繞過大陸 (Whitelist)</string>
+    <string name="routing_preset_china_blacklist">黑名單 (Blacklist)</string>
+    <string name="routing_preset_global">全域 (Global)</string>
+    <string name="routing_preset_iran_whitelist">伊朗 (Iran)</string>
+    <string name="routing_preset_russia_whitelist">俄羅斯白名單 (Russia Whitelist)</string>
 
     <string-array name="vpn_bypass_lan">
         <item>跟隨設定檔</item>
@@ -478,9 +474,7 @@
         <item>輪詢</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>本地</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">本地</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -444,10 +444,8 @@
     <string name="action_delete">Delete</string>
     <string name="action_close">Close</string>
 
-    <string-array name="share_sub_method">
-        <item>QRcode</item>
-        <item>Export to clipboard</item>
-    </string-array>
+    <string name="share_subscription_qrcode">QRcode</string>
+    <string name="share_subscription_clipboard">Export to clipboard</string>
 
     <string-array name="mode_entries">
         <item>VPN</item>
@@ -466,13 +464,11 @@
         <item>Dark</item>
     </string-array>
 
-    <string-array name="preset_rulesets">
-        <item>China Whitelist</item>
-        <item>China Blacklist</item>
-        <item>Global</item>
-        <item>Iran Whitelist</item>
-        <item>Russia Whitelist</item>
-    </string-array>
+    <string name="routing_preset_china_whitelist">China Whitelist</string>
+    <string name="routing_preset_china_blacklist">China Blacklist</string>
+    <string name="routing_preset_global">Global</string>
+    <string name="routing_preset_iran_whitelist">Iran Whitelist</string>
+    <string name="routing_preset_russia_whitelist">Russia Whitelist</string>
 
     <string-array name="vpn_bypass_lan">
         <item>Follow config</item>
@@ -493,9 +489,7 @@
         <item>Round Robin</item>
     </string-array>
 
-    <string-array name="config_backup_options">
-        <item>Local</item>
-        <item>WebDAV</item>
-    </string-array>
+    <string name="backup_location_local">Local</string>
+    <string name="backup_location_webdav">WebDAV</string>
 
 </resources>


### PR DESCRIPTION
I've extracted another big section from the Google TV UI project that's not specific to TV UI.

## Summary

This continues the Compose migration by making fixed application menus type-safe and by replacing the custom drawer rows with the Material 3 component intended for navigation destinations.

- model fixed menu and drawer actions with enums instead of string routes or integer positions
- render repeated dropdown entries through a small shared Compose helper
- use `NavigationDrawerItem` and its standard item padding inside the existing `ModalNavigationDrawer`
- route system Back through Compose so an open drawer closes before the main task is moved to the background

Dynamic value selectors remain unchanged. This PR only covers fixed application actions and destinations.

## Rationale

Several menus retained imperative index or string dispatch after their UI was migrated to Compose. Their visual entries and action handlers were maintained separately, so inserting or reordering an item could silently route to the wrong action. With typed actions, each rendered entry carries its action and exhaustive `when` expressions make incomplete handling visible at compile time.

The drawer container already used `ModalNavigationDrawer` and `ModalDrawerSheet`, but its destinations were custom clickable rows that duplicated Material sizing, colors, selected-state styling, and semantics. The current Android Compose guidance uses `NavigationDrawerItem` for destinations within a drawer sheet. Using the standard component removes that local approximation and inherits the Material 3 behavior and tokens maintained by the library.

The main activity also intercepted `KEYCODE_BACK` in `onKeyDown`, before AndroidX could dispatch the event to Compose. Android's current guidance is to use the AndroidX Back APIs, with `BackHandler` for state-dependent Compose behavior; direct `KEYCODE_BACK` interception is not supported for system Back navigation. Back handling is now layered by responsibility: the inner enabled handler closes an open drawer, while the outer handler preserves the existing behavior of moving the task to the background. Game-controller `BUTTON_B` support remains in `onKeyDown`.

Relevant Android guidance:

- [Navigation drawer in Compose](https://developer.android.com/develop/ui/compose/components/drawer)
- [Custom Back navigation](https://developer.android.com/guide/navigation/custom-back)
- [Predictive Back migration and callback guidance](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture)

## User impact

Menu labels, ordering, destinations, and actions are unchanged. The drawer now uses standard Material 3 item spacing and styling, and Back dismisses an open drawer before leaving the app.
