### PR TITLE
fix: sync locale resources and translations (1/3)

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -134,7 +134,7 @@ class CoreTestService : Service() {
                     channelType = NotificationChannelType.CORE_TEST,
                     context = this,
                     title = getString(R.string.app_name),
-                    content = getString(R.string.connection_runing_task_left, event.text)
+                    content = getString(R.string.connection_running_task_left, event.text)
                 )
                 MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_NOTIFY, event.text)
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -132,7 +132,7 @@ class MainViewModel(
                 _uiState.update {
                     it.copy(
                         statusText = dataSource.getString(
-                            R.string.connection_runing_task_left,
+                            R.string.connection_running_task_left,
                             event.progress
                         )
                     )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
@@ -284,6 +284,10 @@ fun RoutingEditScreen(
             )
             FormDropdownField(
                 label = stringResource(R.string.routing_settings_outbound_tag),
+                placeholder = stringResource(
+                    R.string.routing_settings_outbound_tag_hint,
+                    stringResource(R.string.server_lab_remarks)
+                ),
                 value = outboundTag,
                 options = outboundSuggestions,
                 onValueChange = { outboundTag = it },

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -121,7 +121,7 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                 e
             )
             toast(
-                "${getString(R.string.toast_malformed_josn)} " +
+                "${getString(R.string.toast_malformed_json)} " +
                         "${e.cause?.message.orEmpty()}"
             )
             return false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/settings/SettingsActivity.kt
@@ -453,14 +453,14 @@ fun SettingsScreen(
                     onCheckedChange = { mux = it }
                 )
                 SettingsEditItem(
-                    title = stringResource(R.string.title_pref_mux_concurency),
+                    title = stringResource(R.string.title_pref_mux_concurrency),
                     value = muxConcurrency,
                     enabled = mux,
                     keyboardNumber = true,
                     onValueChanged = { muxConcurrency = it }
                 )
                 SettingsEditItem(
-                    title = stringResource(R.string.title_pref_mux_xudp_concurency),
+                    title = stringResource(R.string.title_pref_mux_xudp_concurrency),
                     value = muxXudpConcurrency,
                     enabled = mux,
                     keyboardNumber = true,

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">رابط URL غير صالح</string>
     <string name="toast_insecure_url_protocol">يرجى عدم استخدام عنوان اشتراك ببروتوكول HTTP غير الآمن</string>
     <string name="server_lab_need_inbound">تأكد من أن منفذ الاتصالات الواردة يتوافق مع الإعدادات</string>
-    <string name="toast_malformed_json">تكوين مشوه</string>
+    <string name="toast_malformed_json">تنسيق التكوين غير صالح.</string>
     <string name="server_lab_request_host6">مضيف (SNI) (اختياري)</string>
     <string name="toast_action_not_allowed">الإجراء غير مسموح به</string>
     <string name="server_obfs_password">كلمة مرور Obfs</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">تمكين Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">يدعم فقط اتصالات xhttp (packet-up) وws الصادرة؛ قد يتم تجاهل الإعدادات المتعلقة بـ TLS أو قد تتعارض</string>
     <string name="toast_allow_insecure_deprecated">تستخدم العقدة الحالية اتصالاً غير مشفر. قد تتمكن تجهيزات الشبكة الوسيطة الخاضعة لسيطرة حكومات استبدادية من الاطلاع مباشرةً على اتصالاتك.\nلأسباب أمنية، لا يمكن الاتصال بهذه العقد عبر نواة Xray الإصدار 26.2.6 أو أحدث.\nإذا كانت العقدة من إعدادك، ففعّل تشفيراً آمناً مثل TLS أو ثبّت بصمة الشهادة pinnedCA256.\nإذا كانت العقدة تابعة لمزوّد خدمة، فتواصل معه لإكمال الترقية التقنية. إذا رفض المزوّد التعاون، فنوصي بالانتقال إلى مزوّد يهتم أكثر بأمان المستخدمين.\nلمزيد من المعلومات، تفضل بزيارة https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">جلب بصمة الشهادة وتعبئتها</string>
+    <string name="pinned_ca256_action_fetch">جلب بصمة الشهادة</string>
     <string name="toast_fetch_cert_sha256_success">تم جلب بصمة الشهادة بنجاح</string>
     <string name="toast_fetch_cert_sha256_failed">فشل جلب بصمة الشهادة</string>
 
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">تمكين عرض السرعة</string>
-    <string name="summary_pref_speed_enabled">عرض السرعة الحالية في الإشعار.\nستتغير أيقونة الإشعار بناءً على الاستخدام.</string>
+    <string name="summary_pref_speed_enabled">عرض سرعات الاتصال الحالية في الإشعار.\nتوضح الأيقونة ما إذا كانت حركة الوكيل أم الحركة المباشرة هي الغالبة.</string>
 
-    <string name="title_pref_sniffing_enabled">تفعيل تحليل الحزم (Sniffing)</string>
-    <string name="summary_pref_sniffing_enabled">محاولة استخراج النطاق من الحزمة (مفعل افتراضيًا)</string>
+    <string name="title_pref_sniffing_enabled">تفعيل اكتشاف نطاقات الوجهة (Sniffing)</string>
+    <string name="summary_pref_sniffing_enabled">اكتشاف نطاقات الوجهة من حركة المرور (مفعّل افتراضيًا).</string>
     <string name="title_pref_route_only_enabled">تمكين routeOnly</string>
     <string name="summary_pref_route_only_enabled">استخدم اسم النطاق الذي تم استخراجه للتوجيه فقط، واحتفظ بعنوان الوجهة كعنوان IP.</string>
 
     <string name="title_pref_local_dns_enabled">تفعيل DNS المحلي</string>
     <string name="summary_pref_local_dns_enabled">يتم معالجة DNS بواسطة وحدة DNS الأساسية (موصى به، إذا لزم تجاوز التوجيه لشبكة LAN وعنوان البر الرئيسي)</string>
 
-    <string name="title_pref_fake_dns_enabled">تفعيل DNS وهمي (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">يعيد DNS المحلي عنوان IP وهمي (أسرع، ولكنه قد لا يعمل مع بعض التطبيقات)</string>
+    <string name="title_pref_fake_dns_enabled">تفعيل DNS اصطناعي (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">يعيد FakeDNS عناوين IP اصطناعية لاستعلامات النطاقات (أسرع، لكنه قد لا يعمل مع بعض التطبيقات).</string>
 
     <string name="title_pref_ipv6_enabled">تفعيل IPv6</string>
     <string name="summary_pref_ipv6_enabled">إضافة عنوان IPv6 والمسارات إلى واجهة VPN</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">عنوان URL لاختبار التأخير الحقيقي</string>
     <string name="summary_pref_delay_test_url">عنوان URL</string>
-    <string name="title_pref_real_ping_concurrency">تزامن اختبار التأخير الحقيقي</string>
+    <string name="title_pref_real_ping_concurrency">اختبارات تأخير حقيقي متزامنة</string>
 
     <string name="title_pref_ip_api_url">عنوان URL لاختبار معلومات الاتصال الحالي</string>
     <string name="summary_pref_ip_api_url">عنوان URL</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">ما إذا كان حذف ملف التكوين يتطلب تأكيدًا ثانيًا من قبل المستخدم</string>
 
 
-    <string name="title_pref_append_http_proxy">إلحاق وكيل HTTP بشبكة VPN</string>
+    <string name="title_pref_append_http_proxy">إضافة وكيل HTTP إلى شبكة VPN</string>
     <string name="summary_pref_append_http_proxy">سيُستخدم وكيل HTTP مباشرةً من المتصفح وبعض التطبيقات المدعومة من دون المرور بواجهة NIC الافتراضية (Android 10+)</string>
 
     <string name="title_pref_double_column_display">تمكين العرض بعمودين</string>
-    <string name="summary_pref_double_column_display">عرض قائمة الملفات الشخصية في عمودين لإظهار محتوى أكبر على الشاشة.</string>
+    <string name="summary_pref_double_column_display">عرض قائمة التكوينات في عمودين لإظهار محتوى أكبر على الشاشة.</string>
 
-    <string name="title_pref_group_all_display">تمكين عرض كل المجموعات</string>
-    <string name="summary_pref_group_all_display">إضافة صفحة «كل علامات التبويب»</string>
+    <string name="title_pref_group_all_display">إظهار علامة تبويب «الكل»</string>
+    <string name="summary_pref_group_all_display">جمع تكوينات جميع مجموعات الاشتراك في علامة تبويب واحدة.</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">ملاحظات</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">فاصل التحديث التلقائي (بالدقائق، الحد الأدنى للقيمة 15)</string>
 
     <string name="title_core_loglevel">مستوى السجل</string>
-    <string name="title_outbound_domain_resolve_method">طريقة الحل المسبق لنطاق الخروج (outbound)</string>
+    <string name="title_outbound_domain_resolve_method">حل أسماء نطاقات الاتصالات الصادرة (outbound)</string>
     <string name="title_mode">الوضع</string>
     <string name="title_mode_help">انقر هنا للحصول على مزيد من المساعدة</string>
     <string name="title_language">اللغة</string>
@@ -302,10 +302,10 @@
     <string name="title_pref_hev_tunnel_rw_timeout">مهلة القراءة/الكتابة لـ Hev TUN بالثواني (القيم الافتراضية tcp,udp هي 300,60)</string>
     <string name="title_mode_settings">إعدادات الوضع</string>
     <string name="title_root_mode_enabled">تمكين وضع Root (لمستخدمي Root)</string>
-    <string name="summary_root_mode_enabled">تمكين وكيل شفاف منخفض المستوى باستخدام صلاحيات Root. يتجاوز هذا الوضع شبكة VPN القياسية لنظام Android ويتولى مباشرةً كل حركة مرور الشبكة الأساسية. بعد تمكينه، لن يعود للوضع العادي الأصلي أو توجيه التطبيقات أو إعدادات VPN المرتبطة بها أي تأثير.</string>
+    <string name="summary_root_mode_enabled">استخدام صلاحيات Root للوكيل الشفاف منخفض المستوى. يدير وضع Root حركة مرور الشبكة مباشرةً بدلاً من استخدام خدمة VPN في Android. أثناء تفعيله، لا يعمل الوضع العادي ولا توجيه التطبيقات ولا إعدادات VPN المرتبطة.</string>
     <string name="toast_root_required">تتطلب هذه الميزة صلاحيات Root</string>
-    <string name="title_root_lan_sharing">مشاركة LAN / الربط (لمستخدمي Root)</string>
-    <string name="summary_root_lan_sharing">توجيه أجهزة نقطة اتصال Wi-Fi والأجهزة المربوطة عبر USB من خلال VPN</string>
+    <string name="title_root_lan_sharing">مشاركة VPN مع أجهزة LAN / الأجهزة المربوطة (لمستخدمي Root)</string>
+    <string name="summary_root_lan_sharing">توجيه حركة مرور أجهزة نقطة اتصال Wi-Fi والأجهزة المربوطة عبر USB من خلال VPN.</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">نسخ</string>
@@ -345,8 +345,8 @@
     <string name="title_update_subscription_result">تم تحديث %1$d إعدادات (%2$d ناجحة، %3$d فاشلة، %4$d متخطاة)</string>
     <string name="title_update_subscription_no_subscription">لا توجد اشتراكات</string>
     <string name="toast_server_not_found_in_group">لم يُعثر على الخادم المحدد في المجموعة الحالية</string>
-    <string name="toast_fragment_not_available">تعذر تحديد العرض الحالي</string>
-    <string name="title_locate_selected_config">تحديد موقع الإعداد المحدد</string>
+    <string name="toast_fragment_not_available">الشاشة الحالية غير متاحة.</string>
+    <string name="title_locate_selected_config">العثور على التكوين المحدد</string>
 
     <string name="tasker_start_service">بدء الخدمة</string>
     <string name="tasker_setting_confirm">تأكيد</string>
@@ -385,7 +385,7 @@
     <string name="connection_test_error_status_code">رمز الخطأ: #%d</string>
     <string name="connection_connected">متصل، انقر للتحقق من الاتصال</string>
     <string name="connection_not_connected">غير متصل</string>
-    <string name="connection_running_task_left">عدد مهام الاختبار قيد التشغيل: %s</string>
+    <string name="connection_running_task_left">الاختبارات قيد التشغيل: %s</string>
 
     <string name="import_subscription_success">تم استيراد الاشتراك بنجاح</string>
     <string name="import_subscription_failure">فشل استيراد الاشتراك</string>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">البصمة</string>
     <string name="server_lab_stream_alpn">بروتوكول الطبقة الآخرى التالية (ALPN)</string>
     <string name="server_lab_allow_insecure">تخطي التحقق من الشهادة (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">العنوان</string>
     <string name="server_lab_port3">المنفذ</string>
     <string name="server_lab_id3">كلمة المرور</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">المفتاح العام</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">المعرّف القصير</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
     <string name="server_lab_secret_key">المفتاح السري</string>
     <string name="server_lab_reserved">محجوز (اختياري)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">تفضيل عناوين IPv6 عند حل أسماء النطاقات</string>
 
     <string name="title_pref_remote_dns">DNS البعيد (udp/tcp/https/quic) (اختياري)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (IPv4/v6 فقط)</string>
     <string name="title_pref_vpn_bypass_lan">هل تتجاوز VPN شبكة LAN؟</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">DNS المحلي (اختياري)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">مضيفو DNS (التنسيق: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">منفذ البروكسي المحلي</string>
     <string name="title_pref_enable_local_proxy">تفعيل الوكيل المحلي</string>
     <string name="summary_pref_enable_local_proxy">عند التعطيل، لن يتوفر وكيل SOCKS، ولذلك لن تتمكن تحديثات الاشتراك والإجراءات المشابهة من استخدام الوكيل</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">مصادقة socks5 ليست آمنة تمامًا عند استخدام UDP</string>
     <string name="summary_pref_socks_port">منفذ البروكسي المحلي</string>
     <string name="title_pref_dynamic_socks_port">تمكين منفذ وكيل محلي ديناميكي</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">إعداد مجموعة الاشتراك</string>
     <string name="sub_setting_remarks">ملاحظات</string>
     <string name="sub_setting_url">عنوان URL اختياري</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">رؤوس الطلب (بتنسيق JSON)</string>
     <string name="sub_setting_filter">مرشح تعبير نمطي للملاحظات</string>
     <string name="sub_setting_enable">تفعيل التحديث</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">تم تحديث %1$d إعدادات (%2$d ناجحة، %3$d فاشلة، %4$d متخطاة)</string>
     <string name="title_update_subscription_no_subscription">لا توجد اشتراكات</string>
     <string name="toast_server_not_found_in_group">لم يُعثر على الخادم المحدد في المجموعة الحالية</string>
-    <string name="toast_fragment_not_available">الشاشة الحالية غير متاحة.</string>
     <string name="title_locate_selected_config">العثور على التكوين المحدد</string>
 
     <string name="tasker_start_service">بدء الخدمة</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">اختيار اسم الحزمة</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">التحقق من الاتصال</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">محلي</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">التبديل</string>
     <string name="app_tile_name">التبديل</string>
     <string name="app_tile_first_use">أول استخدام لهذه الميزة، يرجى استخدام التطبيق لإضافة خادم</string>
@@ -54,7 +55,6 @@
     <string name="server_lab_port">المنفذ</string>
     <string name="server_lab_id">المعرف</string>
     <string name="server_lab_alterid">AlterId</string>
-
     <string name="server_lab_security">الأمان</string>
     <string name="server_lab_network">الشبكة</string>
     <string name="server_lab_more_function">النقل</string>
@@ -77,8 +77,8 @@
     <string name="server_lab_path_kcp">kcp seed</string>
     <string name="server_lab_path_grpc">gRPC serviceName</string>
     <string name="server_lab_stream_security">TLS</string>
-    <string name="server_lab_stream_fingerprint" translatable="false">البصمة</string>
-    <string name="server_lab_stream_alpn" translatable="false">بروتوكول الطبقة الآخرى التالية (ALPN)</string>
+    <string name="server_lab_stream_fingerprint">البصمة</string>
+    <string name="server_lab_stream_alpn">بروتوكول الطبقة الآخرى التالية (ALPN)</string>
     <string name="server_lab_allow_insecure">السماح غير الآمن</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">العنوان</string>
@@ -89,12 +89,12 @@
     <string name="server_lab_security4">المستخدم (اختياري)</string>
     <string name="server_lab_encryption">التشفير</string>
     <string name="server_lab_flow">التدفق</string>
-    <string name="server_lab_public_key" translatable="false">المفتاح العام</string>
+    <string name="server_lab_public_key">المفتاح العام</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
-    <string name="server_lab_short_id" translatable="false">المعرّف القصير</string>
-    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
+    <string name="server_lab_short_id">المعرّف القصير</string>
+    <string name="server_lab_spider_x">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
-    <string name="server_lab_secret_key" translatable="false">المفتاح السري</string>
+    <string name="server_lab_secret_key">المفتاح السري</string>
     <string name="server_lab_reserved">محجوز (اختياري)</string>
     <string name="server_lab_local_address">العنوان المحلي (اختياري IPv4/IPv6، مفصولة بفواصل)</string>
     <string name="server_lab_local_mtu">Mtu (اختياري، الافتراضي 1420)</string>
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">رابط URL غير صالح</string>
     <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
     <string name="server_lab_need_inbound">تأكد من أن منفذ الاتصالات الواردة يتوافق مع الإعدادات</string>
-    <string name="toast_malformed_josn">تكوين مشوه</string>
+    <string name="toast_malformed_json">تكوين مشوه</string>
     <string name="server_lab_request_host6">مضيف (SNI) (اختياري)</string>
     <string name="toast_action_not_allowed">الإجراء غير مسموح به</string>
     <string name="server_obfs_password">Obfs password</string>
@@ -128,6 +128,9 @@
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_browser_dialer">تمكين Browser Dialer</string>
+    <string name="server_lab_browser_dialer_tip">يدعم فقط اتصالات xhttp (packet-up) وws الصادرة؛ قد يتم تجاهل الإعدادات المتعلقة بـ TLS أو قد تتعارض</string>
+    <string name="toast_allow_insecure_deprecated">تستخدم العقدة الحالية اتصالاً غير مشفر. قد تتمكن تجهيزات الشبكة الوسيطة الخاضعة لسيطرة حكومات استبدادية من الاطلاع مباشرةً على اتصالاتك.\nلأسباب أمنية، لا يمكن الاتصال بهذه العقد عبر نواة Xray الإصدار 26.2.6 أو أحدث.\nإذا كانت العقدة من إعدادك، ففعّل تشفيراً آمناً مثل TLS أو ثبّت بصمة الشهادة pinnedCA256.\nإذا كانت العقدة تابعة لمزوّد خدمة، فتواصل معه لإكمال الترقية التقنية. إذا رفض المزوّد التعاون، فنوصي بالانتقال إلى مزوّد يهتم أكثر بأمان المستخدمين.\nلمزيد من المعلومات، تفضل بزيارة https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
     <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
     <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
@@ -138,7 +141,7 @@
     <string name="menu_item_add_file">إضافة ملفات</string>
     <string name="menu_item_add_url">إضافة URL</string>
     <string name="menu_item_scan_qrcode">مسح رمز الاستجابة السريعة (QRcode)</string>
-    <string name="title_url" translatable="false">URL</string>
+    <string name="title_url">URL</string>
     <string name="menu_item_download_file">تنزيل الملفات</string>
     <string name="title_user_asset_add_url">إضافة عنوان URL للأصل</string>
     <string name="msg_file_not_found">الملف غير موجود</string>
@@ -158,7 +161,7 @@
     <string name="menu_item_import_proxy_app">استيراد من الحافظة</string>
     <string name="per_app_proxy_settings">Per-app settings</string>
     <string name="per_app_proxy_settings_enable">Enable per-app</string>
-
+    <string name="app_picker_unknown_app">تطبيق غير معروف (UID غير محدد)</string>
 
     <!-- Preferences -->
     <string name="title_settings">الإعدادات</string>
@@ -170,6 +173,10 @@
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
 
+
+    <string name="subscription_updater_job_tips">ستعمل المهمة في الخلفية، وسيُعرض تقدمها في الإشعار.</string>
+    <string name="title_pref_auto_test_after_update_subscription">اختبار تلقائي بعد تحديث الاشتراك</string>
+    <string name="summary_pref_auto_test_after_update_subscription">يستغرق الاختبار التلقائي وقتاً طويلاً. عند تمكينه، ستعمل المهمة في الخلفية؛ وإلا فستعمل في الصفحة الحالية.</string>
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>
     <string name="title_pref_auto_sort_after_test">Auto sort after testing</string>
@@ -178,8 +185,8 @@
     <string name="title_mux_settings">إعدادات Mux</string>
     <string name="title_pref_mux_enabled">تمكين Mux</string>
     <string name="summary_pref_mux_enabled">أسرع، لكن قد يتسبب في اتصال غير مستقر\nتخصيص كيفية التعامل مع TCP و UDP و QUIC أدناه</string>
-    <string name="title_pref_mux_concurency">اتصالات TCP（النطاق من -1 إلى 1024）</string>
-    <string name="title_pref_mux_xudp_concurency">اتصالات XUDP（النطاق من -1 إلى 1024）</string>
+    <string name="title_pref_mux_concurrency">اتصالات TCP（النطاق من -1 إلى 1024）</string>
+    <string name="title_pref_mux_xudp_concurrency">اتصالات XUDP（النطاق من -1 إلى 1024）</string>
     <string name="title_pref_mux_xudp_quic">التعامل مع QUIC في نفق mux</string>
     <string-array name="mux_xudp_quic_entries">
         <item>رفض</item>
@@ -189,6 +196,7 @@
 
     <string name="title_pref_speed_enabled">تمكين عرض السرعة</string>
     <string name="summary_pref_speed_enabled">عرض السرعة الحالية في الإشعار.\nستتغير أيقونة الإشعار بناءً على الاستخدام.</string>
+
     <string name="title_pref_sniffing_enabled">تفعيل استخراج الشبكة</string>
     <string name="summary_pref_sniffing_enabled">محاولة استخراج النطاق من الحزمة (مفعل افتراضيًا)</string>
     <string name="title_pref_route_only_enabled">تفعيل التوجيه فقط</string>
@@ -213,7 +221,9 @@
     <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
 
     <string name="title_pref_vpn_interface_address">VPN Interface Address</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+
 
     <string name="title_pref_domestic_dns">DNS المحلي (اختياري)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
@@ -260,6 +270,7 @@
 
     <string name="title_pref_group_all_display">Enable show all groups</string>
     <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+
     <!-- AboutActivity -->
     <string name="title_pref_feedback">ملاحظات</string>
     <string name="summary_pref_feedback">ملاحظات التحسينات أو الأخطاء إلى GitHub</string>
@@ -289,6 +300,12 @@
     <string name="summary_pref_use_hev_tunnel">When enabled, TUN will use hev-socks5-tunnel; otherwise, it will use xray-core.</string>
     <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
     <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
+    <string name="title_mode_settings">إعدادات الوضع</string>
+    <string name="title_root_mode_enabled">تمكين وضع Root (لمستخدمي Root)</string>
+    <string name="summary_root_mode_enabled">تمكين وكيل شفاف منخفض المستوى باستخدام صلاحيات Root. يتجاوز هذا الوضع شبكة VPN القياسية لنظام Android ويتولى مباشرةً كل حركة مرور الشبكة الأساسية. بعد تمكينه، لن يعود للوضع العادي الأصلي أو توجيه التطبيقات أو إعدادات VPN المرتبطة بها أي تأثير.</string>
+    <string name="toast_root_required">تتطلب هذه الميزة صلاحيات Root</string>
+    <string name="title_root_lan_sharing">مشاركة LAN / الربط (لمستخدمي Root)</string>
+    <string name="summary_root_lan_sharing">توجيه أجهزة نقطة اتصال Wi-Fi والأجهزة المربوطة عبر USB من خلال VPN</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">نسخ</string>
@@ -303,6 +320,7 @@
     <string name="sub_setting_remarks">ملاحظات</string>
     <string name="sub_setting_url">عنوان URL اختياري</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_request_headers">رؤوس الطلب (بتنسيق JSON)</string>
     <string name="sub_setting_filter">Remarks regular filter</string>
     <string name="sub_setting_enable">تفعيل التحديث</string>
     <string name="sub_auto_update">تفعيل التحديث التلقائي</string>
@@ -318,9 +336,8 @@
     <string name="title_sort_by_test_results">الفرز حسب نتائج الاختبار (5)</string>
     <string name="title_filter_config">تصفية ملف التكوين</string>
     <string name="filter_config_all">All</string>
-    <string name="title_del_duplicate_config_count">حذف %d من الإعدادات المكررة</string>
     <string name="summary_scan_qrcode">Click screen open the camera scan</string>
-
+    <string name="title_del_duplicate_config_count">حذف %d من الإعدادات المكررة</string>
     <string name="title_del_config_count">Delete %d configurations</string>
     <string name="title_import_config_count">Import %d configurations</string>
     <string name="title_export_config_count">Export %d configurations</string>
@@ -350,11 +367,13 @@
     <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
-    <string name="routing_settings_process">process (Package Name — only supported when using Xray TUN, routeOnly enabled, and Android 10+)</string>
+    <string name="routing_settings_process">process (اسم الحزمة — مدعوم فقط عند استخدام Xray TUN وتمكين routeOnly وعلى Android 10+)</string>
+    <string name="routing_settings_process_select">اختيار اسم الحزمة</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">التحقق من الاتصال</string>
@@ -366,7 +385,7 @@
     <string name="connection_test_error_status_code">رمز الخطأ: #%d</string>
     <string name="connection_connected">متصل، انقر للتحقق من الاتصال</string>
     <string name="connection_not_connected">غير متصل</string>
-    <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_task_left">عدد مهام الاختبار قيد التشغيل: %s</string>
 
     <string name="import_subscription_success">تم استيراد الاشتراك بنجاح</string>
     <string name="import_subscription_failure">فشل استيراد الاشتراك</string>
@@ -397,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
     <string name="title_policy_group_test_outbounds">اختبار المخارج</string>
     <string name="title_policy_group_fallback">المخرج الاحتياطي (اختياري)</string>
+
     <string name="server_proxy_chain_members">اعضاء سلسلة الوكيل</string>
     <string name="server_proxy_chain_pick_members">اضغط هنا لاختيار عضو</string>
     <string name="server_proxy_chain_member_unselected">اختر عضوا</string>
@@ -431,11 +451,23 @@
         <item>بروكسي فقط</item>
     </string-array>
 
+    <string-array name="browser_dialer_mode">
+        <item>تعطيل</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
+    </string-array>
+
     <string-array name="ui_mode_night">
         <item>اتبع النظام</item>
         <item>فاتح</item>
         <item>داكن</item>
     </string-array>
+
+    <string name="routing_preset_china_whitelist">القائمة البيضاء للصين</string>
+    <string name="routing_preset_china_blacklist">القائمة السوداء للصين</string>
+    <string name="routing_preset_global">عالمي</string>
+    <string name="routing_preset_iran_whitelist">القائمة البيضاء لإيران</string>
+    <string name="routing_preset_russia_whitelist">القائمة البيضاء لروسيا</string>
 
     <string-array name="vpn_bypass_lan">
         <item>Follow config</item>
@@ -448,6 +480,7 @@
         <item>Resolve and add to DNS Hosts</item>
         <item>Resolve and replace domain</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>Least Ping</item>
         <item>Least Load</item>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">البصمة</string>
     <string name="server_lab_stream_alpn">بروتوكول الطبقة الآخرى التالية (ALPN)</string>
-    <string name="server_lab_allow_insecure">السماح غير الآمن</string>
+    <string name="server_lab_allow_insecure">تخطي التحقق من الشهادة (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">العنوان</string>
     <string name="server_lab_port3">المنفذ</string>
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">كلمة المرور (اختياري)</string>
     <string name="server_lab_security4">المستخدم (اختياري)</string>
     <string name="server_lab_encryption">التشفير</string>
-    <string name="server_lab_flow">التدفق</string>
+    <string name="server_lab_flow">التدفق (flow)</string>
     <string name="server_lab_public_key">المفتاح العام</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">المعرّف القصير</string>
@@ -197,7 +197,7 @@
     <string name="title_pref_speed_enabled">تمكين عرض السرعة</string>
     <string name="summary_pref_speed_enabled">عرض السرعة الحالية في الإشعار.\nستتغير أيقونة الإشعار بناءً على الاستخدام.</string>
 
-    <string name="title_pref_sniffing_enabled">تفعيل استخراج الشبكة</string>
+    <string name="title_pref_sniffing_enabled">تفعيل تحليل الحزم (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">محاولة استخراج النطاق من الحزمة (مفعل افتراضيًا)</string>
     <string name="title_pref_route_only_enabled">تمكين routeOnly</string>
     <string name="summary_pref_route_only_enabled">استخدم اسم النطاق الذي تم استخراجه للتوجيه فقط، واحتفظ بعنوان الوجهة كعنوان IP.</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">تفعيل DNS المحلي</string>
     <string name="summary_pref_local_dns_enabled">يتم معالجة DNS بواسطة وحدة DNS الأساسية (موصى به، إذا لزم تجاوز التوجيه لشبكة LAN وعنوان البر الرئيسي)</string>
 
-    <string name="title_pref_fake_dns_enabled">تفعيل DNS وهمي</string>
+    <string name="title_pref_fake_dns_enabled">تفعيل DNS وهمي (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">يعيد DNS المحلي عنوان IP وهمي (أسرع، ولكنه قد لا يعمل مع بعض التطبيقات)</string>
 
     <string name="title_pref_ipv6_enabled">تفعيل IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">فاصل التحديث التلقائي (بالدقائق، الحد الأدنى للقيمة 15)</string>
 
     <string name="title_core_loglevel">مستوى السجل</string>
-    <string name="title_outbound_domain_resolve_method">طريقة الحل المسبق لنطاق outbound</string>
+    <string name="title_outbound_domain_resolve_method">طريقة الحل المسبق لنطاق الخروج (outbound)</string>
     <string name="title_mode">الوضع</string>
     <string name="title_mode_help">انقر هنا للحصول على مزيد من المساعدة</string>
     <string name="title_language">اللغة</string>
@@ -389,13 +389,13 @@
 
     <string name="import_subscription_success">تم استيراد الاشتراك بنجاح</string>
     <string name="import_subscription_failure">فشل استيراد الاشتراك</string>
-    <string name="title_fragment_settings">إعدادات الجزء</string>
+    <string name="title_fragment_settings">إعدادات تجزئة الحزم (Fragment)</string>
     <string name="title_pref_fragment_packets">حزم الجزء</string>
     <string name="title_pref_fragment_length">طول الجزء (الحد الأدنى - الحد الأقصى)</string>
     <string name="title_pref_fragment_interval">فاصل الجزء (الحد الأدنى - الحد الأقصى)</string>
     <string name="title_pref_fragment_enabled">تفعيل الجزء</string>
     <string name="title_pref_fragment_maxsplit">ماكس سبليت الجزء</string>
-    <string name="title_observatory_settings">إعدادات مراقبة الاتصال</string>
+    <string name="title_observatory_settings">إعدادات مراقبة الاتصال (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">فاصل leastPing</string>
     <string name="title_pref_observatory_least_load_interval">فاصل leastLoad</string>
     <string name="title_pref_observatory_least_load_method">طريقة HTTP لـ leastLoad</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">نوع مجموعة السياسات</string>
     <string name="title_policy_group_subscription_id">من مجموعة الاشتراك</string>
     <string name="title_policy_group_subscription_filter">مرشح تعبير نمطي للملاحظات</string>
-    <string name="title_policy_group_test_outbounds">اختبار outbounds</string>
-    <string name="title_policy_group_fallback">outbound احتياطي (اختياري)</string>
+    <string name="title_policy_group_test_outbounds">اختبار الاتصالات الصادرة (outbounds)</string>
+    <string name="title_policy_group_fallback">الاتصال الصادر الاحتياطي (outbound، اختياري)</string>
 
     <string name="server_proxy_chain_members">اعضاء سلسلة الوكيل</string>
     <string name="server_proxy_chain_pick_members">اضغط هنا لاختيار عضو</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>أقل زمن استجابة</item>
-        <item>أقل حمل</item>
-        <item>عشوائي</item>
-        <item>تناوب دائري</item>
+        <item>أقل زمن استجابة (leastPing)</item>
+        <item>أقل حمل (leastLoad)</item>
+        <item>عشوائي (random)</item>
+        <item>تناوب دائري (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">محلي</string>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -7,14 +7,14 @@
     <string name="navigation_drawer_open">فتح درج التنقل</string>
     <string name="navigation_drawer_close">إغلاق درج التنقل</string>
     <string name="migration_success">نجحت عملية ترحيل البيانات!</string>
-    <string name="action_stop_service">Stop service</string>
+    <string name="action_stop_service">إيقاف الخدمة</string>
     <string name="migration_fail">فشلت عملية ترحيل البيانات!</string>
-    <string name="pull_down_to_refresh">Please pull down to refresh!</string>
+    <string name="pull_down_to_refresh">اسحب لأسفل للتحديث!</string>
 
     <!-- Notifications -->
     <string name="notification_action_stop_v2ray">إيقاف</string>
     <string name="toast_permission_denied">تعذر الحصول على الإذن</string>
-    <string name="toast_permission_denied_notification">Unable to obtain the notification permission</string>
+    <string name="toast_permission_denied_notification">تعذر الحصول على إذن الإشعارات</string>
     <string name="notification_action_more">انقر للمزيد</string>
     <string name="toast_services_start">بدء الخدمات</string>
     <string name="toast_services_stop">إيقاف الخدمات</string>
@@ -25,21 +25,21 @@
     <string name="title_server">ملف التكوين</string>
     <string name="menu_item_add_config">إضافة تكوين</string>
     <string name="menu_item_save_config">حفظ التكوين</string>
-    <string name="menu_item_edit_config">Edit configuration</string>
+    <string name="menu_item_edit_config">تعديل التكوين</string>
     <string name="menu_item_del_config">حذف التكوين</string>
     <string name="menu_item_import_config_qrcode">استيراد التكوين من رمز الاستجابة السريعة (QRcode)</string>
     <string name="menu_item_import_config_clipboard">استيراد التكوين من الحافظة</string>
-    <string name="menu_item_import_config_local">Import config from locally</string>
-    <string name="menu_item_import_config_policy_group">Add [Policy group]</string>
-    <string name="menu_item_import_config_proxy_chain">Add [Proxy chain]</string>
+    <string name="menu_item_import_config_local">استيراد التكوين من الجهاز</string>
+    <string name="menu_item_import_config_policy_group">إضافة [مجموعة سياسات]</string>
+    <string name="menu_item_import_config_proxy_chain">إضافة [سلسلة وكلاء]</string>
     <string name="menu_item_import_config_manually_vmess">الكتابة يدويًا [VMess]</string>
     <string name="menu_item_import_config_manually_vless">الكتابة يدويًا [VLESS]</string>
     <string name="menu_item_import_config_manually_ss">الكتابة يدويًا [Shadowsocks]</string>
     <string name="menu_item_import_config_manually_socks">الكتابة يدويًا [SOCKS]</string>
-    <string name="menu_item_import_config_manually_http">Type manually[HTTP]</string>
+    <string name="menu_item_import_config_manually_http">إدخال يدوي [HTTP]</string>
     <string name="menu_item_import_config_manually_trojan">الكتابة يدويًا [Trojan]</string>
     <string name="menu_item_import_config_manually_wireguard">الكتابة يدويًا [Wireguard]</string>
-    <string name="menu_item_import_config_manually_hysteria2">Type manually[Hysteria2]</string>
+    <string name="menu_item_import_config_manually_hysteria2">إدخال يدوي [Hysteria2]</string>
     <string name="confirm_delete_visible_profiles">هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف المعروضة حاليًا؟</string>
     <string name="confirm_delete_duplicate_profiles">هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف المكررة المعروضة حاليًا؟</string>
     <string name="confirm_delete_invalid_profiles">يرجى اختبار ملفات التعريف أولًا. هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف غير الصالحة المعروضة حاليًا؟</string>
@@ -112,28 +112,28 @@
     <string name="server_lab_content">المحتوى</string>
     <string name="toast_none_data_clipboard">لا توجد بيانات في الحافظة</string>
     <string name="toast_invalid_url">رابط URL غير صالح</string>
-    <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
+    <string name="toast_insecure_url_protocol">يرجى عدم استخدام عنوان اشتراك ببروتوكول HTTP غير الآمن</string>
     <string name="server_lab_need_inbound">تأكد من أن منفذ الاتصالات الواردة يتوافق مع الإعدادات</string>
     <string name="toast_malformed_json">تكوين مشوه</string>
     <string name="server_lab_request_host6">مضيف (SNI) (اختياري)</string>
     <string name="toast_action_not_allowed">الإجراء غير مسموح به</string>
-    <string name="server_obfs_password">Obfs password</string>
-    <string name="server_lab_port_hop">Port Hopping</string>
-    <string name="server_lab_port_hop_interval">Port Hopping Interval</string>
-    <string name="server_lab_bandwidth_down">Bandwidth down (Supported units: k/m/g/t)</string>
-    <string name="server_lab_bandwidth_up">Bandwidth up (Supported units: k/m/g/t)</string>
+    <string name="server_obfs_password">كلمة مرور Obfs</string>
+    <string name="server_lab_port_hop">التنقل بين المنافذ</string>
+    <string name="server_lab_port_hop_interval">فاصل تبديل المنفذ</string>
+    <string name="server_lab_bandwidth_down">عرض النطاق للتنزيل (الوحدات المدعومة: k/m/g/t)</string>
+    <string name="server_lab_bandwidth_up">عرض النطاق للرفع (الوحدات المدعومة: k/m/g/t)</string>
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
-    <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_verify_peer_cert_by_name">التحقق من شهادة النظير بالاسم</string>
+    <string name="server_lab_pinned_ca256">بصمة الشهادة (SHA-256)</string>
     <string name="server_lab_browser_dialer">تمكين Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">يدعم فقط اتصالات xhttp (packet-up) وws الصادرة؛ قد يتم تجاهل الإعدادات المتعلقة بـ TLS أو قد تتعارض</string>
     <string name="toast_allow_insecure_deprecated">تستخدم العقدة الحالية اتصالاً غير مشفر. قد تتمكن تجهيزات الشبكة الوسيطة الخاضعة لسيطرة حكومات استبدادية من الاطلاع مباشرةً على اتصالاتك.\nلأسباب أمنية، لا يمكن الاتصال بهذه العقد عبر نواة Xray الإصدار 26.2.6 أو أحدث.\nإذا كانت العقدة من إعدادك، ففعّل تشفيراً آمناً مثل TLS أو ثبّت بصمة الشهادة pinnedCA256.\nإذا كانت العقدة تابعة لمزوّد خدمة، فتواصل معه لإكمال الترقية التقنية. إذا رفض المزوّد التعاون، فنوصي بالانتقال إلى مزوّد يهتم أكثر بأمان المستخدمين.\nلمزيد من المعلومات، تفضل بزيارة https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
-    <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
-    <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
+    <string name="pinned_ca256_action_fetch">جلب بصمة الشهادة وتعبئتها</string>
+    <string name="toast_fetch_cert_sha256_success">تم جلب بصمة الشهادة بنجاح</string>
+    <string name="toast_fetch_cert_sha256_failed">فشل جلب بصمة الشهادة</string>
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">فشل نسخ الملف، يرجى استخدام مدير الملفات</string>
@@ -146,7 +146,7 @@
     <string name="title_user_asset_add_url">إضافة عنوان URL للأصل</string>
     <string name="msg_file_not_found">الملف غير موجود</string>
     <string name="msg_remark_is_duplicate">الملاحظات موجودة بالفعل</string>
-    <string name="asset_geo_files_sources">Geo files source (optional)</string>
+    <string name="asset_geo_files_sources">مصدر ملفات Geo (اختياري)</string>
 
     <!-- PerAppProxyActivity -->
     <string name="msg_dialog_progress">جار التحميل</string>
@@ -159,8 +159,8 @@
     <string name="msg_downloading_content">جارٍ تنزيل المحتوى</string>
     <string name="menu_item_export_proxy_app">تصدير إلى الحافظة</string>
     <string name="menu_item_import_proxy_app">استيراد من الحافظة</string>
-    <string name="per_app_proxy_settings">Per-app settings</string>
-    <string name="per_app_proxy_settings_enable">Enable per-app</string>
+    <string name="per_app_proxy_settings">إعدادات كل تطبيق</string>
+    <string name="per_app_proxy_settings_enable">تمكين الإعدادات لكل تطبيق</string>
     <string name="app_picker_unknown_app">تطبيق غير معروف (UID غير محدد)</string>
 
     <!-- Preferences -->
@@ -170,17 +170,17 @@
     <string name="title_vpn_settings">إعدادات VPN</string>
     <string name="title_pref_per_app_proxy">الوكيل لكل تطبيق</string>
     <string name="summary_pref_per_app_proxy">عام: التطبيق المحدد هو وكيل، غير المحدد اتصال مباشر؛ \nوضع التجاوز: التطبيق المحدد متصل مباشرة، غير المحدد وكيل. \nخيار تحديد تطبيق الوكيل تلقائيًا في القائمة</string>
-    <string name="title_pref_is_booted">Auto connect at startup</string>
-    <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_is_booted">الاتصال تلقائياً عند بدء التشغيل</string>
+    <string name="summary_pref_is_booted">الاتصال تلقائياً بالخادم المحدد عند بدء التشغيل؛ قد لا تنجح المحاولة</string>
 
 
     <string name="subscription_updater_job_tips">ستعمل المهمة في الخلفية، وسيُعرض تقدمها في الإشعار.</string>
     <string name="title_pref_auto_test_after_update_subscription">اختبار تلقائي بعد تحديث الاشتراك</string>
     <string name="summary_pref_auto_test_after_update_subscription">يستغرق الاختبار التلقائي وقتاً طويلاً. عند تمكينه، ستعمل المهمة في الخلفية؛ وإلا فستعمل في الصفحة الحالية.</string>
-    <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
-    <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>
-    <string name="title_pref_auto_sort_after_test">Auto sort after testing</string>
-    <string name="summary_pref_auto_sort_after_test">Test results may not be accurate;</string>
+    <string name="title_pref_auto_remove_invalid_after_test">حذف الإعدادات غير الصالحة تلقائياً بعد الاختبار</string>
+    <string name="summary_pref_auto_remove_invalid_after_test">قد لا تكون نتائج الاختبار دقيقة؛ لا يمكن استعادة الإعدادات المحذوفة.</string>
+    <string name="title_pref_auto_sort_after_test">الفرز تلقائياً بعد الاختبار</string>
+    <string name="summary_pref_auto_sort_after_test">قد لا تكون نتائج الاختبار دقيقة؛</string>
 
     <string name="title_mux_settings">إعدادات Mux</string>
     <string name="title_pref_mux_enabled">تمكين Mux</string>
@@ -218,42 +218,42 @@
     <string name="summary_pref_remote_dns">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (IPv4/v6 فقط)</string>
-    <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
+    <string name="title_pref_vpn_bypass_lan">هل تتجاوز VPN شبكة LAN؟</string>
 
-    <string name="title_pref_vpn_interface_address">VPN Interface Address</string>
+    <string name="title_pref_vpn_interface_address">عنوان واجهة VPN</string>
 
-    <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+    <string name="title_pref_vpn_mtu">قيمة MTU لشبكة VPN (الافتراضي 1500)</string>
 
 
     <string name="title_pref_domestic_dns">DNS المحلي (اختياري)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
 
-    <string name="title_pref_dns_hosts">DNS hosts (Format: domain:address,…)</string>
+    <string name="title_pref_dns_hosts">مضيفو DNS (التنسيق: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
-    <string name="title_pref_delay_test_url">True delay test url </string>
-    <string name="summary_pref_delay_test_url">Url</string>
-    <string name="title_pref_real_ping_concurrency">True delay test concurrency</string>
+    <string name="title_pref_delay_test_url">عنوان URL لاختبار التأخير الحقيقي</string>
+    <string name="summary_pref_delay_test_url">عنوان URL</string>
+    <string name="title_pref_real_ping_concurrency">تزامن اختبار التأخير الحقيقي</string>
 
-    <string name="title_pref_ip_api_url">Current connection info test url</string>
-    <string name="summary_pref_ip_api_url">Url</string>
+    <string name="title_pref_ip_api_url">عنوان URL لاختبار معلومات الاتصال الحالي</string>
+    <string name="summary_pref_ip_api_url">عنوان URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">السماح بالاتصالات من الشبكة المحلية</string>
     <string name="summary_pref_proxy_sharing_enabled">يمكن للأجهزة الأخرى الاتصال بالبروكسي بواسطة عنوان IP الخاص بك من خلال socks/http، يتم التمكين فقط في الشبكة الموثوقة لتجنب الاتصال غير المصرح به</string>
     <string name="toast_warning_pref_proxysharing_short">السماح بالاتصالات من الشبكة المحلية، تأكد من أنك في شبكة موثوقة</string>
 
-    <string name="title_pref_socks_port">منفذ بروكسي Local</string>
+    <string name="title_pref_socks_port">منفذ البروكسي المحلي</string>
     <string name="title_pref_enable_local_proxy">تفعيل الوكيل المحلي</string>
-    <string name="summary_pref_enable_local_proxy">When disabled, no SOCKS proxy is available, so subscription updates and similar actions cannot use the proxy</string>
+    <string name="summary_pref_enable_local_proxy">عند التعطيل، لن يتوفر وكيل SOCKS، ولذلك لن تتمكن تحديثات الاشتراك والإجراءات المشابهة من استخدام الوكيل</string>
     <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">مصادقة socks5 ليست آمنة تمامًا عند استخدام UDP</string>
-    <string name="summary_pref_socks_port">منفذ بروكسي Local</string>
-    <string name="title_pref_dynamic_socks_port">Enable dynamic local proxy port</string>
-    <string name="summary_pref_dynamic_socks_port">Generate a random local proxy port each time the inbound is created</string>
-    <string name="title_pref_socks_username">Local proxy username (optional)</string>
-    <string name="summary_pref_socks_username">Username</string>
-    <string name="title_pref_socks_password">Local proxy password (optional)</string>
-    <string name="summary_pref_socks_password">Password</string>
+    <string name="summary_pref_socks_port">منفذ البروكسي المحلي</string>
+    <string name="title_pref_dynamic_socks_port">تمكين منفذ وكيل محلي ديناميكي</string>
+    <string name="summary_pref_dynamic_socks_port">إنشاء منفذ وكيل محلي عشوائي في كل مرة يُنشأ فيها inbound</string>
+    <string name="title_pref_socks_username">اسم مستخدم الوكيل المحلي (اختياري)</string>
+    <string name="summary_pref_socks_username">اسم المستخدم</string>
+    <string name="title_pref_socks_password">كلمة مرور الوكيل المحلي (اختيارية)</string>
+    <string name="summary_pref_socks_password">كلمة المرور</string>
 
     <string name="title_pref_local_dns_port">منفذ DNS المحلي</string>
     <string name="summary_pref_local_dns_port">منفذ DNS المحلي</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">ما إذا كان حذف ملف التكوين يتطلب تأكيدًا ثانيًا من قبل المستخدم</string>
 
 
-    <string name="title_pref_append_http_proxy">Append HTTP Proxy to VPN</string>
-    <string name="summary_pref_append_http_proxy">HTTP proxy will be used directly from (browser/ some supported apps), without going through the virtual NIC device (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">إلحاق وكيل HTTP بشبكة VPN</string>
+    <string name="summary_pref_append_http_proxy">سيُستخدم وكيل HTTP مباشرةً من المتصفح وبعض التطبيقات المدعومة من دون المرور بواجهة NIC الافتراضية (Android 10+)</string>
 
-    <string name="title_pref_double_column_display">Enable double column display</string>
-    <string name="summary_pref_double_column_display">The profile list is displayed in double columns, allowing more content to be displayed on the screen.</string>
+    <string name="title_pref_double_column_display">تمكين العرض بعمودين</string>
+    <string name="summary_pref_double_column_display">عرض قائمة الملفات الشخصية في عمودين لإظهار محتوى أكبر على الشاشة.</string>
 
-    <string name="title_pref_group_all_display">Enable show all groups</string>
-    <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+    <string name="title_pref_group_all_display">تمكين عرض كل المجموعات</string>
+    <string name="summary_pref_group_all_display">إضافة صفحة «كل علامات التبويب»</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">ملاحظات</string>
@@ -277,10 +277,10 @@
     <string name="summary_pref_tg_group">الانضمام إلى مجموعة Telegram</string>
     <string name="toast_tg_app_not_found">لم يتم العثور على تطبيق Telegram</string>
     <string name="title_privacy_policy">سياسة الخصوصية</string>
-    <string name="title_qr_code">QR code</string>
+    <string name="title_qr_code">رمز QR</string>
     <string name="title_about">حول\nترجمة م. ابراهيم قاسم</string>
     <string name="title_source_code">الكود المصدري</string>
-    <string name="title_oss_license">Open Source licenses</string>
+    <string name="title_oss_license">تراخيص المصادر المفتوحة</string>
     <string name="title_tg_channel">قناة Telegram</string>
 
     <string name="title_pref_promotion">ترويج</string>
@@ -290,16 +290,16 @@
     <string name="title_pref_auto_update_interval">فاصل التحديث التلقائي (بالدقائق، الحد الأدنى للقيمة 15)</string>
 
     <string name="title_core_loglevel">مستوى السجل</string>
-    <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
+    <string name="title_outbound_domain_resolve_method">طريقة الحل المسبق لنطاق outbound</string>
     <string name="title_mode">الوضع</string>
     <string name="title_mode_help">انقر هنا للحصول على مزيد من المساعدة</string>
     <string name="title_language">اللغة</string>
     <string name="title_ui_settings">إعدادات واجهة المستخدم</string>
     <string name="title_pref_ui_mode_night">إعدادات وضع واجهة المستخدم ليلاً</string>
-    <string name="title_pref_use_hev_tunnel">Enable Hev TUN Feature</string>
-    <string name="summary_pref_use_hev_tunnel">When enabled, TUN will use hev-socks5-tunnel; otherwise, it will use xray-core.</string>
-    <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
-    <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
+    <string name="title_pref_use_hev_tunnel">تمكين ميزة Hev TUN</string>
+    <string name="summary_pref_use_hev_tunnel">عند التمكين، سيستخدم TUN ‏hev-socks5-tunnel؛ وإلا فسيستخدم xray-core.</string>
+    <string name="title_pref_hev_tunnel_loglevel">مستوى سجل Hev TUN</string>
+    <string name="title_pref_hev_tunnel_rw_timeout">مهلة القراءة/الكتابة لـ Hev TUN بالثواني (القيم الافتراضية tcp,udp هي 300,60)</string>
     <string name="title_mode_settings">إعدادات الوضع</string>
     <string name="title_root_mode_enabled">تمكين وضع Root (لمستخدمي Root)</string>
     <string name="summary_root_mode_enabled">تمكين وكيل شفاف منخفض المستوى باستخدام صلاحيات Root. يتجاوز هذا الوضع شبكة VPN القياسية لنظام Android ويتولى مباشرةً كل حركة مرور الشبكة الأساسية. بعد تمكينه، لن يعود للوضع العادي الأصلي أو توجيه التطبيقات أو إعدادات VPN المرتبطة بها أي تأثير.</string>
@@ -321,32 +321,32 @@
     <string name="sub_setting_url">عنوان URL اختياري</string>
     <string name="sub_setting_user_agent">User Agent</string>
     <string name="sub_setting_request_headers">رؤوس الطلب (بتنسيق JSON)</string>
-    <string name="sub_setting_filter">Remarks regular filter</string>
+    <string name="sub_setting_filter">مرشح تعبير نمطي للملاحظات</string>
     <string name="sub_setting_enable">تفعيل التحديث</string>
     <string name="sub_auto_update">تفعيل التحديث التلقائي</string>
-    <string name="sub_allow_insecure_url">Allow insecure HTTP address</string>
-    <string name="sub_setting_pre_profile">Previous proxy configuration remarks</string>
-    <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
-    <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
+    <string name="sub_allow_insecure_url">السماح بعنوان HTTP غير آمن</string>
+    <string name="sub_setting_pre_profile">ملاحظات تكوين الوكيل السابق</string>
+    <string name="sub_setting_next_profile">ملاحظات تكوين الوكيل التالي</string>
+    <string name="sub_setting_pre_profile_tip">يجب أن تكون ملاحظات التكوين موجودة وفريدة</string>
     <string name="toast_invalid_update_interval">فاصل التحديث غير صالح. الحد الأدنى هو 15 دقيقة.</string>
     <string name="title_sub_update">تحديث الاشتراك (أول خطوة)</string>
     <string name="title_ping_all_server">Tcping لجميع الإعدادات</string>
     <string name="title_real_ping_all_server"> اختبر جميع الإعدادات (3)</string>
-    <string name="title_user_asset_setting">Asset files</string>
+    <string name="title_user_asset_setting">ملفات الأصول</string>
     <string name="title_sort_by_test_results">الفرز حسب نتائج الاختبار (5)</string>
     <string name="title_filter_config">تصفية ملف التكوين</string>
-    <string name="filter_config_all">All</string>
-    <string name="summary_scan_qrcode">Click screen open the camera scan</string>
+    <string name="filter_config_all">الكل</string>
+    <string name="summary_scan_qrcode">انقر على الشاشة لفتح الكاميرا والمسح</string>
     <string name="title_del_duplicate_config_count">حذف %d من الإعدادات المكررة</string>
-    <string name="title_del_config_count">Delete %d configurations</string>
-    <string name="title_import_config_count">Import %d configurations</string>
-    <string name="title_export_config_count">Export %d configurations</string>
-    <string name="title_update_config_count">Update %d configurations</string>
-    <string name="title_update_subscription_result">Updated %1$d configs (%2$d success, %3$d failed, %4$d skipped)</string>
-    <string name="title_update_subscription_no_subscription">No subscriptions</string>
-    <string name="toast_server_not_found_in_group">Selected server not found in current group</string>
-    <string name="toast_fragment_not_available">Unable to locate current view</string>
-    <string name="title_locate_selected_config">Locate the selected config</string>
+    <string name="title_del_config_count">حذف %d من التكوينات</string>
+    <string name="title_import_config_count">استيراد %d من التكوينات</string>
+    <string name="title_export_config_count">تصدير %d من التكوينات</string>
+    <string name="title_update_config_count">تحديث %d من التكوينات</string>
+    <string name="title_update_subscription_result">تم تحديث %1$d إعدادات (%2$d ناجحة، %3$d فاشلة، %4$d متخطاة)</string>
+    <string name="title_update_subscription_no_subscription">لا توجد اشتراكات</string>
+    <string name="toast_server_not_found_in_group">لم يُعثر على الخادم المحدد في المجموعة الحالية</string>
+    <string name="toast_fragment_not_available">تعذر تحديد العرض الحالي</string>
+    <string name="title_locate_selected_config">تحديد موقع الإعداد المحدد</string>
 
     <string name="tasker_start_service">بدء الخدمة</string>
     <string name="tasker_setting_confirm">تأكيد</string>
@@ -357,14 +357,14 @@
     <string name="routing_settings_tips">افصل بعلامة الفاصلة (,) واختر أحد: domain أو ip أو process</string>
     <string name="routing_settings_save">حفظ</string>
     <string name="routing_settings_delete">مسح</string>
-    <string name="routing_settings_rule_title">Routing Rule Settings</string>
-    <string name="routing_settings_add_rule">Add rule</string>
+    <string name="routing_settings_rule_title">إعدادات قاعدة التوجيه</string>
+    <string name="routing_settings_add_rule">إضافة قاعدة</string>
     <string name="routing_settings_import_predefined_rulesets">استيراد مجموعات قواعد محددة مسبقاً</string>
-    <string name="routing_settings_import_rulesets_tip">Existing rulesets will be deleted, are you sure to continue?</string>
-    <string name="routing_settings_import_rulesets_from_clipboard">Import ruleset from clipboard</string>
+    <string name="routing_settings_import_rulesets_tip">سيتم حذف مجموعات القواعد الحالية. هل تريد المتابعة؟</string>
+    <string name="routing_settings_import_rulesets_from_clipboard">استيراد مجموعة قواعد من الحافظة</string>
     <string name="routing_settings_import_rulesets_from_qrcode">استيراد مجموعة قواعد من رمز الاستجابة السريعة</string>
-    <string name="routing_settings_export_rulesets_to_clipboard">Export ruleset to clipboard</string>
-    <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
+    <string name="routing_settings_export_rulesets_to_clipboard">تصدير مجموعة القواعد إلى الحافظة</string>
+    <string name="routing_settings_locked">مقفلة؛ احتفظ بهذه القاعدة عند استيراد الإعدادات المسبقة</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
     <string name="routing_settings_process">process (اسم الحزمة — مدعوم فقط عند استخدام Xray TUN وتمكين routeOnly وعلى Android 10+)</string>
@@ -378,7 +378,7 @@
 
     <string name="connection_test_pending">التحقق من الاتصال</string>
     <string name="connection_test_testing">يجري الاختبار…</string>
-    <string name="connection_test_testing_count">Testing %d configurations…</string>
+    <string name="connection_test_testing_count">جارٍ اختبار %d من التكوينات…</string>
     <string name="connection_test_available">نجاح: استغرق اتصال HTTP %dms</string>
     <string name="connection_test_error">فشل اكتشاف اتصال الإنترنت: %s</string>
     <string name="connection_test_fail">الإنترنت غير متاح</string>
@@ -404,18 +404,18 @@
     <string name="toast_invalid_observatory_duration">مدة غير صالحة. استخدم قيمة مثل 3m أو 30s.</string>
     <string name="toast_invalid_observatory_sampling">عدد العينات غير صالح. استخدم رقمًا موجبًا.</string>
 
-    <string name="update_check_for_update">Check for update</string>
-    <string name="update_already_latest_version">Already on the latest version</string>
-    <string name="update_new_version_found">New version found: %s</string>
-    <string name="update_now">Update now</string>
-    <string name="update_check_pre_release">Check Pre-release</string>
-    <string name="update_checking_for_update">Checking for update…</string>
+    <string name="update_check_for_update">التحقق من وجود تحديث</string>
+    <string name="update_already_latest_version">أنت تستخدم أحدث إصدار بالفعل</string>
+    <string name="update_new_version_found">عُثر على إصدار جديد: %s</string>
+    <string name="update_now">التحديث الآن</string>
+    <string name="update_check_pre_release">التحقق من الإصدارات التجريبية</string>
+    <string name="update_checking_for_update">جارٍ التحقق من وجود تحديث…</string>
 
-    <string name="title_policy_group_type">Policy group type</string>
-    <string name="title_policy_group_subscription_id">From subscription group</string>
-    <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
-    <string name="title_policy_group_test_outbounds">اختبار المخارج</string>
-    <string name="title_policy_group_fallback">المخرج الاحتياطي (اختياري)</string>
+    <string name="title_policy_group_type">نوع مجموعة السياسات</string>
+    <string name="title_policy_group_subscription_id">من مجموعة الاشتراك</string>
+    <string name="title_policy_group_subscription_filter">مرشح تعبير نمطي للملاحظات</string>
+    <string name="title_policy_group_test_outbounds">اختبار outbounds</string>
+    <string name="title_policy_group_fallback">outbound احتياطي (اختياري)</string>
 
     <string name="server_proxy_chain_members">اعضاء سلسلة الوكيل</string>
     <string name="server_proxy_chain_pick_members">اضغط هنا لاختيار عضو</string>
@@ -425,16 +425,16 @@
     <string name="server_proxy_chain_members_invalid">اعضاء سلسلة غير صالحين: %1$s</string>
 
     <!-- BackupActivity -->
-    <string name="title_configuration_backup_restore">Backup &amp; Restore</string>
+    <string name="title_configuration_backup_restore">النسخ الاحتياطي والاستعادة</string>
     <string name="title_configuration_backup">نسخ التكوين احتياطيًا</string>
     <string name="title_configuration_restore">استعادة التكوين</string>
     <string name="title_configuration_share">مشاركة التكوين</string>
-    <string name="title_webdav_config_setting">WebDAV Settings</string>
-    <string name="title_webdav_config_setting_unknown">Please configure WebDAV first.</string>
-    <string name="title_webdav_url">WebDAV server URL</string>
-    <string name="title_webdav_user">Username</string>
-    <string name="title_webdav_pass">Password</string>
-    <string name="title_webdav_remote_path">Remote directory (optional)</string>
+    <string name="title_webdav_config_setting">إعدادات WebDAV</string>
+    <string name="title_webdav_config_setting_unknown">يرجى إعداد WebDAV أولاً.</string>
+    <string name="title_webdav_url">عنوان URL لخادم WebDAV</string>
+    <string name="title_webdav_user">اسم المستخدم</string>
+    <string name="title_webdav_pass">كلمة المرور</string>
+    <string name="title_webdav_remote_path">الدليل البعيد (اختياري)</string>
 
     <string name="share_method_qrcode">رمز استجابة سريعة (QRcode)</string>
     <string name="share_method_clipboard">تصدير إلى الحافظة</string>
@@ -470,25 +470,25 @@
     <string name="routing_preset_russia_whitelist">القائمة البيضاء لروسيا</string>
 
     <string-array name="vpn_bypass_lan">
-        <item>Follow config</item>
-        <item>Bypass</item>
-        <item>Not Bypass</item>
+        <item>اتباع الإعداد</item>
+        <item>تجاوز</item>
+        <item>عدم التجاوز</item>
     </string-array>
 
     <string-array name="outbound_domain_resolve_method">
-        <item>Do not resolve</item>
-        <item>Resolve and add to DNS Hosts</item>
-        <item>Resolve and replace domain</item>
+        <item>عدم الحل</item>
+        <item>الحل والإضافة إلى مضيفي DNS</item>
+        <item>الحل واستبدال النطاق</item>
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>Least Ping</item>
-        <item>Least Load</item>
-        <item>Random</item>
-        <item>Round Robin</item>
+        <item>أقل زمن استجابة</item>
+        <item>أقل حمل</item>
+        <item>عشوائي</item>
+        <item>تناوب دائري</item>
     </string-array>
 
-    <string name="backup_location_local">Local</string>
+    <string name="backup_location_local">محلي</string>
     <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -199,7 +199,7 @@
 
     <string name="title_pref_sniffing_enabled">تفعيل استخراج الشبكة</string>
     <string name="summary_pref_sniffing_enabled">محاولة استخراج النطاق من الحزمة (مفعل افتراضيًا)</string>
-    <string name="title_pref_route_only_enabled">تفعيل التوجيه فقط</string>
+    <string name="title_pref_route_only_enabled">تمكين routeOnly</string>
     <string name="summary_pref_route_only_enabled">استخدم اسم النطاق الذي تم استخراجه للتوجيه فقط، واحتفظ بعنوان الوجهة كعنوان IP.</string>
 
     <string name="title_pref_local_dns_enabled">تفعيل DNS المحلي</string>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">QUIC key</string>
     <string name="server_lab_path_kcp">kcp seed</string>
     <string name="server_lab_path_grpc">gRPC serviceName</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">البصمة</string>
-    <string name="server_lab_stream_alpn">بروتوكول الطبقة الآخرى التالية (ALPN)</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">تخطي التحقق من الشهادة (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">العنوان</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">المعرّف القصير</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">المفتاح السري</string>
     <string name="server_lab_reserved">محجوز (اختياري)</string>
     <string name="server_lab_local_address">العنوان المحلي (اختياري IPv4/IPv6، مفصولة بفواصل)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">EchConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">التحقق من شهادة النظير بالاسم</string>
     <string name="server_lab_pinned_ca256">بصمة الشهادة (SHA-256)</string>
     <string name="server_lab_browser_dialer">تمكين Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">إضافة ملفات</string>
     <string name="menu_item_add_url">إضافة URL</string>
     <string name="menu_item_scan_qrcode">مسح رمز الاستجابة السريعة (QRcode)</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">تنزيل الملفات</string>
     <string name="title_user_asset_add_url">إضافة عنوان URL للأصل</string>
     <string name="msg_file_not_found">الملف غير موجود</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">عنوان URL لاختبار التأخير الحقيقي</string>
-    <string name="summary_pref_delay_test_url">عنوان URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">اختبارات تأخير حقيقي متزامنة</string>
 
     <string name="title_pref_ip_api_url">عنوان URL لاختبار معلومات الاتصال الحالي</string>
-    <string name="summary_pref_ip_api_url">عنوان URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">السماح بالاتصالات من الشبكة المحلية</string>
     <string name="summary_pref_proxy_sharing_enabled">يمكن للأجهزة الأخرى الاتصال بالبروكسي بواسطة عنوان IP الخاص بك من خلال socks/http، يتم التمكين فقط في الشبكة الموثوقة لتجنب الاتصال غير المصرح به</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">مشاركة VPN مع أجهزة LAN / الأجهزة المربوطة (لمستخدمي Root)</string>
     <string name="summary_root_lan_sharing">توجيه حركة مرور أجهزة نقطة اتصال Wi-Fi والأجهزة المربوطة عبر USB من خلال VPN.</string>
 
-    <string name="title_logcat">Logcat</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">نسخ</string>
     <string name="logcat_clear">مسح</string>
     <string name="logcat_share">مشاركة السجل</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">استيراد مجموعة قواعد من رمز الاستجابة السريعة</string>
     <string name="routing_settings_export_rulesets_to_clipboard">تصدير مجموعة القواعد إلى الحافظة</string>
     <string name="routing_settings_locked">مقفلة؛ احتفظ بهذه القاعدة عند استيراد الإعدادات المسبقة</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (اسم الحزمة — مدعوم فقط عند استخدام Xray TUN وتمكين routeOnly وعلى Android 10+)</string>
     <string name="routing_settings_process_select">اختيار اسم الحزمة</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">التحقق من الاتصال</string>
     <string name="connection_test_testing">يجري الاختبار…</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -7,14 +7,14 @@
     <string name="navigation_drawer_open">নেভিগেশন ড্রয়ার খোলুন</string>
     <string name="navigation_drawer_close">নেভিগেশন ড্রয়ার বন্ধ করুন</string>
     <string name="migration_success">ডেটা স্থানান্তর সফল!</string>
-    <string name="action_stop_service">Stop service</string>
+    <string name="action_stop_service">সেবা বন্ধ করুন</string>
     <string name="migration_fail">ডেটা স্থানান্তর ব্যর্থ!</string>
-    <string name="pull_down_to_refresh">Please pull down to refresh!</string>
+    <string name="pull_down_to_refresh">রিফ্রেশ করতে নিচে টানুন!</string>
 
     <!-- Notifications -->
     <string name="notification_action_stop_v2ray">বন্ধ করুন</string>
     <string name="toast_permission_denied">অনুমতি পাওয়া যাচ্ছে না</string>
-    <string name="toast_permission_denied_notification">Unable to obtain the notification permission</string>
+    <string name="toast_permission_denied_notification">বিজ্ঞপ্তির অনুমতি পাওয়া যায়নি</string>
     <string name="notification_action_more">আরও দেখতে ক্লিক করুন</string>
     <string name="toast_services_start">সার্ভিস শুরু করুন</string>
     <string name="toast_services_stop">সার্ভিস বন্ধ করুন</string>
@@ -25,21 +25,21 @@
     <string name="title_server">কনফিগারেশন ফাইল</string>
     <string name="menu_item_add_config">কনফিগারেশন যোগ করুন</string>
     <string name="menu_item_save_config">কনফিগারেশন সংরক্ষণ করুন</string>
-    <string name="menu_item_edit_config">Edit configuration</string>
+    <string name="menu_item_edit_config">কনফিগারেশন সম্পাদনা করুন</string>
     <string name="menu_item_del_config">কনফিগারেশন মুছুন</string>
     <string name="menu_item_import_config_qrcode">QR কোড থেকে কনফিগারেশন আমদানি করুন</string>
     <string name="menu_item_import_config_clipboard">ক্লিপবোর্ড থেকে কনফিগারেশন আমদানি করুন</string>
-    <string name="menu_item_import_config_local">Import config from locally</string>
-    <string name="menu_item_import_config_policy_group">Add [Policy group]</string>
-    <string name="menu_item_import_config_proxy_chain">Add [Proxy chain]</string>
+    <string name="menu_item_import_config_local">ডিভাইস থেকে কনফিগ আমদানি করুন</string>
+    <string name="menu_item_import_config_policy_group">[নীতি গ্রুপ] যোগ করুন</string>
+    <string name="menu_item_import_config_proxy_chain">[প্রক্সি চেইন] যোগ করুন</string>
     <string name="menu_item_import_config_manually_vmess">ম্যানুয়ালি টাইপ করুন [VMess]</string>
     <string name="menu_item_import_config_manually_vless">ম্যানুয়ালি টাইপ করুন [VLESS]</string>
     <string name="menu_item_import_config_manually_ss">ম্যানুয়ালি টাইপ করুন [Shadowsocks]</string>
     <string name="menu_item_import_config_manually_socks">ম্যানুয়ালি টাইপ করুন [SOCKS]</string>
-    <string name="menu_item_import_config_manually_http">Type manually[HTTP]</string>
+    <string name="menu_item_import_config_manually_http">ম্যানুয়ালি লিখুন [HTTP]</string>
     <string name="menu_item_import_config_manually_trojan">ম্যানুয়ালি টাইপ করুন [Trojan]</string>
     <string name="menu_item_import_config_manually_wireguard">ম্যানুয়ালি টাইপ করুন [Wireguard]</string>
-    <string name="menu_item_import_config_manually_hysteria2">Type manually[Hysteria2]</string>
+    <string name="menu_item_import_config_manually_hysteria2">ম্যানুয়ালি লিখুন [Hysteria2]</string>
     <string name="confirm_delete_visible_profiles">আপনি কি বর্তমানে প্রদর্শিত সব প্রোফাইল মুছে ফেলতে চান?</string>
     <string name="confirm_delete_duplicate_profiles">আপনি কি বর্তমানে প্রদর্শিত সব সদৃশ প্রোফাইল মুছে ফেলতে চান?</string>
     <string name="confirm_delete_invalid_profiles">প্রথমে প্রোফাইলগুলো পরীক্ষা করুন। আপনি কি বর্তমানে প্রদর্শিত সব অবৈধ প্রোফাইল মুছে ফেলতে চান?</string>
@@ -112,28 +112,28 @@
     <string name="server_lab_content">কনটেন্ট</string>
     <string name="toast_none_data_clipboard">ক্লিপবোর্ডে কোনও তথ্য নেই</string>
     <string name="toast_invalid_url">অবৈধ URL</string>
-    <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
+    <string name="toast_insecure_url_protocol">অনিরাপদ HTTP প্রোটোকলের সাবস্ক্রিপশন ঠিকানা ব্যবহার করবেন না</string>
     <string name="server_lab_need_inbound">ইনবাউন্ড পোর্ট নিশ্চিত করুন সেটিংসের সাথে সামঞ্জস্যপূর্ণ</string>
     <string name="toast_malformed_json">কনফিগারেশন বিকৃত</string>
     <string name="server_lab_request_host6">হোস্ট (SNI) (ঐচ্ছিক)</string>
     <string name="toast_action_not_allowed">অ্যাকশন অনুমোদিত নয়</string>
-    <string name="server_obfs_password">Obfs password</string>
-    <string name="server_lab_port_hop">Port Hopping</string>
-    <string name="server_lab_port_hop_interval">Port Hopping Interval</string>
-    <string name="server_lab_bandwidth_down">Bandwidth down (Supported units: k/m/g/t)</string>
-    <string name="server_lab_bandwidth_up">Bandwidth up (Supported units: k/m/g/t)</string>
+    <string name="server_obfs_password">Obfs পাসওয়ার্ড</string>
+    <string name="server_lab_port_hop">পোর্ট হপিং</string>
+    <string name="server_lab_port_hop_interval">পোর্ট পরিবর্তনের বিরতি</string>
+    <string name="server_lab_bandwidth_down">ডাউনলোড ব্যান্ডউইডথ (সমর্থিত একক: k/m/g/t)</string>
+    <string name="server_lab_bandwidth_up">আপলোড ব্যান্ডউইডথ (সমর্থিত একক: k/m/g/t)</string>
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
-    <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_verify_peer_cert_by_name">নাম দিয়ে পিয়ার সার্টিফিকেট যাচাই করুন</string>
+    <string name="server_lab_pinned_ca256">সার্টিফিকেট ফিঙ্গারপ্রিন্ট (SHA-256)</string>
     <string name="server_lab_browser_dialer">Browser Dialer চালু করুন</string>
     <string name="server_lab_browser_dialer_tip">শুধু xhttp (packet-up) ও ws আউটবাউন্ড সমর্থিত; TLS-সংক্রান্ত সেটিং উপেক্ষিত হতে পারে বা পরস্পরের সঙ্গে বিরোধ করতে পারে</string>
     <string name="toast_allow_insecure_deprecated">বর্তমান নোডটি এনক্রিপশনবিহীন সংযোগ ব্যবহার করে। কর্তৃত্ববাদী সরকারের নিয়ন্ত্রণাধীন মধ্যবর্তী নেটওয়ার্ক অবকাঠামো আপনার যোগাযোগ সরাসরি দেখতে পারে।\nনিরাপত্তার কারণে Xray কোরের 26.2.6 বা পরবর্তী সংস্করণ দিয়ে এ ধরনের নোডে সংযোগ করা যায় না।\nনোডটি নিজে তৈরি করে থাকলে TLS-এর মতো নিরাপদ এনক্রিপশন চালু করুন অথবা pinnedCA256 সার্টিফিকেট ফিঙ্গারপ্রিন্ট পিন করুন।\nনোডটি কোনো সেবা প্রদানকারীর হলে প্রযুক্তিগত আপগ্রেডের জন্য তাদের সঙ্গে যোগাযোগ করুন। তারা সহযোগিতা না করলে ব্যবহারকারীর নিরাপত্তাকে বেশি গুরুত্ব দেয় এমন প্রদানকারীর কাছে যাওয়ার পরামর্শ দেওয়া হয়।\nআরও তথ্যের জন্য দেখুন https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
-    <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
-    <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
+    <string name="pinned_ca256_action_fetch">সার্টিফিকেট ফিঙ্গারপ্রিন্ট এনে পূরণ করুন</string>
+    <string name="toast_fetch_cert_sha256_success">সার্টিফিকেট ফিঙ্গারপ্রিন্ট সফলভাবে আনা হয়েছে</string>
+    <string name="toast_fetch_cert_sha256_failed">সার্টিফিকেট ফিঙ্গারপ্রিন্ট আনা ব্যর্থ হয়েছে</string>
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">ফাইল কপি ব্যর্থ, অনুগ্রহ করে ফাইল ম্যানেজার ব্যবহার করুন</string>
@@ -146,21 +146,21 @@
     <string name="title_user_asset_add_url">অ্যাসেট URL যোগ করুন</string>
     <string name="msg_file_not_found">ফাইল খুঁজে পাওয়া যায়নি</string>
     <string name="msg_remark_is_duplicate">মন্তব্য ইতিমধ্যে বিদ্যমান</string>
-    <string name="asset_geo_files_sources">Geo files source (optional)</string>
+    <string name="asset_geo_files_sources">Geo ফাইলের উৎস (ঐচ্ছিক)</string>
 
     <!-- PerAppProxyActivity -->
     <string name="msg_dialog_progress">লোড হচ্ছে</string>
     <string name="menu_item_search">অনুসন্ধান করুন</string>
     <string name="menu_item_select_all">সবকিছু নির্বাচন করুন</string>
-    <string name="menu_item_invert_selection">Invert selection</string>
+    <string name="menu_item_invert_selection">নির্বাচন উল্টে দিন</string>
     <string name="msg_enter_keywords">কিওয়ার্ড লিখুন</string>
     <string name="switch_bypass_apps_mode">বাইপাস মোড</string>
     <string name="menu_item_select_proxy_app">অটো সিলেক্ট প্রক্সি অ্যাপ</string>
     <string name="msg_downloading_content">বিষয়বস্তু ডাউনলোড হচ্ছে</string>
     <string name="menu_item_export_proxy_app">ক্লিপবোর্ডে রপ্তানি করুন</string>
     <string name="menu_item_import_proxy_app">ক্লিপবোর্ড থেকে আমদানি করুন</string>
-    <string name="per_app_proxy_settings">Per-app settings</string>
-    <string name="per_app_proxy_settings_enable">Enable per-app</string>
+    <string name="per_app_proxy_settings">অ্যাপভিত্তিক সেটিংস</string>
+    <string name="per_app_proxy_settings_enable">অ্যাপভিত্তিক সেটিংস চালু করুন</string>
     <string name="app_picker_unknown_app">অজানা অ্যাপ (UID শনাক্ত করা যায়নি)</string>
 
     <!-- Preferences -->
@@ -170,17 +170,17 @@
     <string name="title_vpn_settings">VPN সেটিংস</string>
     <string name="title_pref_per_app_proxy">প্রতি-অ্যাপ প্রক্সি</string>
     <string name="summary_pref_per_app_proxy">সাধারণ: চেকড অ্যাপ প্রক্সি, আনচেকড সরাসরি সংযোগ; \nবাইপাস মোড: চেকড অ্যাপ সরাসরি সংযুক্ত, আনচেকড প্রক্সি। \nমেনুতে প্রক্সি অ্যাপ্লিকেশন স্বয়ংক্রিয়ভাবে নির্বাচন করার বিকল্প</string>
-    <string name="title_pref_is_booted">Auto connect at startup</string>
-    <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_is_booted">চালুর সময় স্বয়ংক্রিয় সংযোগ</string>
+    <string name="summary_pref_is_booted">চালুর সময় নির্বাচিত সার্ভারে স্বয়ংক্রিয়ভাবে সংযোগ করে; সংযোগ ব্যর্থ হতে পারে</string>
 
 
     <string name="subscription_updater_job_tips">কাজটি ব্যাকগ্রাউন্ডে চলবে এবং অগ্রগতির তথ্য বিজ্ঞপ্তিতে দেখানো হবে।</string>
     <string name="title_pref_auto_test_after_update_subscription">সাবস্ক্রিপশন আপডেটের পর স্বয়ংক্রিয় পরীক্ষা</string>
     <string name="summary_pref_auto_test_after_update_subscription">স্বয়ংক্রিয় পরীক্ষায় অনেক সময় লাগে। চালু থাকলে কাজটি ব্যাকগ্রাউন্ডে চলবে; অন্যথায় বর্তমান পৃষ্ঠায় চলবে।</string>
-    <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
-    <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>
-    <string name="title_pref_auto_sort_after_test">Auto sort after testing</string>
-    <string name="summary_pref_auto_sort_after_test">Test results may not be accurate;</string>
+    <string name="title_pref_auto_remove_invalid_after_test">পরীক্ষার পর অবৈধ কনফিগ স্বয়ংক্রিয়ভাবে মুছুন</string>
+    <string name="summary_pref_auto_remove_invalid_after_test">পরীক্ষার ফল সঠিক নাও হতে পারে; মুছে ফেলা কনফিগ ফেরত আনা যাবে না।</string>
+    <string name="title_pref_auto_sort_after_test">পরীক্ষার পর স্বয়ংক্রিয়ভাবে সাজান</string>
+    <string name="summary_pref_auto_sort_after_test">পরীক্ষার ফল সঠিক নাও হতে পারে;</string>
 
     <string name="title_mux_settings">Mux সেটিংস</string>
     <string name="title_pref_mux_enabled">Mux সক্রিয় করুন</string>
@@ -218,42 +218,42 @@
     <string name="summary_pref_remote_dns">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (শুধুমাত্র IPv4/v6)</string>
-    <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
+    <string name="title_pref_vpn_bypass_lan">VPN কি LAN এড়িয়ে যাবে?</string>
 
-    <string name="title_pref_vpn_interface_address">VPN Interface Address</string>
+    <string name="title_pref_vpn_interface_address">VPN ইন্টারফেসের ঠিকানা</string>
 
-    <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+    <string name="title_pref_vpn_mtu">VPN MTU (ডিফল্ট 1500)</string>
 
 
     <string name="title_pref_domestic_dns">ঘরোয়া DNS (ঐচ্ছিক)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
 
-    <string name="title_pref_dns_hosts">DNS hosts (Format: domain:address,…)</string>
+    <string name="title_pref_dns_hosts">DNS হোস্ট (ফরম্যাট: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">সঠিক বিলম্ব পরীক্ষা ইউআরএল </string>
     <string name="summary_pref_delay_test_url">ইউআরএল</string>
-    <string name="title_pref_real_ping_concurrency">True delay test concurrency</string>
+    <string name="title_pref_real_ping_concurrency">প্রকৃত বিলম্ব পরীক্ষার সমকালীনতা</string>
 
-    <string name="title_pref_ip_api_url">Current connection info test url</string>
-    <string name="summary_pref_ip_api_url">Url</string>
+    <string name="title_pref_ip_api_url">বর্তমান সংযোগের তথ্য পরীক্ষার URL</string>
+    <string name="summary_pref_ip_api_url">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">LAN থেকে সংযোগ অনুমোদন করুন</string>
     <string name="summary_pref_proxy_sharing_enabled">অন্যান্য ডিভাইসগুলি আপনার আইপি ঠিকানা ব্যবহার করে প্রক্সিতে সংযুক্ত হতে পারে, শুধুমাত্র বিশ্বস্ত নেটওয়ার্কে সক্রিয় করুন যাতে অনুমোদিত সংযোগ এড়ানো যায়</string>
     <string name="toast_warning_pref_proxysharing_short">LAN থেকে সংযোগ অনুমোদন করুন, নিশ্চিত করুন যে আপনি একটি বিশ্বস্ত নেটওয়ার্কে আছেন</string>
 
-    <string name="title_pref_socks_port">Local প্রক্সি পোর্ট</string>
+    <string name="title_pref_socks_port">স্থানীয় প্রক্সি পোর্ট</string>
     <string name="title_pref_enable_local_proxy">লোকাল প্রক্সি সক্ষম করুন</string>
-    <string name="summary_pref_enable_local_proxy">When disabled, no SOCKS proxy is available, so subscription updates and similar actions cannot use the proxy</string>
+    <string name="summary_pref_enable_local_proxy">বন্ধ থাকলে কোনো SOCKS প্রক্সি পাওয়া যাবে না, তাই সাবস্ক্রিপশন আপডেট ও অনুরূপ কাজ প্রক্সি ব্যবহার করতে পারবে না</string>
     <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">UDP ব্যবহার করার সময় socks5 প্রমাণীকরণ সম্পূর্ণরূপে নিরাপদ নয়</string>
-    <string name="summary_pref_socks_port">Local প্রক্সি পোর্ট</string>
-    <string name="title_pref_dynamic_socks_port">Enable dynamic local proxy port</string>
-    <string name="summary_pref_dynamic_socks_port">Generate a random local proxy port each time the inbound is created</string>
-    <string name="title_pref_socks_username">Local proxy username (optional)</string>
-    <string name="summary_pref_socks_username">Username</string>
-    <string name="title_pref_socks_password">Local proxy password (optional)</string>
-    <string name="summary_pref_socks_password">Password</string>
+    <string name="summary_pref_socks_port">স্থানীয় প্রক্সি পোর্ট</string>
+    <string name="title_pref_dynamic_socks_port">গতিশীল স্থানীয় প্রক্সি পোর্ট চালু করুন</string>
+    <string name="summary_pref_dynamic_socks_port">প্রতিবার inbound তৈরি হলে একটি এলোমেলো স্থানীয় প্রক্সি পোর্ট তৈরি করুন</string>
+    <string name="title_pref_socks_username">স্থানীয় প্রক্সির ব্যবহারকারীর নাম (ঐচ্ছিক)</string>
+    <string name="summary_pref_socks_username">ব্যবহারকারীর নাম</string>
+    <string name="title_pref_socks_password">স্থানীয় প্রক্সির পাসওয়ার্ড (ঐচ্ছিক)</string>
+    <string name="summary_pref_socks_password">পাসওয়ার্ড</string>
 
     <string name="title_pref_local_dns_port">স্থানীয় DNS পোর্ট</string>
     <string name="summary_pref_local_dns_port">স্থানীয় DNS পোর্ট</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">কনফিগারেশন ফাইল মুছে ফেলার জন্য ব্যবহারকারীর দ্বিতীয় নিশ্চিতকরণের প্রয়োজন</string>
 
 
-    <string name="title_pref_append_http_proxy">Append HTTP Proxy to VPN</string>
-    <string name="summary_pref_append_http_proxy">HTTP proxy will be used directly from (browser/ some supported apps), without going through the virtual NIC device (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">VPN-এ HTTP প্রক্সি যুক্ত করুন</string>
+    <string name="summary_pref_append_http_proxy">ভার্চুয়াল NIC ডিভাইসের মধ্য দিয়ে না গিয়ে ব্রাউজার ও কিছু সমর্থিত অ্যাপ সরাসরি HTTP প্রক্সি ব্যবহার করবে (Android 10+)</string>
 
-    <string name="title_pref_double_column_display">Enable double column display</string>
-    <string name="summary_pref_double_column_display">The profile list is displayed in double columns, allowing more content to be displayed on the screen.</string>
+    <string name="title_pref_double_column_display">দুই কলামে প্রদর্শন চালু করুন</string>
+    <string name="summary_pref_double_column_display">প্রোফাইল তালিকা দুই কলামে দেখায়, ফলে পর্দায় আরও বিষয়বস্তু দেখা যায়।</string>
 
-    <string name="title_pref_group_all_display">Enable show all groups</string>
-    <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+    <string name="title_pref_group_all_display">সব গ্রুপ দেখানো চালু করুন</string>
+    <string name="summary_pref_group_all_display">অতিরিক্ত একটি “সব ট্যাব” পৃষ্ঠা যোগ করুন</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">মতামত</string>
@@ -277,10 +277,10 @@
     <string name="summary_pref_tg_group">টেলিগ্রাম গ্রুপে যোগদান করুন</string>
     <string name="toast_tg_app_not_found">টেলিগ্রাম অ্যাপ পাওয়া যায়নি</string>
     <string name="title_privacy_policy">গোপনীয়তা নীতি</string>
-    <string name="title_qr_code">QR code</string>
+    <string name="title_qr_code">QR কোড</string>
     <string name="title_about">সম্পর্কিত</string>
     <string name="title_source_code">সোর্স কোড</string>
-    <string name="title_oss_license">Open Source licenses</string>
+    <string name="title_oss_license">ওপেন সোর্স লাইসেন্স</string>
     <string name="title_tg_channel">টেলিগ্রাম চ্যানেল</string>
 
     <string name="title_pref_promotion">প্রচার</string>
@@ -290,16 +290,16 @@
     <string name="title_pref_auto_update_interval">অটো আপডেট ইন্টারভ্যাল (মিনিট, সর্বনিম্ন মান ১৫)</string>
 
     <string name="title_core_loglevel">লগ স্তর</string>
-    <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
+    <string name="title_outbound_domain_resolve_method">outbound ডোমেইন আগাম রেজলভ করার পদ্ধতি</string>
     <string name="title_mode">মোড</string>
     <string name="title_mode_help">আরো সাহায্যের জন্য ক্লিক করুন</string>
     <string name="title_language">ভাষা</string>
     <string name="title_ui_settings">ইউআই সেটিংস</string>
     <string name="title_pref_ui_mode_night">ইউআই মোড সেটিংস</string>
-    <string name="title_pref_use_hev_tunnel">Enable Hev TUN Feature</string>
-    <string name="summary_pref_use_hev_tunnel">When enabled, TUN will use hev-socks5-tunnel; otherwise, it will use xray-core.</string>
-    <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
-    <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
+    <string name="title_pref_use_hev_tunnel">Hev TUN সুবিধা চালু করুন</string>
+    <string name="summary_pref_use_hev_tunnel">চালু থাকলে TUN hev-socks5-tunnel ব্যবহার করবে; অন্যথায় xray-core ব্যবহার করবে।</string>
+    <string name="title_pref_hev_tunnel_loglevel">Hev TUN লগ স্তর</string>
+    <string name="title_pref_hev_tunnel_rw_timeout">Hev TUN পড়া/লেখার সময়সীমা, সেকেন্ডে (tcp,udp ডিফল্ট 300,60)</string>
     <string name="title_mode_settings">মোড সেটিংস</string>
     <string name="title_root_mode_enabled">Root মোড চালু (Root ব্যবহারকারীদের জন্য)</string>
     <string name="summary_root_mode_enabled">Root সুবিধা ব্যবহার করে নিম্ন-স্তরের স্বচ্ছ প্রক্সি চালু করুন। এই মোডটি Android-এর মানক সিস্টেম VPN এড়িয়ে সরাসরি অন্তর্নিহিত সব নেটওয়ার্ক ট্রাফিক নিয়ন্ত্রণ করে। চালু করার পর আগের সাধারণ মোড, অ্যাপভিত্তিক রাউটিং এবং সংশ্লিষ্ট VPN সেটিংস আর কার্যকর থাকবে না।</string>
@@ -321,32 +321,32 @@
     <string name="sub_setting_url">ঐচ্ছিক URL</string>
     <string name="sub_setting_user_agent">User Agent</string>
     <string name="sub_setting_request_headers">রিকোয়েস্ট হেডার (JSON ফরম্যাট)</string>
-    <string name="sub_setting_filter">Remarks regular filter</string>
+    <string name="sub_setting_filter">মন্তব্যের রেগুলার এক্সপ্রেশন ফিল্টার</string>
     <string name="sub_setting_enable">আপডেট সক্রিয় করুন</string>
     <string name="sub_auto_update">স্বয়ংক্রিয় আপডেট সক্রিয় করুন</string>
-    <string name="sub_allow_insecure_url">Allow insecure HTTP address</string>
-    <string name="sub_setting_pre_profile">Previous proxy configuration remarks</string>
-    <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
-    <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
+    <string name="sub_allow_insecure_url">অনিরাপদ HTTP ঠিকানা অনুমোদন করুন</string>
+    <string name="sub_setting_pre_profile">আগের প্রক্সি কনফিগারেশনের মন্তব্য</string>
+    <string name="sub_setting_next_profile">পরবর্তী প্রক্সি কনফিগারেশনের মন্তব্য</string>
+    <string name="sub_setting_pre_profile_tip">কনফিগারেশনের মন্তব্যটি বিদ্যমান ও অনন্য হতে হবে</string>
     <string name="toast_invalid_update_interval">আপডেটের বিরতি সঠিক নয়। সর্বনিম্ন ১৫ মিনিট।</string>
     <string name="title_sub_update">সাবস্ক্রিপশন আপডেট</string>
     <string name="title_ping_all_server">সব কনফিগারেশন TCPing</string>
     <string name="title_real_ping_all_server">সব কনফিগারেশন প্রকৃত বিলম্ব</string>
-    <string name="title_user_asset_setting">Asset files</string>
+    <string name="title_user_asset_setting">অ্যাসেট ফাইল</string>
     <string name="title_sort_by_test_results">টেস্ট ফলাফল দ্বারা সাজানো</string>
     <string name="title_filter_config">কনফিগারেশন ফাইল ফিল্টার করুন</string>
-    <string name="filter_config_all">All</string>
-    <string name="summary_scan_qrcode">Click screen open the camera scan</string>
+    <string name="filter_config_all">সব</string>
+    <string name="summary_scan_qrcode">ক্যামেরা স্ক্যান খুলতে পর্দায় ট্যাপ করুন</string>
     <string name="title_del_duplicate_config_count">%d ডুপ্লিকেট কনফিগারেশন মুছে ফেলুন</string>
-    <string name="title_del_config_count">Delete %d configurations</string>
-    <string name="title_import_config_count">Import %d configurations</string>
-    <string name="title_export_config_count">Export %d configurations</string>
-    <string name="title_update_config_count">Update %d configurations</string>
-    <string name="title_update_subscription_result">Updated %1$d configs (%2$d success, %3$d failed, %4$d skipped)</string>
-    <string name="title_update_subscription_no_subscription">No subscriptions</string>
-    <string name="toast_server_not_found_in_group">Selected server not found in current group</string>
-    <string name="toast_fragment_not_available">Unable to locate current view</string>
-    <string name="title_locate_selected_config">Locate the selected config</string>
+    <string name="title_del_config_count">%dটি কনফিগারেশন মুছুন</string>
+    <string name="title_import_config_count">%dটি কনফিগারেশন আমদানি করুন</string>
+    <string name="title_export_config_count">%dটি কনফিগারেশন রপ্তানি করুন</string>
+    <string name="title_update_config_count">%dটি কনফিগারেশন আপডেট করুন</string>
+    <string name="title_update_subscription_result">%1$dটি কনফিগ আপডেট হয়েছে (%2$d সফল, %3$d ব্যর্থ, %4$d এড়ানো)</string>
+    <string name="title_update_subscription_no_subscription">কোনো সাবস্ক্রিপশন নেই</string>
+    <string name="toast_server_not_found_in_group">বর্তমান গ্রুপে নির্বাচিত সার্ভারটি পাওয়া যায়নি</string>
+    <string name="toast_fragment_not_available">বর্তমান ভিউটি খুঁজে পাওয়া যায়নি</string>
+    <string name="title_locate_selected_config">নির্বাচিত কনফিগটি খুঁজুন</string>
 
     <string name="tasker_start_service">সার্ভিস শুরু করুন</string>
     <string name="tasker_setting_confirm">নিশ্চিত করুন</string>
@@ -357,14 +357,14 @@
     <string name="routing_settings_tips">কমা (,) দিয়ে আলাদা করুন। domain, ip বা process-এ একটি নির্বাচন করুন</string>
     <string name="routing_settings_save">সেভ করুন</string>
     <string name="routing_settings_delete">মুছে ফেলুন</string>
-    <string name="routing_settings_rule_title">Routing Rule Settings</string>
-    <string name="routing_settings_add_rule">Add rule</string>
+    <string name="routing_settings_rule_title">রাউটিং নিয়মের সেটিংস</string>
+    <string name="routing_settings_add_rule">নিয়ম যোগ করুন</string>
     <string name="routing_settings_import_predefined_rulesets">পূর্বনির্ধারিত নিয়মাবলী আমদানি করুন</string>
-    <string name="routing_settings_import_rulesets_tip">Existing rulesets will be deleted, are you sure to continue?</string>
-    <string name="routing_settings_import_rulesets_from_clipboard">Import ruleset from clipboard</string>
+    <string name="routing_settings_import_rulesets_tip">বিদ্যমান নিয়মসমূহ মুছে যাবে। চালিয়ে যেতে চান?</string>
+    <string name="routing_settings_import_rulesets_from_clipboard">ক্লিপবোর্ড থেকে নিয়মসমূহ আমদানি করুন</string>
     <string name="routing_settings_import_rulesets_from_qrcode">QRcode থেকে রুলসেট আমদানি করুন</string>
-    <string name="routing_settings_export_rulesets_to_clipboard">Export ruleset to clipboard</string>
-    <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
+    <string name="routing_settings_export_rulesets_to_clipboard">নিয়মসমূহ ক্লিপবোর্ডে রপ্তানি করুন</string>
+    <string name="routing_settings_locked">লক করা; প্রিসেট আমদানির সময় এই নিয়মটি রাখুন</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
     <string name="routing_settings_process">process (প্যাকেজের নাম — শুধু Xray TUN ব্যবহার, routeOnly চালু এবং Android 10+ হলে সমর্থিত)</string>
@@ -378,7 +378,7 @@
 
     <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
     <string name="connection_test_testing">পরীক্ষা চলছে…</string>
-    <string name="connection_test_testing_count">Testing %d configurations…</string>
+    <string name="connection_test_testing_count">%dটি কনফিগারেশন পরীক্ষা করা হচ্ছে…</string>
     <string name="connection_test_available">সফল: HTTP সংযোগ নিয়েছে %dms</string>
     <string name="connection_test_error">ইন্টারনেট সংযোগ সনাক্ত করতে ব্যর্থ: %s</string>
     <string name="connection_test_fail">ইন্টারনেট উপলব্ধ নয়</string>
@@ -404,37 +404,37 @@
     <string name="toast_invalid_observatory_duration">অবৈধ সময়কাল। 3m বা 30s-এর মতো মান ব্যবহার করুন।</string>
     <string name="toast_invalid_observatory_sampling">অবৈধ স্যাম্পলিং। একটি ধনাত্মক সংখ্যা ব্যবহার করুন।</string>
 
-    <string name="update_check_for_update">Check for update</string>
-    <string name="update_already_latest_version">Already on the latest version</string>
-    <string name="update_new_version_found">New version found: %s</string>
-    <string name="update_now">Update now</string>
-    <string name="update_check_pre_release">Check Pre-release</string>
-    <string name="update_checking_for_update">Checking for update…</string>
+    <string name="update_check_for_update">আপডেট পরীক্ষা করুন</string>
+    <string name="update_already_latest_version">ইতিমধ্যে সর্বশেষ সংস্করণ ব্যবহার করছেন</string>
+    <string name="update_new_version_found">নতুন সংস্করণ পাওয়া গেছে: %s</string>
+    <string name="update_now">এখনই আপডেট করুন</string>
+    <string name="update_check_pre_release">প্রাক্‌-রিলিজ পরীক্ষা করুন</string>
+    <string name="update_checking_for_update">আপডেট পরীক্ষা করা হচ্ছে…</string>
 
-    <string name="title_policy_group_type">Policy group type</string>
-    <string name="title_policy_group_subscription_id">From subscription group</string>
-    <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
-    <string name="title_policy_group_test_outbounds">আউটবাউন্ড পরীক্ষা করুন</string>
-    <string name="title_policy_group_fallback">ফলব্যাক আউটবাউন্ড (ঐচ্ছিক)</string>
+    <string name="title_policy_group_type">নীতি গ্রুপের ধরন</string>
+    <string name="title_policy_group_subscription_id">সাবস্ক্রিপশন গ্রুপ থেকে</string>
+    <string name="title_policy_group_subscription_filter">মন্তব্যের রেগুলার এক্সপ্রেশন ফিল্টার</string>
+    <string name="title_policy_group_test_outbounds">outbounds পরীক্ষা করুন</string>
+    <string name="title_policy_group_fallback">fallback outbound (ঐচ্ছিক)</string>
 
-    <string name="server_proxy_chain_members">Proxy chain members</string>
-    <string name="server_proxy_chain_pick_members">Tap here to pick member</string>
-    <string name="server_proxy_chain_member_unselected">Select a member</string>
-    <string name="server_proxy_chain_members_unselected">Please select member for each chain row</string>
-    <string name="server_proxy_chain_members_insufficient">Insufficient members</string>
-    <string name="server_proxy_chain_members_invalid">Invalid chain members: %1$s</string>
+    <string name="server_proxy_chain_members">প্রক্সি চেইনের সদস্য</string>
+    <string name="server_proxy_chain_pick_members">সদস্য বাছতে এখানে ট্যাপ করুন</string>
+    <string name="server_proxy_chain_member_unselected">একজন সদস্য নির্বাচন করুন</string>
+    <string name="server_proxy_chain_members_unselected">চেইনের প্রতিটি সারির জন্য সদস্য নির্বাচন করুন</string>
+    <string name="server_proxy_chain_members_insufficient">পর্যাপ্ত সদস্য নেই</string>
+    <string name="server_proxy_chain_members_invalid">অবৈধ চেইন সদস্য: %1$s</string>
 
     <!-- BackupActivity -->
-    <string name="title_configuration_backup_restore">Backup &amp; Restore</string>
+    <string name="title_configuration_backup_restore">ব্যাকআপ ও পুনরুদ্ধার</string>
     <string name="title_configuration_backup">কনফিগারেশন ব্যাকআপ</string>
     <string name="title_configuration_restore">কনফিগারেশন পুনরুদ্ধার</string>
     <string name="title_configuration_share">কনফিগারেশন শেয়ার করুন</string>
-    <string name="title_webdav_config_setting">WebDAV Settings</string>
-    <string name="title_webdav_config_setting_unknown">Please configure WebDAV first.</string>
-    <string name="title_webdav_url">WebDAV server URL</string>
-    <string name="title_webdav_user">Username</string>
-    <string name="title_webdav_pass">Password</string>
-    <string name="title_webdav_remote_path">Remote directory (optional)</string>
+    <string name="title_webdav_config_setting">WebDAV সেটিংস</string>
+    <string name="title_webdav_config_setting_unknown">প্রথমে WebDAV কনফিগার করুন।</string>
+    <string name="title_webdav_url">WebDAV সার্ভারের URL</string>
+    <string name="title_webdav_user">ব্যবহারকারীর নাম</string>
+    <string name="title_webdav_pass">পাসওয়ার্ড</string>
+    <string name="title_webdav_remote_path">দূরবর্তী ডিরেক্টরি (ঐচ্ছিক)</string>
 
     <string name="share_method_qrcode">QR কোড</string>
     <string name="share_method_clipboard">ক্লিপবোর্ডে রপ্তানি করুন</string>
@@ -470,25 +470,25 @@
     <string name="routing_preset_russia_whitelist">রাশিয়া হোয়াইটলিস্ট</string>
 
     <string-array name="vpn_bypass_lan">
-        <item>Follow config</item>
-        <item>Bypass</item>
-        <item>Not Bypass</item>
+        <item>কনফিগ অনুসরণ করুন</item>
+        <item>বাইপাস</item>
+        <item>বাইপাস নয়</item>
     </string-array>
 
     <string-array name="outbound_domain_resolve_method">
-        <item>Do not resolve</item>
-        <item>Resolve and add to DNS Hosts</item>
-        <item>Resolve and replace domain</item>
+        <item>রেজলভ করবেন না</item>
+        <item>রেজলভ করে DNS Hosts-এ যোগ করুন</item>
+        <item>রেজলভ করে ডোমেইন প্রতিস্থাপন করুন</item>
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>Least Ping</item>
-        <item>Least Load</item>
-        <item>Random</item>
-        <item>Round Robin</item>
+        <item>সর্বনিম্ন পিং</item>
+        <item>সর্বনিম্ন লোড</item>
+        <item>এলোমেলো</item>
+        <item>রাউন্ড রবিন</item>
     </string-array>
 
-    <string name="backup_location_local">Local</string>
+    <string name="backup_location_local">স্থানীয়</string>
     <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">অবৈধ URL</string>
     <string name="toast_insecure_url_protocol">অনিরাপদ HTTP প্রোটোকলের সাবস্ক্রিপশন ঠিকানা ব্যবহার করবেন না</string>
     <string name="server_lab_need_inbound">ইনবাউন্ড পোর্ট নিশ্চিত করুন সেটিংসের সাথে সামঞ্জস্যপূর্ণ</string>
-    <string name="toast_malformed_json">কনফিগারেশন বিকৃত</string>
+    <string name="toast_malformed_json">কনফিগারেশন ফরম্যাট সঠিক নয়।</string>
     <string name="server_lab_request_host6">হোস্ট (SNI) (ঐচ্ছিক)</string>
     <string name="toast_action_not_allowed">অ্যাকশন অনুমোদিত নয়</string>
     <string name="server_obfs_password">Obfs পাসওয়ার্ড</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">Browser Dialer চালু করুন</string>
     <string name="server_lab_browser_dialer_tip">শুধু xhttp (packet-up) ও ws আউটবাউন্ড সমর্থিত; TLS-সংক্রান্ত সেটিং উপেক্ষিত হতে পারে বা পরস্পরের সঙ্গে বিরোধ করতে পারে</string>
     <string name="toast_allow_insecure_deprecated">বর্তমান নোডটি এনক্রিপশনবিহীন সংযোগ ব্যবহার করে। কর্তৃত্ববাদী সরকারের নিয়ন্ত্রণাধীন মধ্যবর্তী নেটওয়ার্ক অবকাঠামো আপনার যোগাযোগ সরাসরি দেখতে পারে।\nনিরাপত্তার কারণে Xray কোরের 26.2.6 বা পরবর্তী সংস্করণ দিয়ে এ ধরনের নোডে সংযোগ করা যায় না।\nনোডটি নিজে তৈরি করে থাকলে TLS-এর মতো নিরাপদ এনক্রিপশন চালু করুন অথবা pinnedCA256 সার্টিফিকেট ফিঙ্গারপ্রিন্ট পিন করুন।\nনোডটি কোনো সেবা প্রদানকারীর হলে প্রযুক্তিগত আপগ্রেডের জন্য তাদের সঙ্গে যোগাযোগ করুন। তারা সহযোগিতা না করলে ব্যবহারকারীর নিরাপত্তাকে বেশি গুরুত্ব দেয় এমন প্রদানকারীর কাছে যাওয়ার পরামর্শ দেওয়া হয়।\nআরও তথ্যের জন্য দেখুন https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">সার্টিফিকেট ফিঙ্গারপ্রিন্ট এনে পূরণ করুন</string>
+    <string name="pinned_ca256_action_fetch">সার্টিফিকেট ফিঙ্গারপ্রিন্ট আনুন</string>
     <string name="toast_fetch_cert_sha256_success">সার্টিফিকেট ফিঙ্গারপ্রিন্ট সফলভাবে আনা হয়েছে</string>
     <string name="toast_fetch_cert_sha256_failed">সার্টিফিকেট ফিঙ্গারপ্রিন্ট আনা ব্যর্থ হয়েছে</string>
 
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">গতি প্রদর্শন সক্রিয় করুন</string>
-    <string name="summary_pref_speed_enabled">বিজ্ঞপ্তিতে বর্তমান গতি প্রদর্শন করুন।\nব্যবহারের উপর ভিত্তি করে বিজ্ঞপ্তি আইকন পরিবর্তিত হবে।</string>
+    <string name="summary_pref_speed_enabled">বিজ্ঞপ্তিতে বর্তমান সংযোগের গতি দেখান।\nআইকনটি প্রক্সি বা সরাসরি ট্রাফিকের মধ্যে কোনটি বেশি তা দেখায়।</string>
 
-    <string name="title_pref_sniffing_enabled">প্যাকেট বিশ্লেষণ সক্রিয় করুন (Sniffing)</string>
-    <string name="summary_pref_sniffing_enabled">প্যাকেট থেকে ডোমেইন স্নিফ করার চেষ্টা করুন (ডিফল্টভাবে চালু)</string>
+    <string name="title_pref_sniffing_enabled">ট্রাফিকের গন্তব্য ডোমেইন শনাক্তকরণ চালু করুন (Sniffing)</string>
+    <string name="summary_pref_sniffing_enabled">ট্রাফিক থেকে গন্তব্য ডোমেইন শনাক্ত করুন (ডিফল্টভাবে চালু)।</string>
     <string name="title_pref_route_only_enabled">routeOnly সক্রিয় করুন</string>
     <string name="summary_pref_route_only_enabled">রুটিংয়ের জন্য শুধুমাত্র স্নিফড ডোমেইন নাম ব্যবহার করুন, এবং লক্ষ্য ঠিকানা হিসেবে আইপি ঠিকানা রাখুন।</string>
 
     <string name="title_pref_local_dns_enabled">স্থানীয় DNS সক্রিয় করুন</string>
     <string name="summary_pref_local_dns_enabled">DNS মূল DNS মডিউল দ্বারা প্রক্রিয়া করা হয় (প্রস্তাবিত, যদি LAN এবং মূলভূমি ঠিকানার বাইপাসিং প্রয়োজন হয়)</string>
 
-    <string name="title_pref_fake_dns_enabled">ভুয়া DNS সক্রিয় করুন (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">স্থানীয় DNS মিথ্যা আইপি ঠিকানা ফেরত দেয় (দ্রুত, তবে এটি কিছু অ্যাপের জন্য কাজ নাও করতে পারে)</string>
+    <string name="title_pref_fake_dns_enabled">কৃত্রিম DNS চালু করুন (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">ডোমেইন রেজলভের সময় FakeDNS কৃত্রিম IP ঠিকানা ফেরত দেয় (দ্রুত, তবে কিছু অ্যাপে কাজ নাও করতে পারে)।</string>
 
     <string name="title_pref_ipv6_enabled">IPv6 সক্রিয় করুন</string>
     <string name="summary_pref_ipv6_enabled">VPN ইন্টারফেসে IPv6 ঠিকানা এবং রুট যোগ করুন</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">সঠিক বিলম্ব পরীক্ষা ইউআরএল </string>
     <string name="summary_pref_delay_test_url">ইউআরএল</string>
-    <string name="title_pref_real_ping_concurrency">প্রকৃত বিলম্ব পরীক্ষার সমকালীনতা</string>
+    <string name="title_pref_real_ping_concurrency">একযোগে প্রকৃত বিলম্ব পরীক্ষা</string>
 
     <string name="title_pref_ip_api_url">বর্তমান সংযোগের তথ্য পরীক্ষার URL</string>
     <string name="summary_pref_ip_api_url">URL</string>
@@ -268,8 +268,8 @@
     <string name="title_pref_double_column_display">দুই কলামে প্রদর্শন চালু করুন</string>
     <string name="summary_pref_double_column_display">প্রোফাইল তালিকা দুই কলামে দেখায়, ফলে পর্দায় আরও বিষয়বস্তু দেখা যায়।</string>
 
-    <string name="title_pref_group_all_display">সব গ্রুপ দেখানো চালু করুন</string>
-    <string name="summary_pref_group_all_display">অতিরিক্ত একটি “সব ট্যাব” পৃষ্ঠা যোগ করুন</string>
+    <string name="title_pref_group_all_display">“সব” গ্রুপ ট্যাব দেখান</string>
+    <string name="summary_pref_group_all_display">সব সাবস্ক্রিপশন গ্রুপের কনফিগ একটি ট্যাবে দেখান।</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">মতামত</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">অটো আপডেট ইন্টারভ্যাল (মিনিট, সর্বনিম্ন মান ১৫)</string>
 
     <string name="title_core_loglevel">লগ স্তর</string>
-    <string name="title_outbound_domain_resolve_method">বহির্গামী ডোমেইন আগাম রেজলভ করার পদ্ধতি (outbound)</string>
+    <string name="title_outbound_domain_resolve_method">বহির্গামী সংযোগের ডোমেইন রেজলভ পদ্ধতি (outbound)</string>
     <string name="title_mode">মোড</string>
     <string name="title_mode_help">আরো সাহায্যের জন্য ক্লিক করুন</string>
     <string name="title_language">ভাষা</string>
@@ -304,8 +304,8 @@
     <string name="title_root_mode_enabled">Root মোড চালু (Root ব্যবহারকারীদের জন্য)</string>
     <string name="summary_root_mode_enabled">Root সুবিধা ব্যবহার করে নিম্ন-স্তরের স্বচ্ছ প্রক্সি চালু করুন। এই মোডটি Android-এর মানক সিস্টেম VPN এড়িয়ে সরাসরি অন্তর্নিহিত সব নেটওয়ার্ক ট্রাফিক নিয়ন্ত্রণ করে। চালু করার পর আগের সাধারণ মোড, অ্যাপভিত্তিক রাউটিং এবং সংশ্লিষ্ট VPN সেটিংস আর কার্যকর থাকবে না।</string>
     <string name="toast_root_required">এই সুবিধার জন্য Root অ্যাক্সেস প্রয়োজন</string>
-    <string name="title_root_lan_sharing">LAN / টেদারিং শেয়ারিং (Root ব্যবহারকারীদের জন্য)</string>
-    <string name="summary_root_lan_sharing">Wi-Fi হটস্পট ও USB-টেদার করা ডিভাইসের ট্রাফিক VPN-এর মাধ্যমে রাউট করুন</string>
+    <string name="title_root_lan_sharing">LAN / টেদার করা ডিভাইসে VPN শেয়ার করুন (Root ব্যবহারকারীদের জন্য)</string>
+    <string name="summary_root_lan_sharing">Wi-Fi হটস্পট ও USB-টেদার করা ডিভাইসের ট্রাফিক VPN-এর মাধ্যমে রাউট করুন।</string>
 
     <string name="title_logcat">লগক্যাট</string>
     <string name="logcat_copy">কপি করুন</string>
@@ -345,7 +345,7 @@
     <string name="title_update_subscription_result">%1$dটি কনফিগ আপডেট হয়েছে (%2$d সফল, %3$d ব্যর্থ, %4$d এড়ানো)</string>
     <string name="title_update_subscription_no_subscription">কোনো সাবস্ক্রিপশন নেই</string>
     <string name="toast_server_not_found_in_group">বর্তমান গ্রুপে নির্বাচিত সার্ভারটি পাওয়া যায়নি</string>
-    <string name="toast_fragment_not_available">বর্তমান ভিউটি খুঁজে পাওয়া যায়নি</string>
+    <string name="toast_fragment_not_available">বর্তমান স্ক্রিনটি উপলভ্য নয়।</string>
     <string name="title_locate_selected_config">নির্বাচিত কনফিগটি খুঁজুন</string>
 
     <string name="tasker_start_service">সার্ভিস শুরু করুন</string>
@@ -385,7 +385,7 @@
     <string name="connection_test_error_status_code">ত্রুটি কোড: #%d</string>
     <string name="connection_connected">সংযুক্ত, সংযোগ পরীক্ষা করতে ট্যাপ করুন</string>
     <string name="connection_not_connected">সংযুক্ত নয়</string>
-    <string name="connection_running_task_left">চলমান পরীক্ষার কাজের সংখ্যা: %s</string>
+    <string name="connection_running_task_left">চলমান পরীক্ষা: %s</string>
 
     <string name="import_subscription_success">সাবস্ক্রিপশন সফলভাবে আমদানি করা হয়েছে</string>
     <string name="import_subscription_failure">সাবস্ক্রিপশন আমদানি ব্যর্থ</string>
@@ -419,7 +419,7 @@
 
     <string name="server_proxy_chain_members">প্রক্সি চেইনের সদস্য</string>
     <string name="server_proxy_chain_pick_members">সদস্য বাছতে এখানে ট্যাপ করুন</string>
-    <string name="server_proxy_chain_member_unselected">একজন সদস্য নির্বাচন করুন</string>
+    <string name="server_proxy_chain_member_unselected">চেইনের সদস্য নির্বাচন করুন</string>
     <string name="server_proxy_chain_members_unselected">চেইনের প্রতিটি সারির জন্য সদস্য নির্বাচন করুন</string>
     <string name="server_proxy_chain_members_insufficient">পর্যাপ্ত সদস্য নেই</string>
     <string name="server_proxy_chain_members_invalid">অবৈধ চেইন সদস্য: %1$s</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -199,7 +199,7 @@
 
     <string name="title_pref_sniffing_enabled">স্নিফিং সক্রিয় করুন</string>
     <string name="summary_pref_sniffing_enabled">প্যাকেট থেকে ডোমেইন স্নিফ করার চেষ্টা করুন (ডিফল্টভাবে চালু)</string>
-    <string name="title_pref_route_only_enabled">রুটঅনলি সক্রিয় করুন</string>
+    <string name="title_pref_route_only_enabled">routeOnly সক্রিয় করুন</string>
     <string name="summary_pref_route_only_enabled">রুটিংয়ের জন্য শুধুমাত্র স্নিফড ডোমেইন নাম ব্যবহার করুন, এবং লক্ষ্য ঠিকানা হিসেবে আইপি ঠিকানা রাখুন।</string>
 
     <string name="title_pref_local_dns_enabled">স্থানীয় DNS সক্রিয় করুন</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">ফিঙ্গারপ্রিন্ট</string>
     <string name="server_lab_stream_alpn">Alpn</string>
-    <string name="server_lab_allow_insecure">অনিরাপদ অনুমতি দিন</string>
+    <string name="server_lab_allow_insecure">সার্টিফিকেট যাচাই এড়িয়ে যান (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">ঠিকানা</string>
     <string name="server_lab_port3">পোর্ট</string>
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">পাসওয়ার্ড (ঐচ্ছিক)</string>
     <string name="server_lab_security4">ব্যবহারকারী (ঐচ্ছিক)</string>
     <string name="server_lab_encryption">এনক্রিপশন</string>
-    <string name="server_lab_flow">ফ্লো</string>
+    <string name="server_lab_flow">প্রবাহ (flow)</string>
     <string name="server_lab_public_key">পাবলিক কী</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">শর্ট আইডি</string>
@@ -197,7 +197,7 @@
     <string name="title_pref_speed_enabled">গতি প্রদর্শন সক্রিয় করুন</string>
     <string name="summary_pref_speed_enabled">বিজ্ঞপ্তিতে বর্তমান গতি প্রদর্শন করুন।\nব্যবহারের উপর ভিত্তি করে বিজ্ঞপ্তি আইকন পরিবর্তিত হবে।</string>
 
-    <string name="title_pref_sniffing_enabled">স্নিফিং সক্রিয় করুন</string>
+    <string name="title_pref_sniffing_enabled">প্যাকেট বিশ্লেষণ সক্রিয় করুন (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">প্যাকেট থেকে ডোমেইন স্নিফ করার চেষ্টা করুন (ডিফল্টভাবে চালু)</string>
     <string name="title_pref_route_only_enabled">routeOnly সক্রিয় করুন</string>
     <string name="summary_pref_route_only_enabled">রুটিংয়ের জন্য শুধুমাত্র স্নিফড ডোমেইন নাম ব্যবহার করুন, এবং লক্ষ্য ঠিকানা হিসেবে আইপি ঠিকানা রাখুন।</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">স্থানীয় DNS সক্রিয় করুন</string>
     <string name="summary_pref_local_dns_enabled">DNS মূল DNS মডিউল দ্বারা প্রক্রিয়া করা হয় (প্রস্তাবিত, যদি LAN এবং মূলভূমি ঠিকানার বাইপাসিং প্রয়োজন হয়)</string>
 
-    <string name="title_pref_fake_dns_enabled">ভুয়া DNS সক্রিয় করুন</string>
+    <string name="title_pref_fake_dns_enabled">ভুয়া DNS সক্রিয় করুন (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">স্থানীয় DNS মিথ্যা আইপি ঠিকানা ফেরত দেয় (দ্রুত, তবে এটি কিছু অ্যাপের জন্য কাজ নাও করতে পারে)</string>
 
     <string name="title_pref_ipv6_enabled">IPv6 সক্রিয় করুন</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">অটো আপডেট ইন্টারভ্যাল (মিনিট, সর্বনিম্ন মান ১৫)</string>
 
     <string name="title_core_loglevel">লগ স্তর</string>
-    <string name="title_outbound_domain_resolve_method">outbound ডোমেইন আগাম রেজলভ করার পদ্ধতি</string>
+    <string name="title_outbound_domain_resolve_method">বহির্গামী ডোমেইন আগাম রেজলভ করার পদ্ধতি (outbound)</string>
     <string name="title_mode">মোড</string>
     <string name="title_mode_help">আরো সাহায্যের জন্য ক্লিক করুন</string>
     <string name="title_language">ভাষা</string>
@@ -389,13 +389,13 @@
 
     <string name="import_subscription_success">সাবস্ক্রিপশন সফলভাবে আমদানি করা হয়েছে</string>
     <string name="import_subscription_failure">সাবস্ক্রিপশন আমদানি ব্যর্থ</string>
-    <string name="title_fragment_settings">ফ্র্যাগমেন্ট সেটিংস</string>
+    <string name="title_fragment_settings">প্যাকেট বিভাজন সেটিংস (Fragment)</string>
     <string name="title_pref_fragment_packets">ফ্র্যাগমেন্ট প্যাকেটস</string>
     <string name="title_pref_fragment_length">ফ্র্যাগমেন্ট দৈর্ঘ্য (ন্যূনতম-সর্বাধিক)</string>
     <string name="title_pref_fragment_interval">ফ্র্যাগমেন্ট ইন্টারভ্যাল (ন্যূনতম-সর্বাধিক)</string>
     <string name="title_pref_fragment_enabled">ফ্র্যাগমেন্ট সক্রিয় করুন</string>
     <string name="title_pref_fragment_maxsplit">ফ্র্যাগমেন্ট ম্যাক্স স্প্লিট</string>
-    <string name="title_observatory_settings">সংযোগ পর্যবেক্ষণ সেটিংস</string>
+    <string name="title_observatory_settings">সংযোগ পর্যবেক্ষণ সেটিংস (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">leastPing ইন্টারভ্যাল</string>
     <string name="title_pref_observatory_least_load_interval">leastLoad ইন্টারভ্যাল</string>
     <string name="title_pref_observatory_least_load_method">leastLoad HTTP পদ্ধতি</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">নীতি গ্রুপের ধরন</string>
     <string name="title_policy_group_subscription_id">সাবস্ক্রিপশন গ্রুপ থেকে</string>
     <string name="title_policy_group_subscription_filter">মন্তব্যের রেগুলার এক্সপ্রেশন ফিল্টার</string>
-    <string name="title_policy_group_test_outbounds">outbounds পরীক্ষা করুন</string>
-    <string name="title_policy_group_fallback">fallback outbound (ঐচ্ছিক)</string>
+    <string name="title_policy_group_test_outbounds">বহির্গামী সংযোগ পরীক্ষা করুন (outbounds)</string>
+    <string name="title_policy_group_fallback">বিকল্প বহির্গামী সংযোগ (outbound, ঐচ্ছিক)</string>
 
     <string name="server_proxy_chain_members">প্রক্সি চেইনের সদস্য</string>
     <string name="server_proxy_chain_pick_members">সদস্য বাছতে এখানে ট্যাপ করুন</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>সর্বনিম্ন পিং</item>
-        <item>সর্বনিম্ন লোড</item>
-        <item>এলোমেলো</item>
-        <item>রাউন্ড রবিন</item>
+        <item>সর্বনিম্ন পিং (leastPing)</item>
+        <item>সর্বনিম্ন লোড (leastLoad)</item>
+        <item>এলোমেলো (random)</item>
+        <item>রাউন্ড রবিন (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">স্থানীয়</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">সুইচ</string>
     <string name="app_tile_name">সুইচ</string>
     <string name="app_tile_first_use">এই ফিচারটি প্রথম ব্যবহার করা হচ্ছে, সার্ভার যোগ করতে অ্যাপটি ব্যবহার করুন</string>
@@ -76,8 +77,8 @@
     <string name="server_lab_path_kcp">kcp বীজ</string>
     <string name="server_lab_path_grpc">gRPC সেবার নাম</string>
     <string name="server_lab_stream_security">TLS</string>
-    <string name="server_lab_stream_fingerprint" translatable="false">ফিঙ্গারপ্রিন্ট</string>
-    <string name="server_lab_stream_alpn" translatable="false">Alpn</string>
+    <string name="server_lab_stream_fingerprint">ফিঙ্গারপ্রিন্ট</string>
+    <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">অনিরাপদ অনুমতি দিন</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">ঠিকানা</string>
@@ -88,12 +89,12 @@
     <string name="server_lab_security4">ব্যবহারকারী (ঐচ্ছিক)</string>
     <string name="server_lab_encryption">এনক্রিপশন</string>
     <string name="server_lab_flow">ফ্লো</string>
-    <string name="server_lab_public_key" translatable="false">পাবলিক কী</string>
+    <string name="server_lab_public_key">পাবলিক কী</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
-    <string name="server_lab_short_id" translatable="false">শর্ট আইডি</string>
-    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
+    <string name="server_lab_short_id">শর্ট আইডি</string>
+    <string name="server_lab_spider_x">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
-    <string name="server_lab_secret_key" translatable="false">সিক্রেট কী</string>
+    <string name="server_lab_secret_key">সিক্রেট কী</string>
     <string name="server_lab_reserved">সংরক্ষিত (ঐচ্ছিক)</string>
     <string name="server_lab_local_address">স্থানীয় ঠিকানা (ঐচ্ছিক IPv4/IPv6, কমা দ্বারা পৃথক করা)</string>
     <string name="server_lab_local_mtu">MTU (ঐচ্ছিক, ডিফল্ট 1420)</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">অবৈধ URL</string>
     <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
     <string name="server_lab_need_inbound">ইনবাউন্ড পোর্ট নিশ্চিত করুন সেটিংসের সাথে সামঞ্জস্যপূর্ণ</string>
-    <string name="toast_malformed_josn">কনফিগারেশন বিকৃত</string>
+    <string name="toast_malformed_json">কনফিগারেশন বিকৃত</string>
     <string name="server_lab_request_host6">হোস্ট (SNI) (ঐচ্ছিক)</string>
     <string name="toast_action_not_allowed">অ্যাকশন অনুমোদিত নয়</string>
     <string name="server_obfs_password">Obfs password</string>
@@ -127,6 +128,9 @@
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_browser_dialer">Browser Dialer চালু করুন</string>
+    <string name="server_lab_browser_dialer_tip">শুধু xhttp (packet-up) ও ws আউটবাউন্ড সমর্থিত; TLS-সংক্রান্ত সেটিং উপেক্ষিত হতে পারে বা পরস্পরের সঙ্গে বিরোধ করতে পারে</string>
+    <string name="toast_allow_insecure_deprecated">বর্তমান নোডটি এনক্রিপশনবিহীন সংযোগ ব্যবহার করে। কর্তৃত্ববাদী সরকারের নিয়ন্ত্রণাধীন মধ্যবর্তী নেটওয়ার্ক অবকাঠামো আপনার যোগাযোগ সরাসরি দেখতে পারে।\nনিরাপত্তার কারণে Xray কোরের 26.2.6 বা পরবর্তী সংস্করণ দিয়ে এ ধরনের নোডে সংযোগ করা যায় না।\nনোডটি নিজে তৈরি করে থাকলে TLS-এর মতো নিরাপদ এনক্রিপশন চালু করুন অথবা pinnedCA256 সার্টিফিকেট ফিঙ্গারপ্রিন্ট পিন করুন।\nনোডটি কোনো সেবা প্রদানকারীর হলে প্রযুক্তিগত আপগ্রেডের জন্য তাদের সঙ্গে যোগাযোগ করুন। তারা সহযোগিতা না করলে ব্যবহারকারীর নিরাপত্তাকে বেশি গুরুত্ব দেয় এমন প্রদানকারীর কাছে যাওয়ার পরামর্শ দেওয়া হয়।\nআরও তথ্যের জন্য দেখুন https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
     <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
     <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
@@ -137,7 +141,7 @@
     <string name="menu_item_add_file">ফাইল যোগ করুন</string>
     <string name="menu_item_add_url">URL যোগ করুন</string>
     <string name="menu_item_scan_qrcode">QR কোড স্ক্যান করুন</string>
-    <string name="title_url" translatable="false">URL</string>
+    <string name="title_url">URL</string>
     <string name="menu_item_download_file">ফাইল ডাউনলোড করুন</string>
     <string name="title_user_asset_add_url">অ্যাসেট URL যোগ করুন</string>
     <string name="msg_file_not_found">ফাইল খুঁজে পাওয়া যায়নি</string>
@@ -157,6 +161,7 @@
     <string name="menu_item_import_proxy_app">ক্লিপবোর্ড থেকে আমদানি করুন</string>
     <string name="per_app_proxy_settings">Per-app settings</string>
     <string name="per_app_proxy_settings_enable">Enable per-app</string>
+    <string name="app_picker_unknown_app">অজানা অ্যাপ (UID শনাক্ত করা যায়নি)</string>
 
     <!-- Preferences -->
     <string name="title_settings">সেটিংস</string>
@@ -168,6 +173,10 @@
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
 
+
+    <string name="subscription_updater_job_tips">কাজটি ব্যাকগ্রাউন্ডে চলবে এবং অগ্রগতির তথ্য বিজ্ঞপ্তিতে দেখানো হবে।</string>
+    <string name="title_pref_auto_test_after_update_subscription">সাবস্ক্রিপশন আপডেটের পর স্বয়ংক্রিয় পরীক্ষা</string>
+    <string name="summary_pref_auto_test_after_update_subscription">স্বয়ংক্রিয় পরীক্ষায় অনেক সময় লাগে। চালু থাকলে কাজটি ব্যাকগ্রাউন্ডে চলবে; অন্যথায় বর্তমান পৃষ্ঠায় চলবে।</string>
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>
     <string name="title_pref_auto_sort_after_test">Auto sort after testing</string>
@@ -176,8 +185,8 @@
     <string name="title_mux_settings">Mux সেটিংস</string>
     <string name="title_pref_mux_enabled">Mux সক্রিয় করুন</string>
     <string name="summary_pref_mux_enabled">দ্রুত, তবে এটি অস্থিতিশীল সংযোগ সৃষ্টি করতে পারে\nTCP, UDP এবং QUIC পরিচালনা কাস্টমাইজ করুন</string>
-    <string name="title_pref_mux_concurency">TCP সংযোগ (পরিসর -1 থেকে 1024)</string>
-    <string name="title_pref_mux_xudp_concurency">XUDP সংযোগ (পরিসর -1 থেকে 1024)</string>
+    <string name="title_pref_mux_concurrency">TCP সংযোগ (পরিসর -1 থেকে 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP সংযোগ (পরিসর -1 থেকে 1024)</string>
     <string name="title_pref_mux_xudp_quic">Mux টানেলে QUIC পরিচালনা</string>
     <string-array name="mux_xudp_quic_entries">
         <item>অস্বীকার করুন</item>
@@ -190,7 +199,6 @@
 
     <string name="title_pref_sniffing_enabled">স্নিফিং সক্রিয় করুন</string>
     <string name="summary_pref_sniffing_enabled">প্যাকেট থেকে ডোমেইন স্নিফ করার চেষ্টা করুন (ডিফল্টভাবে চালু)</string>
-
     <string name="title_pref_route_only_enabled">রুটঅনলি সক্রিয় করুন</string>
     <string name="summary_pref_route_only_enabled">রুটিংয়ের জন্য শুধুমাত্র স্নিফড ডোমেইন নাম ব্যবহার করুন, এবং লক্ষ্য ঠিকানা হিসেবে আইপি ঠিকানা রাখুন।</string>
 
@@ -213,7 +221,9 @@
     <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
 
     <string name="title_pref_vpn_interface_address">VPN Interface Address</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+
 
     <string name="title_pref_domestic_dns">ঘরোয়া DNS (ঐচ্ছিক)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
@@ -260,6 +270,7 @@
 
     <string name="title_pref_group_all_display">Enable show all groups</string>
     <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+
     <!-- AboutActivity -->
     <string name="title_pref_feedback">মতামত</string>
     <string name="summary_pref_feedback">মতামত উন্নয়ন বা বাগগুলি GitHub-এ পাঠান</string>
@@ -289,6 +300,12 @@
     <string name="summary_pref_use_hev_tunnel">When enabled, TUN will use hev-socks5-tunnel; otherwise, it will use xray-core.</string>
     <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
     <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
+    <string name="title_mode_settings">মোড সেটিংস</string>
+    <string name="title_root_mode_enabled">Root মোড চালু (Root ব্যবহারকারীদের জন্য)</string>
+    <string name="summary_root_mode_enabled">Root সুবিধা ব্যবহার করে নিম্ন-স্তরের স্বচ্ছ প্রক্সি চালু করুন। এই মোডটি Android-এর মানক সিস্টেম VPN এড়িয়ে সরাসরি অন্তর্নিহিত সব নেটওয়ার্ক ট্রাফিক নিয়ন্ত্রণ করে। চালু করার পর আগের সাধারণ মোড, অ্যাপভিত্তিক রাউটিং এবং সংশ্লিষ্ট VPN সেটিংস আর কার্যকর থাকবে না।</string>
+    <string name="toast_root_required">এই সুবিধার জন্য Root অ্যাক্সেস প্রয়োজন</string>
+    <string name="title_root_lan_sharing">LAN / টেদারিং শেয়ারিং (Root ব্যবহারকারীদের জন্য)</string>
+    <string name="summary_root_lan_sharing">Wi-Fi হটস্পট ও USB-টেদার করা ডিভাইসের ট্রাফিক VPN-এর মাধ্যমে রাউট করুন</string>
 
     <string name="title_logcat">লগক্যাট</string>
     <string name="logcat_copy">কপি করুন</string>
@@ -303,6 +320,7 @@
     <string name="sub_setting_remarks">মন্তব্য</string>
     <string name="sub_setting_url">ঐচ্ছিক URL</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_request_headers">রিকোয়েস্ট হেডার (JSON ফরম্যাট)</string>
     <string name="sub_setting_filter">Remarks regular filter</string>
     <string name="sub_setting_enable">আপডেট সক্রিয় করুন</string>
     <string name="sub_auto_update">স্বয়ংক্রিয় আপডেট সক্রিয় করুন</string>
@@ -318,8 +336,8 @@
     <string name="title_sort_by_test_results">টেস্ট ফলাফল দ্বারা সাজানো</string>
     <string name="title_filter_config">কনফিগারেশন ফাইল ফিল্টার করুন</string>
     <string name="filter_config_all">All</string>
-    <string name="title_del_duplicate_config_count">%d ডুপ্লিকেট কনফিগারেশন মুছে ফেলুন</string>
     <string name="summary_scan_qrcode">Click screen open the camera scan</string>
+    <string name="title_del_duplicate_config_count">%d ডুপ্লিকেট কনফিগারেশন মুছে ফেলুন</string>
     <string name="title_del_config_count">Delete %d configurations</string>
     <string name="title_import_config_count">Import %d configurations</string>
     <string name="title_export_config_count">Export %d configurations</string>
@@ -349,11 +367,13 @@
     <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
-    <string name="routing_settings_process">process (Package Name — only supported when using Xray TUN, routeOnly enabled, and Android 10+)</string>
+    <string name="routing_settings_process">process (প্যাকেজের নাম — শুধু Xray TUN ব্যবহার, routeOnly চালু এবং Android 10+ হলে সমর্থিত)</string>
+    <string name="routing_settings_process_select">প্যাকেজের নাম নির্বাচন করুন</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
@@ -365,7 +385,7 @@
     <string name="connection_test_error_status_code">ত্রুটি কোড: #%d</string>
     <string name="connection_connected">সংযুক্ত, সংযোগ পরীক্ষা করতে ট্যাপ করুন</string>
     <string name="connection_not_connected">সংযুক্ত নয়</string>
-    <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_task_left">চলমান পরীক্ষার কাজের সংখ্যা: %s</string>
 
     <string name="import_subscription_success">সাবস্ক্রিপশন সফলভাবে আমদানি করা হয়েছে</string>
     <string name="import_subscription_failure">সাবস্ক্রিপশন আমদানি ব্যর্থ</string>
@@ -396,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
     <string name="title_policy_group_test_outbounds">আউটবাউন্ড পরীক্ষা করুন</string>
     <string name="title_policy_group_fallback">ফলব্যাক আউটবাউন্ড (ঐচ্ছিক)</string>
+
     <string name="server_proxy_chain_members">Proxy chain members</string>
     <string name="server_proxy_chain_pick_members">Tap here to pick member</string>
     <string name="server_proxy_chain_member_unselected">Select a member</string>
@@ -430,11 +451,18 @@
         <item>শুধুমাত্র প্রোক্সি</item>
     </string-array>
 
+    <string-array name="browser_dialer_mode">
+        <item>নিষ্ক্রিয়</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
+    </string-array>
+
     <string-array name="ui_mode_night">
         <item>সিস্টেম অনুসরণ করুন</item>
         <item>লাইট</item>
         <item>ডার্ক</item>
     </string-array>
+
     <string name="routing_preset_china_whitelist">চায়না হোয়াইটলিস্ট</string>
     <string name="routing_preset_china_blacklist">চায়না ব্ল্যাকলিস্ট</string>
     <string name="routing_preset_global">গ্লোবাল</string>
@@ -452,6 +480,7 @@
         <item>Resolve and add to DNS Hosts</item>
         <item>Resolve and replace domain</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>Least Ping</item>
         <item>Least Load</item>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">ফিঙ্গারপ্রিন্ট</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">সার্টিফিকেট যাচাই এড়িয়ে যান (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">ঠিকানা</string>
     <string name="server_lab_port3">পোর্ট</string>
     <string name="server_lab_id3">পাসওয়ার্ড</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">পাবলিক কী</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">শর্ট আইডি</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
     <string name="server_lab_secret_key">সিক্রেট কী</string>
     <string name="server_lab_reserved">সংরক্ষিত (ঐচ্ছিক)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">ডোমেইন নাম রেজোলিউশনে IPv6 ঠিকানাকে অগ্রাধিকার দিন</string>
 
     <string name="title_pref_remote_dns">রিমোট DNS (udp/tcp/https/quic)(ঐচ্ছিক)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (শুধুমাত্র IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">VPN কি LAN এড়িয়ে যাবে?</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">ঘরোয়া DNS (ঐচ্ছিক)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS হোস্ট (ফরম্যাট: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">স্থানীয় প্রক্সি পোর্ট</string>
     <string name="title_pref_enable_local_proxy">লোকাল প্রক্সি সক্ষম করুন</string>
     <string name="summary_pref_enable_local_proxy">বন্ধ থাকলে কোনো SOCKS প্রক্সি পাওয়া যাবে না, তাই সাবস্ক্রিপশন আপডেট ও অনুরূপ কাজ প্রক্সি ব্যবহার করতে পারবে না</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">UDP ব্যবহার করার সময় socks5 প্রমাণীকরণ সম্পূর্ণরূপে নিরাপদ নয়</string>
     <string name="summary_pref_socks_port">স্থানীয় প্রক্সি পোর্ট</string>
     <string name="title_pref_dynamic_socks_port">গতিশীল স্থানীয় প্রক্সি পোর্ট চালু করুন</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">সাবস্ক্রিপশন গ্রুপ সেটিং</string>
     <string name="sub_setting_remarks">মন্তব্য</string>
     <string name="sub_setting_url">ঐচ্ছিক URL</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">রিকোয়েস্ট হেডার (JSON ফরম্যাট)</string>
     <string name="sub_setting_filter">মন্তব্যের রেগুলার এক্সপ্রেশন ফিল্টার</string>
     <string name="sub_setting_enable">আপডেট সক্রিয় করুন</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">%1$dটি কনফিগ আপডেট হয়েছে (%2$d সফল, %3$d ব্যর্থ, %4$d এড়ানো)</string>
     <string name="title_update_subscription_no_subscription">কোনো সাবস্ক্রিপশন নেই</string>
     <string name="toast_server_not_found_in_group">বর্তমান গ্রুপে নির্বাচিত সার্ভারটি পাওয়া যায়নি</string>
-    <string name="toast_fragment_not_available">বর্তমান স্ক্রিনটি উপলভ্য নয়।</string>
     <string name="title_locate_selected_config">নির্বাচিত কনফিগটি খুঁজুন</string>
 
     <string name="tasker_start_service">সার্ভিস শুরু করুন</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">প্যাকেজের নাম নির্বাচন করুন</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">স্থানীয়</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">QUIC কী</string>
     <string name="server_lab_path_kcp">kcp বীজ</string>
     <string name="server_lab_path_grpc">gRPC সেবার নাম</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">ফিঙ্গারপ্রিন্ট</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">সার্টিফিকেট যাচাই এড়িয়ে যান (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">ঠিকানা</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">শর্ট আইডি</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">সিক্রেট কী</string>
     <string name="server_lab_reserved">সংরক্ষিত (ঐচ্ছিক)</string>
     <string name="server_lab_local_address">স্থানীয় ঠিকানা (ঐচ্ছিক IPv4/IPv6, কমা দ্বারা পৃথক করা)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">EchConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">নাম দিয়ে পিয়ার সার্টিফিকেট যাচাই করুন</string>
     <string name="server_lab_pinned_ca256">সার্টিফিকেট ফিঙ্গারপ্রিন্ট (SHA-256)</string>
     <string name="server_lab_browser_dialer">Browser Dialer চালু করুন</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">ফাইল যোগ করুন</string>
     <string name="menu_item_add_url">URL যোগ করুন</string>
     <string name="menu_item_scan_qrcode">QR কোড স্ক্যান করুন</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">ফাইল ডাউনলোড করুন</string>
     <string name="title_user_asset_add_url">অ্যাসেট URL যোগ করুন</string>
     <string name="msg_file_not_found">ফাইল খুঁজে পাওয়া যায়নি</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">সঠিক বিলম্ব পরীক্ষা ইউআরএল </string>
-    <string name="summary_pref_delay_test_url">ইউআরএল</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">একযোগে প্রকৃত বিলম্ব পরীক্ষা</string>
 
     <string name="title_pref_ip_api_url">বর্তমান সংযোগের তথ্য পরীক্ষার URL</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">LAN থেকে সংযোগ অনুমোদন করুন</string>
     <string name="summary_pref_proxy_sharing_enabled">অন্যান্য ডিভাইসগুলি আপনার আইপি ঠিকানা ব্যবহার করে প্রক্সিতে সংযুক্ত হতে পারে, শুধুমাত্র বিশ্বস্ত নেটওয়ার্কে সক্রিয় করুন যাতে অনুমোদিত সংযোগ এড়ানো যায়</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">LAN / টেদার করা ডিভাইসে VPN শেয়ার করুন (Root ব্যবহারকারীদের জন্য)</string>
     <string name="summary_root_lan_sharing">Wi-Fi হটস্পট ও USB-টেদার করা ডিভাইসের ট্রাফিক VPN-এর মাধ্যমে রাউট করুন।</string>
 
-    <string name="title_logcat">লগক্যাট</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">কপি করুন</string>
     <string name="logcat_clear">স্পষ্ট করুন</string>
     <string name="logcat_share">লগ শেয়ার করুন</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">QRcode থেকে রুলসেট আমদানি করুন</string>
     <string name="routing_settings_export_rulesets_to_clipboard">নিয়মসমূহ ক্লিপবোর্ডে রপ্তানি করুন</string>
     <string name="routing_settings_locked">লক করা; প্রিসেট আমদানির সময় এই নিয়মটি রাখুন</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (প্যাকেজের নাম — শুধু Xray TUN ব্যবহার, routeOnly চালু এবং Android 10+ হলে সমর্থিত)</string>
     <string name="routing_settings_process_select">প্যাকেজের নাম নির্বাচন করুন</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
     <string name="connection_test_testing">পরীক্ষা চলছে…</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">آلشت</string>
     <string name="app_tile_name">آلشت</string>
     <string name="app_tile_first_use">سی کرت ٱولی و کار بوردن ای ویژیی، ٱول ز من برنومه ی سرور ازاف کۊنین</string>
@@ -10,7 +11,7 @@
     <string name="migration_fail">جاگورویی داده یل شکست خرد!</string>
     <string name="pull_down_to_refresh">سی وانۊ کردن، بلگه ن بلم بکشین!</string>
 
-    <!-- Notifications -->↓
+    <!-- Notifications -->
     <string name="notification_action_stop_v2ray">واڌاشتن</string>
     <string name="toast_permission_denied">گرؽڌن موجوز مومکن نؽڌ</string>
     <string name="toast_permission_denied_notification">گرؽڌن موجوز وارسۊوی مومکن نؽڌ</string>
@@ -76,7 +77,7 @@
     <string name="server_lab_path_kcp">KCP seed</string>
     <string name="server_lab_path_grpc">نوم سرویس gRPC</string>
     <string name="server_lab_stream_security">TLS</string>
-    <string name="server_lab_stream_fingerprint" translatable="false">Fingerprint</string>
+    <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">هشتن SSL نا ٱمن</string>
     <string name="server_lab_sni">SNI</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">نشۊوی اینترنتی نا موئتبر هڌ</string>
     <string name="toast_insecure_url_protocol">نشۊوی اشتراک پوروتوکول نا ٱمن HTTP ن و کار مبرین</string>
     <string name="server_lab_need_inbound">موتمعن بۊین ک پورت وۊرۊڌی وا سامووا ی جۊر هڌ</string>
-    <string name="toast_malformed_josn">کانفیگ زبال نؽڌ</string>
+    <string name="toast_malformed_json">کانفیگ زبال نؽڌ</string>
     <string name="server_lab_request_host6">هاست(SNI)(اختیاری)</string>
     <string name="toast_action_not_allowed">ای کار ممنۊع هڌ</string>
     <string name="server_obfs_password">رزم obfs</string>
@@ -127,6 +128,9 @@
     <string name="server_lab_ech_config_list">نومگه کانفیگ Ech</string>
     <string name="server_lab_verify_peer_cert_by_name">تئیڌ گوواهی هومتا و ری نوم</string>
     <string name="server_lab_pinned_ca256">جا کلک گوواهی (SHA-256)</string>
+    <string name="server_lab_browser_dialer">Browser Dialer ن ره وستین</string>
+    <string name="server_lab_browser_dialer_tip">تینا وۊرۊیا xhttp (packet-up) وو ws ن پوشتؽووی اکونه؛ گاشڌ سامووا وابسته و TLS ناڌیڌه گرفته ابۊن یا وا همن جۊر نین</string>
+    <string name="toast_allow_insecure_deprecated">ای گر ز منپیز بی رمزنگاری کار اگیره. گاشڌ منپیزا شمو و دست دسگایل میووݩ شبکه ک و دست دولتا استبداڌی کنتورول ابۊن موستقیمن دیڌه ابۊ.\nسی ٱمنیت، ای جۊر گر یل وا هسته Xray نوسخه 26.2.6+ منپیز نابۊن.\nٱر گر خوتووݩ هڌ، رمزنگاری ٱمنی وری TLS ن ره وستین یا اثر انگشت گوواهی pinnedCA256 ن چفت کۊنین.\nٱر گر مال سرویس ڌهنده هڌ، ز سرویس ڌهنده بخواین ٱرتقا فنی ن ٱنجوم بڌه. ٱر همکاری نکونه، بئتره سرویس ڌهنده ی ک ب ٱمنیت کارورووݩ بؽتر اهمیت اڌه پسند کۊنین.\nسی دووسته بؽتر ورین و https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">گرؽڌن وو پور کردن جا کلک گوواهی</string>
     <string name="toast_fetch_cert_sha256_success">جا کلک گوواهی وا مووفقیت گرؽڌه وابی</string>
     <string name="toast_fetch_cert_sha256_failed">گرؽڌن جا کلک گوواهی مووفق نبی</string>
@@ -157,7 +161,7 @@
     <string name="menu_item_import_proxy_app">و من ٱووردن ز کلیپ بورد</string>
     <string name="per_app_proxy_settings">سامووا ب تفکیک برنومه</string>
     <string name="per_app_proxy_settings_enable">ره وندن ب تفکیک برنومه</string>
-
+    <string name="app_picker_unknown_app">برنومه ناناس (UID ناساڌه)</string>
 
     <!-- Preferences -->
     <string name="title_settings">سامووا</string>
@@ -169,6 +173,10 @@
     <string name="title_pref_is_booted">منپیز خوتکار مجال ره ونی</string>
     <string name="summary_pref_is_booted">مجال ره وندن، خوساخوس و سرور پسند بیڌه منپیز ابۊ که گاشڌ نا مووفق بۊ.</string>
 
+
+    <string name="subscription_updater_job_tips">وزیفه من پس زمینه کار اکونه وو ایلاعات پؽشرفت من اعلان نشووݩ داڌه ابۊ.</string>
+    <string name="title_pref_auto_test_after_update_subscription">تست خوتکار بئڌ و رۊز کۊنی اشتراک</string>
+    <string name="summary_pref_auto_test_after_update_subscription">تست خوتکار زمووݩ زیاڌی ابره. ٱر ره وست بۊ، وزیفه من پس زمینه کار اکونه؛ وگرنه من همین بلگه کار اکونه.</string>
     <string name="title_pref_auto_remove_invalid_after_test">پاک کردن خوتکار کانفیگا نا موئتبر بئڌ پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتیجه یل پینگ گاشڌ دییق نبۊن؛ کانفیگا پاک وابیڌه ن نتری وورگنی.</string>
     <string name="title_pref_auto_sort_after_test">ترتیب خوتکار بئڌ پینگ گرؽڌن</string>
@@ -177,8 +185,8 @@
     <string name="title_mux_settings">سامووا Mux</string>
     <string name="title_pref_mux_enabled">ره وندن Mux</string>
     <string name="summary_pref_mux_enabled">زل تر، ٱما گاشڌ منپیز زی قت بۊ\nمخزن ترافیک TCP وا 8 منپیز پؽش فرز، بارت دؽوۉداری UDP وو QUIC ن ای لم سفارشی کۊنین.</string>
-    <string name="title_pref_mux_concurency">منپیزا TCP (تلایه منجا 1-1024)</string>
-    <string name="title_pref_mux_xudp_concurency">منپیزا XUDP (تلایه منجا 1-1024)</string>
+    <string name="title_pref_mux_concurrency">منپیزا TCP (تلایه منجا -1 تا 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">منپیزا XUDP (تلایه منجا -1 تا 1024)</string>
     <string name="title_pref_mux_xudp_quic">دؽوۉداری QUIC من تۊنل mux</string>
     <string-array name="mux_xudp_quic_entries">
         <item>رڌ کردن</item>
@@ -213,7 +221,9 @@
     <string name="title_pref_vpn_bypass_lan">VPN ز شبکه مهلی اگوڌرته؟</string>
 
     <string name="title_pref_vpn_interface_address">نشۊوی رابت VPN</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (پؽش فرز 1500)</string>
+
 
     <string name="title_pref_domestic_dns">DNS منی (اختیاری)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
@@ -260,6 +270,7 @@
 
     <string name="title_pref_group_all_display">نشووݩ داڌن پوی بونکۊ یل ن ره ونین</string>
     <string name="summary_pref_group_all_display">ی بلگه «پوی بونکۊ یل کانفیگ» ازاف کۊنین</string>
+
     <!-- AboutActivity -->
     <string name="title_pref_feedback">فشناڌن منشڌ</string>
     <string name="summary_pref_feedback">فشناڌن منشڌ یا گوزارش موشکلا من Github</string>
@@ -309,6 +320,7 @@
     <string name="sub_setting_remarks">نیشتنا</string>
     <string name="sub_setting_url">نشۊوی اینترنتی اختیاری</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_request_headers">سرآیندا درخاست (قالوو JSON)</string>
     <string name="sub_setting_filter">نوم موستعار فیلتر</string>
     <string name="sub_setting_enable">ره وندن ورۊ کردن</string>
     <string name="sub_auto_update">ره وندن ورۊ کردن خوتکار</string>
@@ -324,9 +336,8 @@
     <string name="title_sort_by_test_results">ترتیب و ری نتیجه یل پینگ</string>
     <string name="title_filter_config">فیلتر کردن کانفیگا</string>
     <string name="filter_config_all">پوی</string>
-    <string name="title_del_duplicate_config_count">پاک کردن %d کانفیگ تکراری</string>
     <string name="summary_scan_qrcode">Click screen open the camera scan</string>
-
+    <string name="title_del_duplicate_config_count">پاک کردن %d کانفیگ تکراری</string>
     <string name="title_del_config_count">پاک کردن %d کانفیگ</string>
     <string name="title_import_config_count">و من ٱووردن %d کانفیگ</string>
     <string name="title_export_config_count">و در کشیڌن %d کانفیگ</string>
@@ -354,13 +365,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">و من ٱووردن قانووا ز QRcode</string>
     <string name="routing_settings_export_rulesets_to_clipboard">و در کشیڌن قانووا وو زفت من کلیپ بورد</string>
     <string name="routing_settings_locked">چفت هڌ، ای قانووݩ ن مجال و من ٱووردن ز پؽش سامووا زفت کۊنین</string>
-    <string name="routing_settings_domain" translatable="false">domain</string>
-    <string name="routing_settings_ip" translatable="false">ip</string>
-    <string name="routing_settings_port" translatable="false">port</string>
-    <string name="routing_settings_protocol" translatable="false">protocol</string>
-    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network" translatable="false">network</string>"[udp|tcp]"
-    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
+    <string name="routing_settings_domain">domain</string>
+    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_process">process (نوم بسته — تینا مجال کار بوردن Xray TUN، ره بیڌن routeOnly وو Android 10+ پوشتؽووی ابۊ)</string>
+    <string name="routing_settings_process_select">نوم بسته ن پسند کۊنین</string>
+    <string name="routing_settings_port">port</string>
+    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">منپیزن واجۊری کوݩ</string>
     <string name="connection_test_testing">هونی آزمایش ابۊ…</string>
@@ -371,7 +385,7 @@
     <string name="connection_test_error_status_code">کود ختا: #%d</string>
     <string name="connection_connected">منپیز هڌ، سی واجۊری کیلیک کوݩ</string>
     <string name="connection_not_connected">منپیز نؽڌ</string>
-    <string name="connection_runing_task_left">تعداد وزیفه یل آزمایشی ک ره اۊفتانه: %s</string>
+    <string name="connection_running_task_left">تعداد وزیفه یل آزمایشی ک ره اۊفتانه: %s</string>
 
     <string name="import_subscription_success">اشتراک وا مووفقیت زفت وابی</string>
     <string name="import_subscription_failure">اشتراک زفت نوابی</string>
@@ -402,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">توزیهات فیلتر معمۊلی</string>
     <string name="title_policy_group_test_outbounds">آزمایش بارتا</string>
     <string name="title_policy_group_fallback">بارت جایگزین (اختیاری)</string>
+
     <string name="server_proxy_chain_members">ٱئزا زنجیره پروکسی</string>
     <string name="server_proxy_chain_pick_members">سی پسند عوزو ایچو بزنین</string>
     <string name="server_proxy_chain_member_unselected">ی عوزو پسند کۊنین</string>
@@ -436,6 +451,12 @@
         <item>تینا پروکسی</item>
     </string-array>
 
+    <string-array name="browser_dialer_mode">
+        <item>خامۊش</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
+    </string-array>
+
     <string-array name="ui_mode_night">
         <item>و دین کردن سیستوم</item>
         <item>رۊشنا</item>
@@ -459,6 +480,7 @@
         <item>هل وو ٱووردن و میزبووݩ یل دامنه DNS</item>
         <item>هل وو جایونی دامنه</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>کم ترین پینگ</item>
         <item>کم ترین بار (لود)</item>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -266,7 +266,7 @@
     <string name="summary_pref_append_http_proxy">پروکسی HTTP ن موسقیمن ز (مۊرۊرگر/ی قرد ز برنومه یل لادراری بیڌه)، بؽ استفاڌه ز دسگا NIC مجازی (Android 10+) استفاڌه ابۊ.</string>
 
     <string name="title_pref_double_column_display">ره وندن نشووݩ داڌن دو سۊتۊنی</string>
-    <string name="summary_pref_double_column_display">The profile list is displayed in double columns, allowing more content to be displayed on the screen.</string>
+    <string name="summary_pref_double_column_display">نومگه کانفیگا من دو ستۊݩ نشووݩ داڌه ابۊ تا مهتووا بؽتری من بلگه جا بگره.</string>
 
     <string name="title_pref_group_all_display">نشووݩ داڌن پوی بونکۊ یل ن ره ونین</string>
     <string name="summary_pref_group_all_display">ی بلگه «پوی بونکۊ یل کانفیگ» ازاف کۊنین</string>
@@ -277,7 +277,7 @@
     <string name="summary_pref_tg_group">ٱووڌن من بونکۊ تلگرام</string>
     <string name="toast_tg_app_not_found">برنومه تلگرامن نجوست</string>
     <string name="title_privacy_policy">هریم سیخومی</string>
-    <string name="title_qr_code">QR code</string>
+    <string name="title_qr_code">کود QR</string>
     <string name="title_about">زبار</string>
     <string name="title_source_code">کود بونچک</string>
     <string name="title_oss_license">موجوزا کود بونچک</string>
@@ -336,7 +336,7 @@
     <string name="title_sort_by_test_results">ترتیب و ری نتیجه یل پینگ</string>
     <string name="title_filter_config">فیلتر کردن کانفیگا</string>
     <string name="filter_config_all">پوی</string>
-    <string name="summary_scan_qrcode">Click screen open the camera scan</string>
+    <string name="summary_scan_qrcode">سی وا کردن دوربیݩ وو ٱسکووݩ، و ری بلگه بزنین</string>
     <string name="title_del_duplicate_config_count">پاک کردن %d کانفیگ تکراری</string>
     <string name="title_del_config_count">پاک کردن %d کانفیگ</string>
     <string name="title_import_config_count">و من ٱووردن %d کانفیگ</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
-    <string name="server_lab_allow_insecure">هشتن SSL نا ٱمن</string>
+    <string name="server_lab_allow_insecure">هشتن SSL نا ٱمن (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">نشۊوی</string>
     <string name="server_lab_port3">پورت</string>
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">رزم (اختیاری)</string>
     <string name="server_lab_security4">نوم منتوری (اختیاری)</string>
     <string name="server_lab_encryption">رزم نگاری</string>
-    <string name="server_lab_flow">جریان</string>
+    <string name="server_lab_flow">جریان (flow)</string>
     <string name="server_lab_public_key">کیلیت پوی وولاتی</string>
     <string name="server_lab_preshared_key">کیلیت پؽش اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کۊتال</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">ره وندن DNS مهلی</string>
     <string name="summary_pref_local_dns_enabled">درخاستا DNS و هسته و من ایان وو و دست ماژول DNS پردازشت ابۊن (پؽشنهاڌ ابۊ ٱر لنگ تور جوستن سی دور زیڌن نشۊویا LAN وو وولات ٱسلی هڌین ره ونده بۊ)</string>
 
-    <string name="title_pref_fake_dns_enabled">ره وندن DNS جئلی</string>
+    <string name="title_pref_fake_dns_enabled">ره وندن DNS جئلی (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">دی ان اس مهلی نشۊویا آی پی جئلی ن اوورگنه (زل تر، ٱما گاشڌ من ی قرده ز برنومه یل کار نکونه)</string>
 
     <string name="title_pref_ipv6_enabled">ره وندن IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">فاسله ورۊ کردن خوتکار (اقلن وا 15 دؽقه بۊ)</string>
 
     <string name="title_core_loglevel">سئت گوزارشا</string>
-    <string name="title_outbound_domain_resolve_method">بارت پؽش هل دامنه دری</string>
+    <string name="title_outbound_domain_resolve_method">بارت پؽش هل دامنه دری (outbound)</string>
     <string name="title_mode">هالت</string>
     <string name="title_mode_help">سی دووسمندیا وو هیاری قلوه، ری ای هؽل بزݩ</string>
     <string name="title_language">زووݩ</string>
@@ -389,13 +389,13 @@
 
     <string name="import_subscription_success">اشتراک وا مووفقیت زفت وابی</string>
     <string name="import_subscription_failure">اشتراک زفت نوابی</string>
-    <string name="title_fragment_settings">سامووا فرگمنت</string>
+    <string name="title_fragment_settings">سامووا فرگمنت (Fragment)</string>
     <string name="title_pref_fragment_packets">کتنا فرگمنت</string>
     <string name="title_pref_fragment_length">تۊل کتنا فرگمنت (هدقل-هدکسر)</string>
     <string name="title_pref_fragment_interval">فاسله منجا کتنا فرگمنت (هدقل-هدکسر)</string>
     <string name="title_pref_fragment_enabled">ره وندن فرگمنت</string>
     <string name="title_pref_fragment_maxsplit">هدکسر تقسیم فرگمنت</string>
-    <string name="title_observatory_settings">سامووا واجۊری منپیز</string>
+    <string name="title_observatory_settings">سامووا واجۊری منپیز (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">فاسله leastPing</string>
     <string name="title_pref_observatory_least_load_interval">فاسله leastLoad</string>
     <string name="title_pref_observatory_least_load_method">روش HTTP سی leastLoad</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">نوع بونکۊ سیاست</string>
     <string name="title_policy_group_subscription_id">ز بونکۊ اشتراک</string>
     <string name="title_policy_group_subscription_filter">توزیهات فیلتر معمۊلی</string>
-    <string name="title_policy_group_test_outbounds">آزمایش بارتا</string>
-    <string name="title_policy_group_fallback">بارت جایگزین (اختیاری)</string>
+    <string name="title_policy_group_test_outbounds">آزمایش بارتا (outbounds)</string>
+    <string name="title_policy_group_fallback">بارت جایگزین (outbound، اختیاری)</string>
 
     <string name="server_proxy_chain_members">ٱئزا زنجیره پروکسی</string>
     <string name="server_proxy_chain_pick_members">سی پسند عوزو ایچو بزنین</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>کم ترین پینگ</item>
-        <item>کم ترین بار (لود)</item>
-        <item>تساڌۊفی</item>
-        <item>گردشی</item>
+        <item>کم ترین پینگ (leastPing)</item>
+        <item>کم ترین بار (لود) (leastLoad)</item>
+        <item>تساڌۊفی (random)</item>
+        <item>گردشی (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">مهلی</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -79,8 +79,8 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
-    <string name="server_lab_allow_insecure">Skip certificate verification (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_allow_insecure">تئیڌ گوواهی ن ناڌیڌه بگرین (allowInsecure)</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">نشۊوی</string>
     <string name="server_lab_port3">پورت</string>
     <string name="server_lab_id3">رزم</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">کیلیت پوی وولاتی</string>
     <string name="server_lab_preshared_key">کیلیت پؽش اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کۊتال</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">تاییدیه Mldsa65Verify</string>
     <string name="server_lab_secret_key">کیلیت سیخومی</string>
     <string name="server_lab_reserved">Reserved(اختیاری، وا کاما (,) ز یک جوڌا ابۊن)</string>
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">نشۊوی اینترنتی نا موئتبر هڌ</string>
     <string name="toast_insecure_url_protocol">نشۊوی اشتراک پوروتوکول نا ٱمن HTTP ن و کار مبرین</string>
     <string name="server_lab_need_inbound">موتمعن بۊین ک پورت وۊرۊڌی وا سامووا ی جۊر هڌ</string>
-    <string name="toast_malformed_json">Invalid configuration.</string>
+    <string name="toast_malformed_json">کانفیگ نا موئتبر هڌ</string>
     <string name="server_lab_request_host6">هاست(SNI)(اختیاری)</string>
     <string name="toast_action_not_allowed">ای کار ممنۊع هڌ</string>
     <string name="server_obfs_password">رزم obfs</string>
@@ -195,9 +195,9 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">ره وندن نشووݩ داڌن سورعت</string>
-    <string name="summary_pref_speed_enabled">Show current speeds in the notification.\nThe icon indicates whether proxy or direct traffic is dominant.</string>
+    <string name="summary_pref_speed_enabled">سورعت هیم سکویی من وارسۊوی نشووݩ داڌه ابۊ.\nنماڌ نشووݩ اڌه ک ترافیک پروکسی یا موستقیم بؽتره.</string>
 
-    <string name="title_pref_sniffing_enabled">Detect destination domains (Sniffing)</string>
+    <string name="title_pref_sniffing_enabled">ره وندن در کشیڌن نوم دامنه موورد نزر (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">قپ ریت سی و در کشیڌن نوم دامنه واقعی ز کتنا (پؽش فرز رۊشن هڌ)</string>
     <string name="title_pref_route_only_enabled">ره وندن تینا تور جوستن routeOnly</string>
     <string name="summary_pref_route_only_enabled">نوم دامنه sniffed ن تینا سی تور جوستن و کار بگیرین وو نشۊوی موورد نزرن و عونوان نشۊوی IP ووردارین.</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">مجال هل وو فسل نوم دامنه، نشۊویا IPv6 ن ترجی بڌین</string>
 
     <string name="title_pref_remote_dns">DNS ز ره دیر (اختیاری) (udp/tcp/https/quic) (اختیاری)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (تینا IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">VPN ز شبکه مهلی اگوڌرته؟</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">DNS منی (اختیاری)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS هاست موستقیم (قالوو: دامنه: نشۊوی،...)</string>
     <string name="summary_pref_dns_hosts">دامنه:نشۊوی،...</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">پورت پروکسی مهلی</string>
     <string name="title_pref_enable_local_proxy">ره وندن پروکسی مهلی</string>
     <string name="summary_pref_enable_local_proxy">هرسا ره نوسته بۊ، هیچ پروکسی SOCKS من دسرس نؽ، سی دل هیمو کارایی جۊر ورۊ رسۊوی یل اشتراک نترن پروکسی ن و کار گرن.</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">ائراز هۊویت socks5 مجال استفاڌه ز UDP کاملن ایمن نؽ</string>
     <string name="summary_pref_socks_port">پورت پروکسی مهلی</string>
     <string name="title_pref_dynamic_socks_port">وورکل پورت موتقیر سی پروکسی مهلی</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">سامووا بونکۊ اشتراک</string>
     <string name="sub_setting_remarks">نیشتنا</string>
     <string name="sub_setting_url">نشۊوی اینترنتی اختیاری</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">سرآیندا درخاست (قالوو JSON)</string>
     <string name="sub_setting_filter">نوم موستعار فیلتر</string>
     <string name="sub_setting_enable">ره وندن ورۊ کردن</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">%1$d کانفیگ ورۊ وابی (مووفق: %2$d، شکست خرده: %3$d، رڌ وابیڌه: %4$d)</string>
     <string name="title_update_subscription_no_subscription">بؽ اشتراک</string>
     <string name="toast_server_not_found_in_group">سرور پسند وابیڌه من بونکۊ سکویی نجۊرست</string>
-    <string name="toast_fragment_not_available">نتره نما سکویی ن بجۊره</string>
     <string name="title_locate_selected_config">کانفیگ پسند وابیڌه ن بجۊرین</string>
 
     <string name="tasker_start_service">ره وندن سرویس</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">نوم بسته ن پسند کۊنین</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">منپیزن واجۊری کوݩ</string>
@@ -413,7 +412,7 @@
 
     <string name="title_policy_group_type">نوع بونکۊ سیاست</string>
     <string name="title_policy_group_subscription_id">ز بونکۊ اشتراک</string>
-    <string name="title_policy_group_subscription_filter">Remarks regex filter</string>
+    <string name="title_policy_group_subscription_filter">فیلتر نیشتنا وا regex</string>
     <string name="title_policy_group_test_outbounds">آزمایش بارتا (outbounds)</string>
     <string name="title_policy_group_fallback">بارت جایگزین (outbound، اختیاری)</string>
 
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">مهلی</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">تور QUIC</string>
     <string name="server_lab_path_kcp">KCP seed</string>
     <string name="server_lab_path_grpc">نوم سرویس gRPC</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">تئیڌ گوواهی ن ناڌیڌه بگرین (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">نشۊوی</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">کیلیت پؽش اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کۊتال</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">تاییدیه Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">کیلیت سیخومی</string>
     <string name="server_lab_reserved">Reserved(اختیاری، وا کاما (,) ز یک جوڌا ابۊن)</string>
     <string name="server_lab_local_address">نشۊوی مهلی (اختیاری IPv4/IPv6، وا کاما (,) ز یک جوڌا ابۊن)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">هالت XHTTP</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra خام JSON، قالوو: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask خام JSON، قالوو: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">نومگه کانفیگ Ech</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">تئیڌ گوواهی هومتا و ری نوم</string>
     <string name="server_lab_pinned_ca256">جا کلک گوواهی (SHA-256)</string>
     <string name="server_lab_browser_dialer">Browser Dialer ن ره وستین</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">ٱووردن فایل</string>
     <string name="menu_item_add_url">ٱووردن لینگ</string>
     <string name="menu_item_scan_qrcode">اسکن QRcode</string>
-    <string name="title_url">نشۊوی اینترنتی</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">دانلود فایلا</string>
     <string name="title_user_asset_add_url">نشۊوی اینترنتی دارایی ن ازاف کۊنین</string>
     <string name="msg_file_not_found">فایلن نجوست</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">دامنه:نشۊوی،...</string>
 
     <string name="title_pref_delay_test_url">نشۊوی اینترنتی آزمایش تئخیر واقعی</string>
-    <string name="summary_pref_delay_test_url">نشۊوی اینترنتی</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">تعداد هوم زمووی تست تئخیر واقعی</string>
 
     <string name="title_pref_ip_api_url">نشۊوی اینترنتی آزمایش دووسمندیا منپیز هیم سکویی</string>
-    <string name="summary_pref_ip_api_url">نشۊوی اینترنتی</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">یک رسۊوی پروکسی من شبکه مهلی LAN</string>
     <string name="summary_pref_proxy_sharing_enabled">پوی دسگایل ترن وا نشۊوی IP ایسا، ز ره socks/http و پروکسی منپیز بۊن، تینا من شبکه قابل ائتماد ره ونده بۊ تا ز منپیز قیر موجاز جلو گری بۊ.</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">یک رسۊوی LAN / تترینگ (منتورووݩ رۊت وابیڌه)</string>
     <string name="summary_root_lan_sharing">ترافیک هات‌اسپات وای‌فای وو دسگا یل منپیز وابیڌه وا USB (تترینگ) ن ز تور VPN بفشنین.</string>
 
-    <string name="title_logcat">گوزارشا</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">لف گیری</string>
     <string name="logcat_clear">روفتن</string>
     <string name="logcat_share">یک رسۊوی گوزارش</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">و من ٱووردن قانووا ز QRcode</string>
     <string name="routing_settings_export_rulesets_to_clipboard">و در کشیڌن قانووا وو زفت من کلیپ بورد</string>
     <string name="routing_settings_locked">چفت هڌ، ای قانووݩ ن مجال و من ٱووردن ز پؽش سامووا زفت کۊنین</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (نوم بسته — تینا مجال کار بوردن Xray TUN، ره بیڌن routeOnly وو Android 10+ پوشتؽووی ابۊ)</string>
     <string name="routing_settings_process_select">نوم بسته ن پسند کۊنین</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">منپیزن واجۊری کوݩ</string>
     <string name="connection_test_testing">هونی آزمایش ابۊ…</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
-    <string name="server_lab_allow_insecure">هشتن SSL نا ٱمن (allowInsecure)</string>
+    <string name="server_lab_allow_insecure">Skip certificate verification (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">نشۊوی</string>
     <string name="server_lab_port3">پورت</string>
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">نشۊوی اینترنتی نا موئتبر هڌ</string>
     <string name="toast_insecure_url_protocol">نشۊوی اشتراک پوروتوکول نا ٱمن HTTP ن و کار مبرین</string>
     <string name="server_lab_need_inbound">موتمعن بۊین ک پورت وۊرۊڌی وا سامووا ی جۊر هڌ</string>
-    <string name="toast_malformed_json">کانفیگ زبال نؽڌ</string>
+    <string name="toast_malformed_json">Invalid configuration.</string>
     <string name="server_lab_request_host6">هاست(SNI)(اختیاری)</string>
     <string name="toast_action_not_allowed">ای کار ممنۊع هڌ</string>
     <string name="server_obfs_password">رزم obfs</string>
@@ -195,9 +195,9 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">ره وندن نشووݩ داڌن سورعت</string>
-    <string name="summary_pref_speed_enabled">نشووݩ داڌن سورعت هیم سکویی من وارسۊویا.\nنماڌ وارسۊوی و ری و کار گرؽڌن کانفیگ آلشت ابۊ.</string>
+    <string name="summary_pref_speed_enabled">Show current speeds in the notification.\nThe icon indicates whether proxy or direct traffic is dominant.</string>
 
-    <string name="title_pref_sniffing_enabled">ره وندن تجزیه وو تئلیل کتنا (Sniffing)</string>
+    <string name="title_pref_sniffing_enabled">Detect destination domains (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">قپ ریت سی و در کشیڌن نوم دامنه واقعی ز کتنا (پؽش فرز رۊشن هڌ)</string>
     <string name="title_pref_route_only_enabled">ره وندن تینا تور جوستن routeOnly</string>
     <string name="summary_pref_route_only_enabled">نوم دامنه sniffed ن تینا سی تور جوستن و کار بگیرین وو نشۊوی موورد نزرن و عونوان نشۊوی IP ووردارین.</string>
@@ -413,7 +413,7 @@
 
     <string name="title_policy_group_type">نوع بونکۊ سیاست</string>
     <string name="title_policy_group_subscription_id">ز بونکۊ اشتراک</string>
-    <string name="title_policy_group_subscription_filter">توزیهات فیلتر معمۊلی</string>
+    <string name="title_policy_group_subscription_filter">Remarks regex filter</string>
     <string name="title_policy_group_test_outbounds">آزمایش بارتا (outbounds)</string>
     <string name="title_policy_group_fallback">بارت جایگزین (outbound، اختیاری)</string>
 
@@ -483,7 +483,7 @@
 
     <string-array name="policy_group_type">
         <item>کم ترین پینگ (leastPing)</item>
-        <item>کم ترین بار (لود) (leastLoad)</item>
+        <item>کم ترین بار (leastLoad)</item>
         <item>تساڌۊفی (random)</item>
         <item>گردشی (roundRobin)</item>
     </string-array>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">اثرانگشت</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">نادیده گرفتن تأیید گواهی (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">نشانی</string>
     <string name="server_lab_port3">پورت</string>
     <string name="server_lab_id3">رمز عبور</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">کلید عمومی</string>
     <string name="server_lab_preshared_key">کلید پیش‌اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کوتاه</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">تاییدیه Mldsa65Verify</string>
     <string name="server_lab_secret_key">کلید خصوصی</string>
     <string name="server_lab_reserved">Reserved (اختیاری، جدا شده با کاما)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">هنگام بازیابی نام دامنه، آدرس‌های IPv6 را ترجیح دهید</string>
 
     <string name="title_pref_remote_dns">DNS از راه دور (اختیاری) (udp/tcp/https/quic)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (فقط IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">آیا VPN از شبکه محلی عبور می کند؟</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">DNS داخلی (اختیاری)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS مستقیم هاست (فرمت: دامنه:آدرس،…)</string>
     <string name="summary_pref_dns_hosts">دامنه:آدرس،…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">پورت پروکسی محلی</string>
     <string name="title_pref_enable_local_proxy">فعال‌سازی پروکسی محلی</string>
     <string name="summary_pref_enable_local_proxy">اگر غیرفعال باشد، هیچ پروکسی SOCKS در دسترس نخواهد بود و کارهایی مثل آپدیت اشتراک‌ها نمی‌توانند از پروکسی استفاده کنند.</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">احراز هویت socks5 هنگام استفاده از UDP کاملاً ایمن نیست</string>
     <string name="summary_pref_socks_port">پورت پروکسی محلی</string>
     <string name="title_pref_dynamic_socks_port">تولید پورت متغیر برای پروکسی محلی</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">تنظیمات گروه‌ اشتراک</string>
     <string name="sub_setting_remarks">ملاحظات</string>
     <string name="sub_setting_url">نشانی اینترنتی اختیاری</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">سرآیندهای درخواست (قالب JSON)</string>
     <string name="sub_setting_filter">نام مستعار فیلتر</string>
     <string name="sub_setting_enable">فعال کردن به‌روزرسانی</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">بروزرسانی %1$d کانفیگ انجام شد (%2$d موفق، %3$d شکست خورده، %4$d نادیده گرفته شده)</string>
     <string name="title_update_subscription_no_subscription">هیچ اشتراکی وجود ندارد</string>
     <string name="toast_server_not_found_in_group">سرور انتخاب‌شده در گروه فعلی پیدا نشد</string>
-    <string name="toast_fragment_not_available">صفحهٔ فعلی در دسترس نیست.</string>
     <string name="title_locate_selected_config">یافتن پیکربندی انتخاب‌شده</string>
 
     <string name="tasker_start_service">شروع خدمات</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">انتخاب نام بسته</string>
     <string name="routing_settings_port">پورت</string>
     <string name="routing_settings_protocol">پورتکل</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">شبکه</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">برچسب خروجی</string>
 
     <string name="connection_test_pending">اتصال را بررسی کنید</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">محلی</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -199,7 +199,7 @@
 
     <string name="title_pref_sniffing_enabled">فعال کردن تجزیه و تحلیل بسته ها (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">تلاش برای استخراج نام دامنه واقعی از بسته‌های ترافیک (به‌طور پیش‌فرض روشن است)</string>
-    <string name="title_pref_route_only_enabled">فعال‌سازی فقط مسیر یابی (RouteOnly)</string>
+    <string name="title_pref_route_only_enabled">فعال‌سازی routeOnly</string>
     <string name="summary_pref_route_only_enabled">از نام دامنه (Snnifed) فقط برای مسیریابی استفاده کنید و آدرس مقصد را به عنوان IP ذخیره کنید.</string>
 
     <string name="title_pref_local_dns_enabled">فعال کردن DNS محلی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">رمز عبور (اختیاری)</string>
     <string name="server_lab_security4">نام‌ کاربری (اختیاری)</string>
     <string name="server_lab_encryption">رمزنگاری</string>
-    <string name="server_lab_flow">جریان (flow)</string>
+    <string name="server_lab_flow">حالت جریان (flow)</string>
     <string name="server_lab_public_key">کلید عمومی</string>
     <string name="server_lab_preshared_key">کلید پیش‌اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کوتاه</string>
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">نشانی اینترنتی نامعتبر است</string>
     <string name="toast_insecure_url_protocol">لطفاً از آدرس های اشتراک پروتکل HTTP ناامن استفاده نکنید</string>
     <string name="server_lab_need_inbound">اطمینان حاصل کنید که پورت ورودی با تنظیمات مطابقت دارد</string>
-    <string name="toast_malformed_json">کانفیگ درست نیست</string>
+    <string name="toast_malformed_json">قالب پیکربندی نامعتبر است.</string>
     <string name="server_lab_request_host6">هاست (SNI) (اختیاری)</string>
     <string name="toast_action_not_allowed">این عمل ممنوع است</string>
     <string name="server_obfs_password">رمز عبور obfs</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">فعال‌سازی Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">فقط خروجی‌های xhttp (packet-up) و ws پشتیبانی می‌شوند؛ تنظیمات مرتبط با TLS ممکن است نادیده گرفته شوند یا تداخل داشته باشند</string>
     <string name="toast_allow_insecure_deprecated">گره فعلی از اتصال رمزنگاری‌نشده استفاده می‌کند. زیرساخت‌های واسط شبکه که در کنترل حکومت‌های اقتدارگرا هستند ممکن است ارتباطات شما را مستقیماً مشاهده کنند.\nبه‌دلایل امنیتی، اتصال به چنین گره‌هایی با هسته Xray نسخه 26.2.6 و بالاتر امکان‌پذیر نیست.\nاگر گره را خودتان راه‌اندازی کرده‌اید، رمزنگاری امنی مانند TLS را فعال کنید یا اثر انگشت گواهی pinnedCA256 را پین کنید.\nاگر گره متعلق به ارائه‌دهنده خدمات است، برای ارتقای فنی با آن‌ها تماس بگیرید. اگر ارائه‌دهنده همکاری نمی‌کند، توصیه می‌شود به ارائه‌دهنده‌ای بروید که برای امنیت کاربران اهمیت بیشتری قائل است.\nبرای اطلاعات بیشتر به https://github.com/2dust/v2rayN/discussions/9460 مراجعه کنید</string>
-    <string name="pinned_ca256_action_fetch">دریافت و تکمیل اثر انگشت گواهی</string>
+    <string name="pinned_ca256_action_fetch">دریافت اثر انگشت گواهی</string>
     <string name="toast_fetch_cert_sha256_success">اثر انگشت گواهی با موفقیت دریافت شد</string>
     <string name="toast_fetch_cert_sha256_failed">دریافت اثر انگشت گواهی ناموفق بود</string>
 
@@ -174,9 +174,9 @@
     <string name="summary_pref_is_booted">هنگام راه اندازی به طور خودکار به سرور انتخابی متصل می شود که ممکن است ناموفق باشد.</string>
 
 
-    <string name="subscription_updater_job_tips">وظیفه در پس‌زمینه اجرا می‌شود و اطلاعات پیشرفت در اعلان نمایش داده خواهد شد.</string>
+    <string name="subscription_updater_job_tips">این کار در پس‌زمینه اجرا می‌شود و پیشرفت آن در اعلان نمایش داده خواهد شد.</string>
     <string name="title_pref_auto_test_after_update_subscription">آزمایش خودکار پس از به‌روزرسانی اشتراک</string>
-    <string name="summary_pref_auto_test_after_update_subscription">آزمایش خودکار زمان زیادی می‌برد. در صورت فعال بودن، وظیفه در پس‌زمینه اجرا می‌شود؛ در غیر این صورت در صفحه فعلی اجرا خواهد شد.</string>
+    <string name="summary_pref_auto_test_after_update_subscription">آزمایش خودکار زمان زیادی می‌برد. در صورت فعال بودن، این کار در پس‌زمینه اجرا می‌شود؛ در غیر این صورت در صفحهٔ فعلی اجرا خواهد شد.</string>
     <string name="title_pref_auto_remove_invalid_after_test">حذف خودکار کانفیگ‌های نامعتبر بعد از پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتایج پینگ ممکن است همیشه دقیق نباشند؛ کانفیگ‌های حذف‌شده قابل بازیابی نیستند.</string>
     <string name="title_pref_auto_sort_after_test">مرتب‌سازی خودکار بعد از پینگ گرفتن</string>
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">فعال کردن نمایش سرعت</string>
-    <string name="summary_pref_speed_enabled">نمایش سرعت فعلی در قسمت اعلان. \nآیکون اعلان بر اساس استفاده تغییر می‌کند.</string>
+    <string name="summary_pref_speed_enabled">نمایش سرعت‌های فعلی در اعلان.\nنماد نشان می‌دهد ترافیک پروکسی بیشتر است یا ترافیک مستقیم.</string>
 
-    <string name="title_pref_sniffing_enabled">فعال کردن تجزیه و تحلیل بسته ها (Sniffing)</string>
-    <string name="summary_pref_sniffing_enabled">تلاش برای استخراج نام دامنه واقعی از بسته‌های ترافیک (به‌طور پیش‌فرض روشن است)</string>
+    <string name="title_pref_sniffing_enabled">فعال‌سازی تشخیص دامنهٔ مقصد در ترافیک (Sniffing)</string>
+    <string name="summary_pref_sniffing_enabled">شناسایی دامنه‌های مقصد از ترافیک (به‌طور پیش‌فرض فعال است).</string>
     <string name="title_pref_route_only_enabled">فعال‌سازی routeOnly</string>
     <string name="summary_pref_route_only_enabled">از نام دامنه (Snnifed) فقط برای مسیریابی استفاده کنید و آدرس مقصد را به عنوان IP ذخیره کنید.</string>
 
     <string name="title_pref_local_dns_enabled">فعال کردن DNS محلی</string>
     <string name="summary_pref_local_dns_enabled">درخواست های DNS به هسته وارد شده و توسط ماژول DNS پردازش می شوند (توصیه می شود در صورت نیاز به مسیریابی برای دور زدن آدرس های LAN و سرزمین اصلی فعال شود)</string>
 
-    <string name="title_pref_fake_dns_enabled">فعال کردن DNS جعلی (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">دی ان اس محلی آدرس های آیپی جعلی را بر می گرداند (سریع تر می باشد و تاخیر را کاهش می دهد اما ممکن است برای برخی از برنامه ها کار نکند)</string>
+    <string name="title_pref_fake_dns_enabled">فعال‌سازی DNS مجازی (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">FakeDNS برای نام‌گشایی دامنه‌ها نشانی‌های IP مجازی برمی‌گرداند (سریع‌تر است، اما ممکن است با برخی برنامه‌ها کار نکند).</string>
 
     <string name="title_pref_ipv6_enabled">فعال کردن IPv6</string>
     <string name="summary_pref_ipv6_enabled">آدرس و مسیرهای IPv6 را به رابط VPN اضافه کنید</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">آدرس اینترنتی آزمایش تاخیر واقعی کانفیگ ها </string>
     <string name="summary_pref_delay_test_url">URL</string>
-    <string name="title_pref_real_ping_concurrency">تعداد همزمانی تست تأخیر واقعی</string>
+    <string name="title_pref_real_ping_concurrency">آزمایش‌های هم‌زمان تأخیر واقعی</string>
 
     <string name="title_pref_ip_api_url">تست اطلاعات اتصال فعلی url</string>
     <string name="summary_pref_ip_api_url">URL</string>
@@ -263,13 +263,13 @@
 
 
     <string name="title_pref_append_http_proxy">پروکسی HTTP را به VPN اضافه کنید</string>
-    <string name="summary_pref_append_http_proxy">پروکسی HTTP مستقیماً از (مرورگر/برخی برنامه‌های پشتیبانی‌شده)، بدون استفاده از دستگاه NIC مجازی (Android 10+) استفاده می‌شود.</string>
+    <string name="summary_pref_append_http_proxy">مرورگر و برنامه‌های پشتیبانی‌شده می‌توانند بدون عبور از رابط شبکهٔ مجازی، مستقیماً از پروکسی HTTP استفاده کنند (Android 10+).</string>
 
     <string name="title_pref_double_column_display">فعال کردن نمایش دو ستون</string>
     <string name="summary_pref_double_column_display">فهرست پروفایل‌ها در دو ستون نمایش داده می‌شود تا محتوای بیشتری در صفحه دیده شود.</string>
 
-    <string name="title_pref_group_all_display">نمایش همه گروه‌ها</string>
-    <string name="summary_pref_group_all_display">افزودن یک صفحه «همه زبانه‌ها»</string>
+    <string name="title_pref_group_all_display">نمایش زبانهٔ «همه»</string>
+    <string name="summary_pref_group_all_display">نمایش پروفایل‌های همهٔ گروه‌های اشتراک در یک زبانه.</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">بازخورد</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">فاصله به‌ روزرسانی خودکار ( حداقل مقدار ، 15 دقیقه )</string>
 
     <string name="title_core_loglevel">سطح گزارشات</string>
-    <string name="title_outbound_domain_resolve_method">روش پیش‌تفکیک دامنه خروجی (outbound)</string>
+    <string name="title_outbound_domain_resolve_method">روش نام‌گشایی دامنهٔ خروجی (outbound)</string>
     <string name="title_mode">حالت</string>
     <string name="title_mode_help">برای اطلاعات و راهنمایی بیشتر، روی این متن کلیک کنید</string>
     <string name="title_language">زبان</string>
@@ -302,10 +302,10 @@
     <string name="title_pref_hev_tunnel_rw_timeout">زمان انتظار خواندن/نوشتن Hev Tun (ثانیه) (پیش‌فرض tcp,udp 300،60)</string>
     <string name="title_mode_settings">تنظیمات حالت</string>
     <string name="title_root_mode_enabled">فعال‌سازی حالت Root (کاربران Root)</string>
-    <string name="summary_root_mode_enabled">پروکسی شفاف سطح پایین را با مجوزهای Root فعال می‌کند. این حالت VPN استاندارد سیستم Android را کنار می‌گذارد و مستقیماً همه ترافیک زیرساختی شبکه را در اختیار می‌گیرد. پس از فعال‌سازی، حالت عادی قبلی، مسیریابی جداگانه برنامه‌ها و تنظیمات مرتبط VPN کاملاً بی‌اثر می‌شوند.</string>
+    <string name="summary_root_mode_enabled">برای پروکسی شفاف سطح پایین از دسترسی Root استفاده می‌کند. حالت Root به‌جای سرویس VPN در Android، ترافیک شبکه را مستقیماً مدیریت می‌کند. هنگام فعال بودن این حالت، حالت عادی، مسیریابی جداگانهٔ برنامه‌ها و تنظیمات مرتبط با VPN اعمال نمی‌شوند.</string>
     <string name="toast_root_required">این قابلیت به دسترسی Root نیاز دارد</string>
-    <string name="title_root_lan_sharing">اشتراک‌گذاری LAN / اتصال اینترنت (کاربران Root)</string>
-    <string name="summary_root_lan_sharing">ترافیک دستگاه‌های متصل به نقطه اتصال Wi-Fi و USB را از VPN عبور می‌دهد</string>
+    <string name="title_root_lan_sharing">اشتراک VPN با شبکهٔ محلی / دستگاه‌های متصل (کاربران Root)</string>
+    <string name="summary_root_lan_sharing">ترافیک دستگاه‌های متصل به نقطهٔ اتصال Wi-Fi و USB را از VPN عبور می‌دهد.</string>
 
     <string name="title_logcat">گزارشات</string>
     <string name="logcat_copy">کپی</string>
@@ -345,8 +345,8 @@
     <string name="title_update_subscription_result">بروزرسانی %1$d کانفیگ انجام شد (%2$d موفق، %3$d شکست خورده، %4$d نادیده گرفته شده)</string>
     <string name="title_update_subscription_no_subscription">هیچ اشتراکی وجود ندارد</string>
     <string name="toast_server_not_found_in_group">سرور انتخاب‌شده در گروه فعلی پیدا نشد</string>
-    <string name="toast_fragment_not_available">موقعیت صفحه فعلی پیدا نشد</string>
-    <string name="title_locate_selected_config">پیدا کردن کانفیگ متصل‌شده در لیست</string>
+    <string name="toast_fragment_not_available">صفحهٔ فعلی در دسترس نیست.</string>
+    <string name="title_locate_selected_config">یافتن پیکربندی انتخاب‌شده</string>
 
     <string name="tasker_start_service">شروع خدمات</string>
     <string name="tasker_setting_confirm">تایید</string>
@@ -385,11 +385,11 @@
     <string name="connection_test_error_status_code">کد خطا: #%d</string>
     <string name="connection_connected">متصل است، برای بررسی اتصال ضربه بزنید</string>
     <string name="connection_not_connected">متصل نیست</string>
-    <string name="connection_running_task_left">تعداد وظایف آزمایشی در حال اجرا: %s</string>
+    <string name="connection_running_task_left">آزمایش‌های در حال اجرا: %s</string>
 
     <string name="import_subscription_success">اشتراک با موفقیت ذخیره شد</string>
     <string name="import_subscription_failure">ذخیره اشتراک ناموفق بود</string>
-    <string name="title_fragment_settings">تنظیمات فرگمنت (Fragment)</string>
+    <string name="title_fragment_settings">تنظیمات قطعه‌بندی بسته‌ها (Fragment)</string>
     <string name="title_pref_fragment_packets">بسته های فرگمنت</string>
     <string name="title_pref_fragment_length">طول بسته های فرگمنت (حداقل-حداکثر)</string>
     <string name="title_pref_fragment_interval">فاصله بین بسته های فرگمنت (حداقل-حداکثر)</string>
@@ -413,9 +413,9 @@
 
     <string name="title_policy_group_type">نوع گروه خط مشی</string>
     <string name="title_policy_group_subscription_id">از گروه اشتراک</string>
-    <string name="title_policy_group_subscription_filter">توضیحات فیلتر معمولی</string>
+    <string name="title_policy_group_subscription_filter">فیلتر توضیحات با عبارت منظم</string>
     <string name="title_policy_group_test_outbounds">آزمایش خروجی‌ها (outbounds)</string>
-    <string name="title_policy_group_fallback">خروجی جایگزین (outbound، اختیاری)</string>
+    <string name="title_policy_group_fallback">خروجی پشتیبان (outbound، اختیاری)</string>
 
     <string name="server_proxy_chain_members">اعضای زنجیره پروکسی</string>
     <string name="server_proxy_chain_pick_members">برای انتخاب عضو اینجا بزنید</string>
@@ -476,16 +476,16 @@
     </string-array>
 
     <string-array name="outbound_domain_resolve_method">
-        <item>تفکیک نشود</item>
-        <item>تفکیک و به DNS Hosts افزوده شود</item>
-        <item>تفکیک و جایگزین دامنه شود</item>
+        <item>نام‌گشایی نشود</item>
+        <item>نام‌گشایی و به DNS Hosts افزوده شود</item>
+        <item>نام‌گشایی و جایگزین دامنه شود</item>
     </string-array>
 
     <string-array name="policy_group_type">
         <item>کمترین پینگ (leastPing)</item>
-        <item>کمترین بار(لود) (leastLoad)</item>
+        <item>کمترین بار (leastLoad)</item>
         <item>تصادفی (random)</item>
-        <item>گردشی (roundRobin)</item>
+        <item>چرخشی (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">محلی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -235,7 +235,7 @@
     <string name="summary_pref_delay_test_url">URL</string>
     <string name="title_pref_real_ping_concurrency">آزمایش‌های هم‌زمان تأخیر واقعی</string>
 
-    <string name="title_pref_ip_api_url">تست اطلاعات اتصال فعلی url</string>
+    <string name="title_pref_ip_api_url">تست اطلاعات اتصال فعلی URL</string>
     <string name="summary_pref_ip_api_url">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">اشتراک‌گذاری پروکسی در شبکه محلی (LAN)</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">تعویض</string>
     <string name="app_tile_name">تعویض</string>
     <string name="app_tile_first_use">برای اولین استفاده از این قابلیت، لطفاً ابتدا از داخل برنامه یک سرور اضافه کنید</string>
@@ -29,7 +30,7 @@
     <string name="menu_item_import_config_qrcode">کانفیگ را از QRcode وارد کنید</string>
     <string name="menu_item_import_config_clipboard">کانفیگ را از کلیپ ‌بورد وارد کنید</string>
     <string name="menu_item_import_config_local">کانفیگ را از محلی وارد کنید</string>
-<string name="menu_item_import_config_policy_group">افزودن [گروه خط‌‌ مشی]</string>
+    <string name="menu_item_import_config_policy_group">افزودن [گروه خط‌‌ مشی]</string>
     <string name="menu_item_import_config_proxy_chain">افزودن [زنجیره پروکسی]</string>
     <string name="menu_item_import_config_manually_vmess">افزودن [VMess]</string>
     <string name="menu_item_import_config_manually_vless">افزودن [VLESS]</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">نشانی اینترنتی نامعتبر است</string>
     <string name="toast_insecure_url_protocol">لطفاً از آدرس های اشتراک پروتکل HTTP ناامن استفاده نکنید</string>
     <string name="server_lab_need_inbound">اطمینان حاصل کنید که پورت ورودی با تنظیمات مطابقت دارد</string>
-    <string name="toast_malformed_josn">کانفیگ درست نیست</string>
+    <string name="toast_malformed_json">کانفیگ درست نیست</string>
     <string name="server_lab_request_host6">هاست (SNI) (اختیاری)</string>
     <string name="toast_action_not_allowed">این عمل ممنوع است</string>
     <string name="server_obfs_password">رمز عبور obfs</string>
@@ -127,13 +128,18 @@
     <string name="server_lab_ech_config_list">لیست کانفیگ Ech</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_browser_dialer">فعال‌سازی Browser Dialer</string>
+    <string name="server_lab_browser_dialer_tip">فقط خروجی‌های xhttp (packet-up) و ws پشتیبانی می‌شوند؛ تنظیمات مرتبط با TLS ممکن است نادیده گرفته شوند یا تداخل داشته باشند</string>
+    <string name="toast_allow_insecure_deprecated">گره فعلی از اتصال رمزنگاری‌نشده استفاده می‌کند. زیرساخت‌های واسط شبکه که در کنترل حکومت‌های اقتدارگرا هستند ممکن است ارتباطات شما را مستقیماً مشاهده کنند.\nبه‌دلایل امنیتی، اتصال به چنین گره‌هایی با هسته Xray نسخه 26.2.6 و بالاتر امکان‌پذیر نیست.\nاگر گره را خودتان راه‌اندازی کرده‌اید، رمزنگاری امنی مانند TLS را فعال کنید یا اثر انگشت گواهی pinnedCA256 را پین کنید.\nاگر گره متعلق به ارائه‌دهنده خدمات است، برای ارتقای فنی با آن‌ها تماس بگیرید. اگر ارائه‌دهنده همکاری نمی‌کند، توصیه می‌شود به ارائه‌دهنده‌ای بروید که برای امنیت کاربران اهمیت بیشتری قائل است.\nبرای اطلاعات بیشتر به https://github.com/2dust/v2rayN/discussions/9460 مراجعه کنید</string>
     <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
     <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
     <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">کپی فایل شکست خورد، لطفا از برنامه مدیریت فایل استفاده کنید</string>
+    <string name="menu_item_add_asset">افزودن منبع</string>
     <string name="menu_item_add_file">افزودن فایل ‌ها</string>
+    <string name="menu_item_add_url">افزودن لینک</string>
     <string name="menu_item_scan_qrcode">اسکن QRcode</string>
     <string name="title_url">URL</string>
     <string name="menu_item_download_file">دانلود فایل‌ ها</string>
@@ -155,6 +161,7 @@
     <string name="menu_item_import_proxy_app">وارد کردن از کلیپ‌ بورد</string>
     <string name="per_app_proxy_settings">تنظیمات به تفکیک برنامه</string>
     <string name="per_app_proxy_settings_enable">فعال‌سازی به تفکیک برنامه</string>
+    <string name="app_picker_unknown_app">برنامه ناشناس (UID شناسایی‌نشده)</string>
 
     <!-- Preferences -->
     <string name="title_settings">تنظیمات</string>
@@ -166,6 +173,10 @@
     <string name="title_pref_is_booted">اتصال خودکار هنگام راه اندازی</string>
     <string name="summary_pref_is_booted">هنگام راه اندازی به طور خودکار به سرور انتخابی متصل می شود که ممکن است ناموفق باشد.</string>
 
+
+    <string name="subscription_updater_job_tips">وظیفه در پس‌زمینه اجرا می‌شود و اطلاعات پیشرفت در اعلان نمایش داده خواهد شد.</string>
+    <string name="title_pref_auto_test_after_update_subscription">آزمایش خودکار پس از به‌روزرسانی اشتراک</string>
+    <string name="summary_pref_auto_test_after_update_subscription">آزمایش خودکار زمان زیادی می‌برد. در صورت فعال بودن، وظیفه در پس‌زمینه اجرا می‌شود؛ در غیر این صورت در صفحه فعلی اجرا خواهد شد.</string>
     <string name="title_pref_auto_remove_invalid_after_test">حذف خودکار کانفیگ‌های نامعتبر بعد از پینگ</string>
     <string name="summary_pref_auto_remove_invalid_after_test">نتایج پینگ ممکن است همیشه دقیق نباشند؛ کانفیگ‌های حذف‌شده قابل بازیابی نیستند.</string>
     <string name="title_pref_auto_sort_after_test">مرتب‌سازی خودکار بعد از پینگ گرفتن</string>
@@ -174,8 +185,8 @@
     <string name="title_mux_settings">تنظیمات MUX</string>
     <string name="title_pref_mux_enabled">فعال کردن MUX</string>
     <string name="summary_pref_mux_enabled">سریعتر است، اما ممکن است باعث اتصال ناپایدار شود\nمخزن ترافیک TCP با 8 اتصال پیش‌فرض، نحوه مدیریت UDP و QUIC را در زیر سفارشی کنید.</string>
-    <string name="title_pref_mux_concurency">اتصالات TCP (محدوده -1 تا 1024)</string>
-    <string name="title_pref_mux_xudp_concurency">اتصالات XUDP (محدوده -1 تا 1024)</string>
+    <string name="title_pref_mux_concurrency">اتصالات TCP (محدوده -1 تا 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">اتصالات XUDP (محدوده -1 تا 1024)</string>
     <string name="title_pref_mux_xudp_quic">مدیریت QUIC در تونل MUX</string>
     <string-array name="mux_xudp_quic_entries">
         <item>رد کردن</item>
@@ -190,7 +201,6 @@
     <string name="summary_pref_sniffing_enabled">تلاش برای استخراج نام دامنه واقعی از بسته‌های ترافیک (به‌طور پیش‌فرض روشن است)</string>
     <string name="title_pref_route_only_enabled">فعال‌سازی فقط مسیر یابی (RouteOnly)</string>
     <string name="summary_pref_route_only_enabled">از نام دامنه (Snnifed) فقط برای مسیریابی استفاده کنید و آدرس مقصد را به عنوان IP ذخیره کنید.</string>
-
 
     <string name="title_pref_local_dns_enabled">فعال کردن DNS محلی</string>
     <string name="summary_pref_local_dns_enabled">درخواست های DNS به هسته وارد شده و توسط ماژول DNS پردازش می شوند (توصیه می شود در صورت نیاز به مسیریابی برای دور زدن آدرس های LAN و سرزمین اصلی فعال شود)</string>
@@ -211,7 +221,9 @@
     <string name="title_pref_vpn_bypass_lan">آیا VPN از شبکه محلی عبور می کند؟</string>
 
     <string name="title_pref_vpn_interface_address">آدرس واسط VPN</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+
 
     <string name="title_pref_domestic_dns">DNS داخلی (اختیاری)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
@@ -258,23 +270,25 @@
 
     <string name="title_pref_group_all_display">Enable show all groups</string>
     <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+
     <!-- AboutActivity -->
     <string name="title_pref_feedback">بازخورد</string>
     <string name="summary_pref_feedback">بازخورد یا گزارش اشکالات در گیت‌ هاب</string>
     <string name="summary_pref_tg_group">عضویت در گروه تلگرام</string>
     <string name="toast_tg_app_not_found">برنامه تلگرام پیدا نشد</string>
-
     <string name="title_privacy_policy">حریم خصوصی</string>
     <string name="title_qr_code">QR code</string>
     <string name="title_about">درباره</string>
     <string name="title_source_code">کد منبع</string>
     <string name="title_oss_license">مجوز های منبع باز</string>
     <string name="title_tg_channel">کانال تلگرام</string>
+
     <string name="title_pref_promotion">تبلیغات</string>
 
     <string name="title_pref_auto_update_subscription">به‌ روزرسانی خودکار اشتراک ها</string>
     <string name="summary_pref_auto_update_subscription">اشتراک های خود را به طور خودکار با فاصله زمانی در پس زمینه به روز کنید. بسته به دستگاه، این ویژگی ممکن است همیشه کار نکند.</string>
     <string name="title_pref_auto_update_interval">فاصله به‌ روزرسانی خودکار ( حداقل مقدار ، 15 دقیقه )</string>
+
     <string name="title_core_loglevel">سطح گزارشات</string>
     <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
     <string name="title_mode">حالت</string>
@@ -286,6 +300,12 @@
     <string name="summary_pref_use_hev_tunnel">اگر فعال باشد، تونل VPN از hev-socks5-tunnel استفاده می‌کند؛ در غیر این صورت از xray-core استفاده خواهد شد.</string>
     <string name="title_pref_hev_tunnel_loglevel">سطح گزارشات Hev Tun</string>
     <string name="title_pref_hev_tunnel_rw_timeout">زمان انتظار خواندن/نوشتن Hev Tun (ثانیه) (پیش‌فرض tcp,udp 300،60)</string>
+    <string name="title_mode_settings">تنظیمات حالت</string>
+    <string name="title_root_mode_enabled">فعال‌سازی حالت Root (کاربران Root)</string>
+    <string name="summary_root_mode_enabled">پروکسی شفاف سطح پایین را با مجوزهای Root فعال می‌کند. این حالت VPN استاندارد سیستم Android را کنار می‌گذارد و مستقیماً همه ترافیک زیرساختی شبکه را در اختیار می‌گیرد. پس از فعال‌سازی، حالت عادی قبلی، مسیریابی جداگانه برنامه‌ها و تنظیمات مرتبط VPN کاملاً بی‌اثر می‌شوند.</string>
+    <string name="toast_root_required">این قابلیت به دسترسی Root نیاز دارد</string>
+    <string name="title_root_lan_sharing">اشتراک‌گذاری LAN / اتصال اینترنت (کاربران Root)</string>
+    <string name="summary_root_lan_sharing">ترافیک دستگاه‌های متصل به نقطه اتصال Wi-Fi و USB را از VPN عبور می‌دهد</string>
 
     <string name="title_logcat">گزارشات</string>
     <string name="logcat_copy">کپی</string>
@@ -300,6 +320,7 @@
     <string name="sub_setting_remarks">ملاحظات</string>
     <string name="sub_setting_url">نشانی اینترنتی اختیاری</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_request_headers">سرآیندهای درخواست (قالب JSON)</string>
     <string name="sub_setting_filter">نام مستعار فیلتر</string>
     <string name="sub_setting_enable">فعال کردن به‌روزرسانی</string>
     <string name="sub_auto_update">فعال سازی به‌روزرسانی خودکار</string>
@@ -315,9 +336,8 @@
     <string name="title_sort_by_test_results">مرتب‌ سازی بر اساس نتایج آزمایش</string>
     <string name="title_filter_config">فیلتر کردن کانفیگ‌ها</string>
     <string name="filter_config_all">همه</string>
-    <string name="title_del_duplicate_config_count">حذف %d کانفیگ تکراری</string>
     <string name="summary_scan_qrcode">Click screen open the camera scan</string>
-
+    <string name="title_del_duplicate_config_count">حذف %d کانفیگ تکراری</string>
     <string name="title_del_config_count">حذف %d کانفیگ</string>
     <string name="title_import_config_count">وارد کردن %d کانفیگ</string>
     <string name="title_export_config_count">صادر کردن %d کانفیگ</string>
@@ -347,10 +367,13 @@
     <string name="routing_settings_locked">قفل است، این قانون را هنگام وارد کردن از پیش تنظیم‌ ها حفظ کنید</string>
     <string name="routing_settings_domain">دامنه</string>
     <string name="routing_settings_ip">آیپی</string>
+    <string name="routing_settings_process">process (نام بسته — فقط هنگام استفاده از Xray TUN، فعال بودن routeOnly و Android 10+ پشتیبانی می‌شود)</string>
+    <string name="routing_settings_process_select">انتخاب نام بسته</string>
     <string name="routing_settings_port">پورت</string>
     <string name="routing_settings_protocol">پورتکل</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">شبکه</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">برچسب خروجی</string>
 
     <string name="connection_test_pending">اتصال را بررسی کنید</string>
@@ -362,7 +385,7 @@
     <string name="connection_test_error_status_code">کد خطا: #%d</string>
     <string name="connection_connected">متصل است، برای بررسی اتصال ضربه بزنید</string>
     <string name="connection_not_connected">متصل نیست</string>
-    <string name="connection_runing_task_left">تعداد وظایف آزمایشی در حال اجرا: %s</string>
+    <string name="connection_running_task_left">تعداد وظایف آزمایشی در حال اجرا: %s</string>
 
     <string name="import_subscription_success">اشتراک با موفقیت ذخیره شد</string>
     <string name="import_subscription_failure">ذخیره اشتراک ناموفق بود</string>
@@ -393,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">توضیحات فیلتر معمولی</string>
     <string name="title_policy_group_test_outbounds">آزمایش خروجی‌ها</string>
     <string name="title_policy_group_fallback">خروجی جایگزین (اختیاری)</string>
+
     <string name="server_proxy_chain_members">اعضای زنجیره پروکسی</string>
     <string name="server_proxy_chain_pick_members">برای انتخاب عضو اینجا بزنید</string>
     <string name="server_proxy_chain_member_unselected">یک عضو را انتخاب کنید</string>
@@ -426,8 +450,12 @@
         <item>VPN</item>
         <item>فقط پروکسی</item>
     </string-array>
-    <string name="menu_item_add_asset">افزودن منبع</string>
-    <string name="menu_item_add_url">افزودن لینک</string>
+
+    <string-array name="browser_dialer_mode">
+        <item>غیرفعال</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
+    </string-array>
 
     <string-array name="ui_mode_night">
         <item>پیش فرض سیستم</item>
@@ -452,6 +480,7 @@
         <item>Resolve and add to DNS Hosts</item>
         <item>Resolve and replace domain</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>کمترین پینگ</item>
         <item>کمترین بار(لود)</item>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">مسیر QUIC</string>
     <string name="server_lab_path_kcp">KCP سید</string>
     <string name="server_lab_path_grpc">gRPC نام سرویس</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">اثرانگشت</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">نادیده گرفتن تأیید گواهی (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">نشانی</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">کلید پیش‌اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کوتاه</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">تاییدیه Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">کلید خصوصی</string>
     <string name="server_lab_reserved">Reserved (اختیاری، جدا شده با کاما)</string>
     <string name="server_lab_local_address">آدرس محلی (IPv4/IPv6 اختیاری، جدا شده با کاما)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">حالت XHTTP</string>
     <string name="server_lab_xhttp_extra">خام JSON XHTTP Extra، قالب: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">لیست کانفیگ Ech</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">تأیید گواهی همتا بر اساس نام</string>
     <string name="server_lab_pinned_ca256">اثر انگشت گواهی (SHA-256)</string>
     <string name="server_lab_browser_dialer">فعال‌سازی Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">افزودن فایل ‌ها</string>
     <string name="menu_item_add_url">افزودن لینک</string>
     <string name="menu_item_scan_qrcode">اسکن QRcode</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">دانلود فایل‌ ها</string>
     <string name="title_user_asset_add_url">آدرس اینترنتی را اضافه کنید</string>
     <string name="msg_file_not_found">فایل پیدا نشد</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">دامنه:آدرس،…</string>
 
     <string name="title_pref_delay_test_url">آدرس اینترنتی آزمایش تاخیر واقعی کانفیگ ها </string>
-    <string name="summary_pref_delay_test_url">URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">آزمایش‌های هم‌زمان تأخیر واقعی</string>
 
     <string name="title_pref_ip_api_url">تست اطلاعات اتصال فعلی URL</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">اشتراک‌گذاری پروکسی در شبکه محلی (LAN)</string>
     <string name="summary_pref_proxy_sharing_enabled">دستگاه‌های دیگر می‌توانند با وارد کردن IP شما، از پروکسی‌تان استفاده کنند. برای جلوگیری از سوءاستفاده، فقط در شبکه‌های امن و قابل اعتماد این گزینه را روشن کنید.</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">اشتراک VPN با شبکهٔ محلی / دستگاه‌های متصل (کاربران Root)</string>
     <string name="summary_root_lan_sharing">ترافیک دستگاه‌های متصل به نقطهٔ اتصال Wi-Fi و USB را از VPN عبور می‌دهد.</string>
 
-    <string name="title_logcat">گزارشات</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">کپی</string>
     <string name="logcat_clear">پاک کردن</string>
     <string name="logcat_share">اشتراک‌گذاری گزارش</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">وارد کردن مجموعه قوانین از QRcode</string>
     <string name="routing_settings_export_rulesets_to_clipboard">صادر کردن مجموعه قوانین به کلیپ بورد</string>
     <string name="routing_settings_locked">قفل است، این قانون را هنگام وارد کردن از پیش تنظیم‌ ها حفظ کنید</string>
-    <string name="routing_settings_domain">دامنه</string>
-    <string name="routing_settings_ip">آیپی</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (نام بسته — فقط هنگام استفاده از Xray TUN، فعال بودن routeOnly و Android 10+ پشتیبانی می‌شود)</string>
     <string name="routing_settings_process_select">انتخاب نام بسته</string>
-    <string name="routing_settings_port">پورت</string>
-    <string name="routing_settings_protocol">پورتکل</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">شبکه</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">برچسب خروجی</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">اتصال را بررسی کنید</string>
     <string name="connection_test_testing">در حال آزمایش...</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">اثرانگشت</string>
     <string name="server_lab_stream_alpn">Alpn</string>
-    <string name="server_lab_allow_insecure">مجوز SSL ناامن</string>
+    <string name="server_lab_allow_insecure">نادیده گرفتن تأیید گواهی (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">نشانی</string>
     <string name="server_lab_port3">پورت</string>
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">رمز عبور (اختیاری)</string>
     <string name="server_lab_security4">نام‌ کاربری (اختیاری)</string>
     <string name="server_lab_encryption">رمزنگاری</string>
-    <string name="server_lab_flow">جریان</string>
+    <string name="server_lab_flow">جریان (flow)</string>
     <string name="server_lab_public_key">کلید عمومی</string>
     <string name="server_lab_preshared_key">کلید پیش‌اشتراکی (اختیاری)</string>
     <string name="server_lab_short_id">شناسه کوتاه</string>
@@ -182,8 +182,8 @@
     <string name="title_pref_auto_sort_after_test">مرتب‌سازی خودکار بعد از پینگ گرفتن</string>
     <string name="summary_pref_auto_sort_after_test">نتایج آزمایش ممکن است کاملاً دقیق نباشند.</string>
 
-    <string name="title_mux_settings">تنظیمات MUX</string>
-    <string name="title_pref_mux_enabled">فعال کردن MUX</string>
+    <string name="title_mux_settings">تنظیمات Mux</string>
+    <string name="title_pref_mux_enabled">فعال کردن Mux</string>
     <string name="summary_pref_mux_enabled">سریعتر است، اما ممکن است باعث اتصال ناپایدار شود\nمخزن ترافیک TCP با 8 اتصال پیش‌فرض، نحوه مدیریت UDP و QUIC را در زیر سفارشی کنید.</string>
     <string name="title_pref_mux_concurrency">اتصالات TCP (محدوده -1 تا 1024)</string>
     <string name="title_pref_mux_xudp_concurrency">اتصالات XUDP (محدوده -1 تا 1024)</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">فعال کردن DNS محلی</string>
     <string name="summary_pref_local_dns_enabled">درخواست های DNS به هسته وارد شده و توسط ماژول DNS پردازش می شوند (توصیه می شود در صورت نیاز به مسیریابی برای دور زدن آدرس های LAN و سرزمین اصلی فعال شود)</string>
 
-    <string name="title_pref_fake_dns_enabled">فعال کردن DNS جعلی</string>
+    <string name="title_pref_fake_dns_enabled">فعال کردن DNS جعلی (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">دی ان اس محلی آدرس های آیپی جعلی را بر می گرداند (سریع تر می باشد و تاخیر را کاهش می دهد اما ممکن است برای برخی از برنامه ها کار نکند)</string>
 
     <string name="title_pref_ipv6_enabled">فعال کردن IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">فاصله به‌ روزرسانی خودکار ( حداقل مقدار ، 15 دقیقه )</string>
 
     <string name="title_core_loglevel">سطح گزارشات</string>
-    <string name="title_outbound_domain_resolve_method">روش پیش‌تفکیک دامنه outbound</string>
+    <string name="title_outbound_domain_resolve_method">روش پیش‌تفکیک دامنه خروجی (outbound)</string>
     <string name="title_mode">حالت</string>
     <string name="title_mode_help">برای اطلاعات و راهنمایی بیشتر، روی این متن کلیک کنید</string>
     <string name="title_language">زبان</string>
@@ -389,13 +389,13 @@
 
     <string name="import_subscription_success">اشتراک با موفقیت ذخیره شد</string>
     <string name="import_subscription_failure">ذخیره اشتراک ناموفق بود</string>
-    <string name="title_fragment_settings">تنظیمات فرگمنت</string>
+    <string name="title_fragment_settings">تنظیمات فرگمنت (Fragment)</string>
     <string name="title_pref_fragment_packets">بسته های فرگمنت</string>
     <string name="title_pref_fragment_length">طول بسته های فرگمنت (حداقل-حداکثر)</string>
     <string name="title_pref_fragment_interval">فاصله بین بسته های فرگمنت (حداقل-حداکثر)</string>
     <string name="title_pref_fragment_enabled">فعال کردن فرگمنت</string>
     <string name="title_pref_fragment_maxsplit">حداکثر تقسیم فرگمنت</string>
-    <string name="title_observatory_settings">تنظیمات پایش اتصال</string>
+    <string name="title_observatory_settings">تنظیمات پایش اتصال (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">فاصله leastPing</string>
     <string name="title_pref_observatory_least_load_interval">فاصله leastLoad</string>
     <string name="title_pref_observatory_least_load_method">روش HTTP برای leastLoad</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">نوع گروه خط مشی</string>
     <string name="title_policy_group_subscription_id">از گروه اشتراک</string>
     <string name="title_policy_group_subscription_filter">توضیحات فیلتر معمولی</string>
-    <string name="title_policy_group_test_outbounds">آزمایش خروجی‌ها</string>
-    <string name="title_policy_group_fallback">خروجی جایگزین (اختیاری)</string>
+    <string name="title_policy_group_test_outbounds">آزمایش خروجی‌ها (outbounds)</string>
+    <string name="title_policy_group_fallback">خروجی جایگزین (outbound، اختیاری)</string>
 
     <string name="server_proxy_chain_members">اعضای زنجیره پروکسی</string>
     <string name="server_proxy_chain_pick_members">برای انتخاب عضو اینجا بزنید</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>کمترین پینگ</item>
-        <item>کمترین بار(لود)</item>
-        <item>تصادفی</item>
-        <item>گردشی</item>
+        <item>کمترین پینگ (leastPing)</item>
+        <item>کمترین بار(لود) (leastLoad)</item>
+        <item>تصادفی (random)</item>
+        <item>گردشی (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">محلی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -126,14 +126,14 @@
     <string name="server_lab_xhttp_extra">خام JSON XHTTP Extra، قالب: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">لیست کانفیگ Ech</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
-    <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_verify_peer_cert_by_name">تأیید گواهی همتا بر اساس نام</string>
+    <string name="server_lab_pinned_ca256">اثر انگشت گواهی (SHA-256)</string>
     <string name="server_lab_browser_dialer">فعال‌سازی Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">فقط خروجی‌های xhttp (packet-up) و ws پشتیبانی می‌شوند؛ تنظیمات مرتبط با TLS ممکن است نادیده گرفته شوند یا تداخل داشته باشند</string>
     <string name="toast_allow_insecure_deprecated">گره فعلی از اتصال رمزنگاری‌نشده استفاده می‌کند. زیرساخت‌های واسط شبکه که در کنترل حکومت‌های اقتدارگرا هستند ممکن است ارتباطات شما را مستقیماً مشاهده کنند.\nبه‌دلایل امنیتی، اتصال به چنین گره‌هایی با هسته Xray نسخه 26.2.6 و بالاتر امکان‌پذیر نیست.\nاگر گره را خودتان راه‌اندازی کرده‌اید، رمزنگاری امنی مانند TLS را فعال کنید یا اثر انگشت گواهی pinnedCA256 را پین کنید.\nاگر گره متعلق به ارائه‌دهنده خدمات است، برای ارتقای فنی با آن‌ها تماس بگیرید. اگر ارائه‌دهنده همکاری نمی‌کند، توصیه می‌شود به ارائه‌دهنده‌ای بروید که برای امنیت کاربران اهمیت بیشتری قائل است.\nبرای اطلاعات بیشتر به https://github.com/2dust/v2rayN/discussions/9460 مراجعه کنید</string>
-    <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
-    <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
-    <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
+    <string name="pinned_ca256_action_fetch">دریافت و تکمیل اثر انگشت گواهی</string>
+    <string name="toast_fetch_cert_sha256_success">اثر انگشت گواهی با موفقیت دریافت شد</string>
+    <string name="toast_fetch_cert_sha256_failed">دریافت اثر انگشت گواهی ناموفق بود</string>
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">کپی فایل شکست خورد، لطفا از برنامه مدیریت فایل استفاده کنید</string>
@@ -222,7 +222,7 @@
 
     <string name="title_pref_vpn_interface_address">آدرس واسط VPN</string>
 
-    <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+    <string name="title_pref_vpn_mtu">VPN MTU (پیش‌فرض 1500)</string>
 
 
     <string name="title_pref_domestic_dns">DNS داخلی (اختیاری)</string>
@@ -236,7 +236,7 @@
     <string name="title_pref_real_ping_concurrency">تعداد همزمانی تست تأخیر واقعی</string>
 
     <string name="title_pref_ip_api_url">تست اطلاعات اتصال فعلی url</string>
-    <string name="summary_pref_ip_api_url">Url</string>
+    <string name="summary_pref_ip_api_url">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">اشتراک‌گذاری پروکسی در شبکه محلی (LAN)</string>
     <string name="summary_pref_proxy_sharing_enabled">دستگاه‌های دیگر می‌توانند با وارد کردن IP شما، از پروکسی‌تان استفاده کنند. برای جلوگیری از سوءاستفاده، فقط در شبکه‌های امن و قابل اعتماد این گزینه را روشن کنید.</string>
@@ -266,10 +266,10 @@
     <string name="summary_pref_append_http_proxy">پروکسی HTTP مستقیماً از (مرورگر/برخی برنامه‌های پشتیبانی‌شده)، بدون استفاده از دستگاه NIC مجازی (Android 10+) استفاده می‌شود.</string>
 
     <string name="title_pref_double_column_display">فعال کردن نمایش دو ستون</string>
-    <string name="summary_pref_double_column_display">The profile list is displayed in double columns, allowing more content to be displayed on the screen.</string>
+    <string name="summary_pref_double_column_display">فهرست پروفایل‌ها در دو ستون نمایش داده می‌شود تا محتوای بیشتری در صفحه دیده شود.</string>
 
-    <string name="title_pref_group_all_display">Enable show all groups</string>
-    <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+    <string name="title_pref_group_all_display">نمایش همه گروه‌ها</string>
+    <string name="summary_pref_group_all_display">افزودن یک صفحه «همه زبانه‌ها»</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">بازخورد</string>
@@ -277,7 +277,7 @@
     <string name="summary_pref_tg_group">عضویت در گروه تلگرام</string>
     <string name="toast_tg_app_not_found">برنامه تلگرام پیدا نشد</string>
     <string name="title_privacy_policy">حریم خصوصی</string>
-    <string name="title_qr_code">QR code</string>
+    <string name="title_qr_code">کد QR</string>
     <string name="title_about">درباره</string>
     <string name="title_source_code">کد منبع</string>
     <string name="title_oss_license">مجوز های منبع باز</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">فاصله به‌ روزرسانی خودکار ( حداقل مقدار ، 15 دقیقه )</string>
 
     <string name="title_core_loglevel">سطح گزارشات</string>
-    <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
+    <string name="title_outbound_domain_resolve_method">روش پیش‌تفکیک دامنه outbound</string>
     <string name="title_mode">حالت</string>
     <string name="title_mode_help">برای اطلاعات و راهنمایی بیشتر، روی این متن کلیک کنید</string>
     <string name="title_language">زبان</string>
@@ -336,7 +336,7 @@
     <string name="title_sort_by_test_results">مرتب‌ سازی بر اساس نتایج آزمایش</string>
     <string name="title_filter_config">فیلتر کردن کانفیگ‌ها</string>
     <string name="filter_config_all">همه</string>
-    <string name="summary_scan_qrcode">Click screen open the camera scan</string>
+    <string name="summary_scan_qrcode">برای باز کردن دوربین و اسکن، روی صفحه بزنید</string>
     <string name="title_del_duplicate_config_count">حذف %d کانفیگ تکراری</string>
     <string name="title_del_config_count">حذف %d کانفیگ</string>
     <string name="title_import_config_count">وارد کردن %d کانفیگ</string>
@@ -476,9 +476,9 @@
     </string-array>
 
     <string-array name="outbound_domain_resolve_method">
-        <item>Do not resolve</item>
-        <item>Resolve and add to DNS Hosts</item>
-        <item>Resolve and replace domain</item>
+        <item>تفکیک نشود</item>
+        <item>تفکیک و به DNS Hosts افزوده شود</item>
+        <item>تفکیک و جایگزین دامنه شود</item>
     </string-array>
 
     <string-array name="policy_group_type">

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">Отпечаток</string>
     <string name="server_lab_stream_alpn">ALPN</string>
     <string name="server_lab_allow_insecure">Пропускать проверку сертификата (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">Адрес</string>
     <string name="server_lab_port3">Порт</string>
     <string name="server_lab_id3">Пароль</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">Открытый ключ</string>
     <string name="server_lab_preshared_key">Дополнительный ключ шифрования (необязательно)</string>
     <string name="server_lab_short_id">ShortID</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">mldsa65Verify</string>
     <string name="server_lab_secret_key">Закрытый ключ</string>
     <string name="server_lab_reserved">Reserved (необязательно, через запятую)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">Предпочитать IPv6-адреса при определении доменных имён</string>
 
     <string name="title_pref_remote_dns">Удалённая DNS (UDP/TCP/HTTPS/QUIC) (необязательно)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (только IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">VPN обходит LAN</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">Внутренняя DNS (необязательно)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">Узлы DNS (формат: домен:адрес,…)</string>
     <string name="summary_pref_dns_hosts">домен:адрес,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">Порт локального прокси</string>
     <string name="title_pref_enable_local_proxy">Использовать локальный прокси</string>
     <string name="summary_pref_enable_local_proxy">Если отключено, SOCKS-прокси недоступен, поэтому обновления подписки и подобные действия не смогут использовать прокси</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">Аутентификация SOCKS5 не полностью безопасна при использовании UDP</string>
     <string name="summary_pref_socks_port">Порт локального прокси</string>
     <string name="title_pref_dynamic_socks_port">Динамически менять порт локального прокси</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">Группы</string>
     <string name="sub_setting_remarks">Название</string>
     <string name="sub_setting_url">URL (необязательно)</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">Заголовки запроса (формат JSON)</string>
     <string name="sub_setting_filter">Название фильтра</string>
     <string name="sub_setting_enable">Использовать обновление</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">Обновлено профилей: %1$d (успешно: %2$d, ошибки: %3$d, пропущено: %4$d)</string>
     <string name="title_update_subscription_no_subscription">Нет подписок</string>
     <string name="toast_server_not_found_in_group">Выбранный профиль не найден в текущей группе</string>
-    <string name="toast_fragment_not_available">Текущий экран недоступен.</string>
     <string name="title_locate_selected_config">Найти выбранный профиль</string>
 
     <string name="tasker_start_service">Запуск службы</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">Выбор названия пакета</string>
     <string name="routing_settings_port">Порт</string>
     <string name="routing_settings_protocol">Протокол</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">Сеть</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">Исходящее соединение</string>
 
     <string name="connection_test_pending">Проверить соединение</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">Локально</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">Пароль (необязательно)</string>
     <string name="server_lab_security4">Пользователь (необязательно)</string>
     <string name="server_lab_encryption">Шифрование</string>
-    <string name="server_lab_flow">Поток (flow)</string>
+    <string name="server_lab_flow">Режим потока (flow)</string>
     <string name="server_lab_public_key">Открытый ключ</string>
     <string name="server_lab_preshared_key">Дополнительный ключ шифрования (необязательно)</string>
     <string name="server_lab_short_id">ShortID</string>
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">Неправильный URL</string>
     <string name="toast_insecure_url_protocol">Не используйте небезопасный HTTP-протокол в адресе подписки</string>
     <string name="server_lab_need_inbound">Убедитесь, что входящий порт соответствует настройкам</string>
-    <string name="toast_malformed_json">Профиль повреждён</string>
+    <string name="toast_malformed_json">Некорректная конфигурация.</string>
     <string name="server_lab_request_host6">Узел (SNI) (необязательно)</string>
     <string name="toast_action_not_allowed">Это действие запрещено</string>
     <string name="server_obfs_password">Пароль obfs</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">Включить Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">Поддерживаются только исходящие соединения XHTTP (packet-up) и WS; настройки, связанные с TLS, могут быть проигнорированы или конфликтовать</string>
     <string name="toast_allow_insecure_deprecated">Этот узел использует незашифрованное соединение. Ваши данные могут быть перехвачены и просмотрены государственными структурами через промежуточное сетевое оборудование.\nВ целях безопасности такие узлы больше не поддерживаются ядром Xray версии 26.2.6+.\nДля исправления: включите TLS (или другое шифрование) на своём сервере или используйте отпечаток сертификата (pinnedCA256).\nЕсли вы используете платный сервис, обратитесь в поддержку для обновления. Если провайдер отказывается, рекомендуется сменить его на более безопасный.\nПодробнее: https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">Получить и заполнить отпечаток сертификата</string>
+    <string name="pinned_ca256_action_fetch">Получить отпечаток сертификата</string>
     <string name="toast_fetch_cert_sha256_success">Отпечаток сертификата успешно получен</string>
     <string name="toast_fetch_cert_sha256_failed">Отпечаток сертификата не получен</string>
 
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">Показывать скорость</string>
-    <string name="summary_pref_speed_enabled">Показывать текущую скорость в уведомлении.\nЗначок будет меняться в зависимости от использования.</string>
+    <string name="summary_pref_speed_enabled">Показывать текущую скорость в уведомлении.\nЗначок указывает, какой трафик преобладает: через прокси или напрямую.</string>
 
-    <string name="title_pref_sniffing_enabled">Анализировать пакеты (Sniffing)</string>
-    <string name="summary_pref_sniffing_enabled">Пытаться определять доменные имена в пакетах (по умолчанию включено)</string>
+    <string name="title_pref_sniffing_enabled">Определять домены в трафике (Sniffing)</string>
+    <string name="summary_pref_sniffing_enabled">Определять домены назначения в трафике (по умолчанию включено).</string>
     <string name="title_pref_route_only_enabled">Включить routeOnly</string>
     <string name="summary_pref_route_only_enabled">Использовать доменное имя только для маршрутизации и сохранять целевой адрес в виде IP.</string>
 
     <string name="title_pref_local_dns_enabled">Использовать локальную DNS</string>
     <string name="summary_pref_local_dns_enabled">Обслуживание выполняется DNS-модулем ядра (в настройках маршрутизации рекомендуется выбрать режим «Все, кроме LAN и Китая»)</string>
 
-    <string name="title_pref_fake_dns_enabled">Использовать поддельную DNS (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">Локальная DNS возвращает поддельные IP-адреса (быстрее, но может не работать с некоторыми приложениями)</string>
+    <string name="title_pref_fake_dns_enabled">Использовать виртуальный DNS (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">FakeDNS возвращает виртуальные IP-адреса при разрешении доменов (быстрее, но может не работать с некоторыми приложениями).</string>
 
     <string name="title_pref_ipv6_enabled">Включить IPv6</string>
     <string name="summary_pref_ipv6_enabled">Добавить IPv6-адрес и маршруты в VPN-интерфейс</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">Обязательное подтверждение удаления профиля</string>
 
 
-    <string name="title_pref_append_http_proxy">Дополнительный HTTP-прокси</string>
-    <string name="summary_pref_append_http_proxy">HTTP-прокси будет использоваться напрямую (из браузера и других поддерживающих приложений), минуя виртуальный сетевой адаптер (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">Добавить HTTP-прокси в VPN</string>
+    <string name="summary_pref_append_http_proxy">Браузеры и поддерживаемые приложения смогут использовать HTTP-прокси напрямую, минуя виртуальный сетевой адаптер (Android 10+).</string>
 
     <string name="title_pref_double_column_display">Профили в два столбца</string>
     <string name="summary_pref_double_column_display">Список профилей отображается двумя столбцами, что позволяет показать больше информации на экране.</string>
 
-    <string name="title_pref_group_all_display">Общая вкладка групп</string>
-    <string name="summary_pref_group_all_display">Показывать дополнительную вкладку со всеми профилями групп</string>
+    <string name="title_pref_group_all_display">Показывать вкладку «Все»</string>
+    <string name="summary_pref_group_all_display">Объединять профили из всех групп подписок на одной вкладке.</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">Обратная связь</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">Интервал автообновления (минут, не менее 15)</string>
 
     <string name="title_core_loglevel">Подробность ведения журнала</string>
-    <string name="title_outbound_domain_resolve_method">Предварительное разрешение исходящего домена (outbound)</string>
+    <string name="title_outbound_domain_resolve_method">Разрешение доменов исходящих подключений (outbound)</string>
     <string name="title_mode">Режим</string>
     <string name="title_mode_help">Нажмите для получения дополнительной информации</string>
     <string name="title_language">Язык</string>
@@ -302,10 +302,10 @@
     <string name="title_pref_hev_tunnel_rw_timeout">Ожидание чтения/записи HevTun (секунд, по умолчанию TCP,UDP 300,60)</string>
     <string name="title_mode_settings">Настройки режима</string>
     <string name="title_root_mode_enabled">Использовать root-режим</string>
-    <string name="summary_root_mode_enabled">Низкоуровневое прозрачное проксирование с помощью привилегий root. Этот режим обходит стандартный VPN системы Android, чтобы напрямую управлять всем сетевым трафиком. После включения первоначальный обычный режим, маршрутизация отдельных приложений и связанные с ними настройки VPN станут полностью недействительными.</string>
+    <string name="summary_root_mode_enabled">Использовать root-доступ для низкоуровневого прозрачного проксирования. Root-режим управляет сетевым трафиком напрямую вместо службы VPN Android. Пока он включён, обычный режим, маршрутизация отдельных приложений и связанные настройки VPN не действуют.</string>
     <string name="toast_root_required">Для этой функции требуется доступ с правами root</string>
-    <string name="title_root_lan_sharing">Совместное использование LAN/точки доступа (root)</string>
-    <string name="summary_root_lan_sharing">Маршрутизация точек доступа Wi-Fi и устройств, подключённых к USB, через VPN</string>
+    <string name="title_root_lan_sharing">Доступ к VPN для устройств LAN/точки доступа (root)</string>
+    <string name="summary_root_lan_sharing">Направлять через VPN трафик устройств, подключённых к точке доступа Wi-Fi или по USB.</string>
 
     <string name="title_logcat">Журнал</string>
     <string name="logcat_copy">Копировать</string>
@@ -345,7 +345,7 @@
     <string name="title_update_subscription_result">Обновлено профилей: %1$d (успешно: %2$d, ошибки: %3$d, пропущено: %4$d)</string>
     <string name="title_update_subscription_no_subscription">Нет подписок</string>
     <string name="toast_server_not_found_in_group">Выбранный профиль не найден в текущей группе</string>
-    <string name="toast_fragment_not_available">Фрагмент недоступен</string>
+    <string name="toast_fragment_not_available">Текущий экран недоступен.</string>
     <string name="title_locate_selected_config">Найти выбранный профиль</string>
 
     <string name="tasker_start_service">Запуск службы</string>
@@ -395,7 +395,7 @@
     <string name="title_pref_fragment_interval">Интервал фрагментов (от — до)</string>
     <string name="title_pref_fragment_enabled">Использовать фрагментирование</string>
     <string name="title_pref_fragment_maxsplit">Максимальное число фрагментов</string>
-    <string name="title_observatory_settings">Настройки наблюдения соединений (Observatory)</string>
+    <string name="title_observatory_settings">Настройки мониторинга соединений (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">Интервал leastPing</string>
     <string name="title_pref_observatory_least_load_interval">Интервал leastLoad</string>
     <string name="title_pref_observatory_least_load_method">HTTP-метод leastLoad</string>
@@ -413,9 +413,9 @@
 
     <string name="title_policy_group_type">Тип политики группы</string>
     <string name="title_policy_group_subscription_id">Из группы подписки</string>
-    <string name="title_policy_group_subscription_filter">Название фильтра</string>
-    <string name="title_policy_group_test_outbounds">Проверять исходящие соединения (outbounds)</string>
-    <string name="title_policy_group_fallback">Резервное исходящее соединение (outbound, необязательно)</string>
+    <string name="title_policy_group_subscription_filter">Фильтр примечаний (регулярное выражение)</string>
+    <string name="title_policy_group_test_outbounds">Тестировать исходящие подключения (outbounds)</string>
+    <string name="title_policy_group_fallback">Резервное исходящее подключение (outbound, необязательно)</string>
 
     <string name="server_proxy_chain_members">Участники цепочки прокси</string>
     <string name="server_proxy_chain_pick_members">Нажмите здесь, чтобы выбрать участника</string>
@@ -484,8 +484,8 @@
     <string-array name="policy_group_type">
         <item>Наименьшая задержка (leastPing)</item>
         <item>Наименьшая нагрузка (leastLoad)</item>
-        <item>Случайно (random)</item>
-        <item>По очереди (roundRobin)</item>
+        <item>Случайный выбор (random)</item>
+        <item>Циклический выбор (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">Локально</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -199,7 +199,7 @@
 
     <string name="title_pref_sniffing_enabled">Анализировать пакеты</string>
     <string name="summary_pref_sniffing_enabled">Пытаться определять доменные имена в пакетах (по умолчанию включено)</string>
-    <string name="title_pref_route_only_enabled">Домен только для маршрутизации</string>
+    <string name="title_pref_route_only_enabled">Включить routeOnly</string>
     <string name="summary_pref_route_only_enabled">Использовать доменное имя только для маршрутизации и сохранять целевой адрес в виде IP.</string>
 
     <string name="title_pref_local_dns_enabled">Использовать локальную DNS</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">v2rayNG</string>
     <string name="app_tile_name">v2rayNG</string>
     <string name="app_tile_first_use">Первое использование этой функции, пожалуйста, используйте приложение, чтобы добавить профиль</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">Неправильный URL</string>
     <string name="toast_insecure_url_protocol">Не используйте небезопасный HTTP-протокол в адресе подписки</string>
     <string name="server_lab_need_inbound">Убедитесь, что входящий порт соответствует настройкам</string>
-    <string name="toast_malformed_josn">Профиль повреждён</string>
+    <string name="toast_malformed_json">Профиль повреждён</string>
     <string name="server_lab_request_host6">Узел (SNI) (необязательно)</string>
     <string name="toast_action_not_allowed">Это действие запрещено</string>
     <string name="server_obfs_password">Пароль obfs</string>
@@ -127,7 +128,7 @@
     <string name="server_lab_ech_config_list">ECHConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Проверять сертификат узла по имени</string>
     <string name="server_lab_pinned_ca256">Отпечаток сертификата (SHA-256)</string>
-    <string name="server_lab_browser_dialer">Использовать переадресацию браузера</string>
+    <string name="server_lab_browser_dialer">Включить Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">Поддерживаются только исходящие соединения XHTTP (packet-up) и WS; настройки, связанные с TLS, могут быть проигнорированы или конфликтовать</string>
     <string name="toast_allow_insecure_deprecated">Этот узел использует незашифрованное соединение. Ваши данные могут быть перехвачены и просмотрены государственными структурами через промежуточное сетевое оборудование.\nВ целях безопасности такие узлы больше не поддерживаются ядром Xray версии 26.2.6+.\nДля исправления: включите TLS (или другое шифрование) на своём сервере или используйте отпечаток сертификата (pinnedCA256).\nЕсли вы используете платный сервис, обратитесь в поддержку для обновления. Если провайдер отказывается, рекомендуется сменить его на более безопасный.\nПодробнее: https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">Получить и заполнить отпечаток сертификата</string>
@@ -184,8 +185,8 @@
     <string name="title_mux_settings">Настройки мультиплексирования</string>
     <string name="title_pref_mux_enabled">Использовать мультиплексирование</string>
     <string name="summary_pref_mux_enabled">Быстрее, но это может привести к нестабильному соединению.\nНиже можно настроить обработку TCP, UDP и QUIC.</string>
-    <string name="title_pref_mux_concurency">TCP-соединения (диапазон от 1 до 1024)</string>
-    <string name="title_pref_mux_xudp_concurency">XUDP-соединения (диапазон от 1 до 1024)</string>
+    <string name="title_pref_mux_concurrency">TCP-соединения (диапазон от -1 до 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP-соединения (диапазон от -1 до 1024)</string>
     <string name="title_pref_mux_xudp_quic">Обработка QUIC в мультиплексном туннеле</string>
     <string-array name="mux_xudp_quic_entries">
         <item>Отклонять</item>
@@ -366,12 +367,13 @@
     <string name="routing_settings_locked">Постоянное (сохранится при импорте правил)</string>
     <string name="routing_settings_domain">Домен</string>
     <string name="routing_settings_ip">IP</string>
-    <string name="routing_settings_process">Процесс (название пакета; поддерживается только при использовании Xray TUN, включённой функции «Домен только для маршрутизации» и ОС Android 10+)</string>
+    <string name="routing_settings_process">process (имя пакета — поддерживается только при использовании Xray TUN, включённом routeOnly и Android 10+)</string>
     <string name="routing_settings_process_select">Выбор названия пакета</string>
     <string name="routing_settings_port">Порт</string>
     <string name="routing_settings_protocol">Протокол</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">Сеть</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">Исходящее соединение</string>
 
     <string name="connection_test_pending">Проверить соединение</string>
@@ -383,7 +385,7 @@
     <string name="connection_test_error_status_code">Код ошибки: #%d</string>
     <string name="connection_connected">Соединено, нажмите для проверки</string>
     <string name="connection_not_connected">Нет соединения</string>
-    <string name="connection_runing_task_left">Запущено проверок: %s</string>
+    <string name="connection_running_task_left">Запущено проверок: %s</string>
 
     <string name="import_subscription_success">Подписка импортирована</string>
     <string name="import_subscription_failure">Невозможно импортировать подписку</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">Отпечаток</string>
     <string name="server_lab_stream_alpn">ALPN</string>
-    <string name="server_lab_allow_insecure">Разрешать небезопасные соединения</string>
+    <string name="server_lab_allow_insecure">Пропускать проверку сертификата (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">Адрес</string>
     <string name="server_lab_port3">Порт</string>
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">Пароль (необязательно)</string>
     <string name="server_lab_security4">Пользователь (необязательно)</string>
     <string name="server_lab_encryption">Шифрование</string>
-    <string name="server_lab_flow">Поток</string>
+    <string name="server_lab_flow">Поток (flow)</string>
     <string name="server_lab_public_key">Открытый ключ</string>
     <string name="server_lab_preshared_key">Дополнительный ключ шифрования (необязательно)</string>
     <string name="server_lab_short_id">ShortID</string>
@@ -182,8 +182,8 @@
     <string name="title_pref_auto_sort_after_test">Автосортировка профилей</string>
     <string name="summary_pref_auto_sort_after_test">Автоматическая сортировка профилей после проверки (результаты проверки могут быть неточными)</string>
 
-    <string name="title_mux_settings">Настройки мультиплексирования</string>
-    <string name="title_pref_mux_enabled">Использовать мультиплексирование</string>
+    <string name="title_mux_settings">Настройки мультиплексирования (Mux)</string>
+    <string name="title_pref_mux_enabled">Использовать мультиплексирование (Mux)</string>
     <string name="summary_pref_mux_enabled">Быстрее, но это может привести к нестабильному соединению.\nНиже можно настроить обработку TCP, UDP и QUIC.</string>
     <string name="title_pref_mux_concurrency">TCP-соединения (диапазон от -1 до 1024)</string>
     <string name="title_pref_mux_xudp_concurrency">XUDP-соединения (диапазон от -1 до 1024)</string>
@@ -197,7 +197,7 @@
     <string name="title_pref_speed_enabled">Показывать скорость</string>
     <string name="summary_pref_speed_enabled">Показывать текущую скорость в уведомлении.\nЗначок будет меняться в зависимости от использования.</string>
 
-    <string name="title_pref_sniffing_enabled">Анализировать пакеты</string>
+    <string name="title_pref_sniffing_enabled">Анализировать пакеты (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">Пытаться определять доменные имена в пакетах (по умолчанию включено)</string>
     <string name="title_pref_route_only_enabled">Включить routeOnly</string>
     <string name="summary_pref_route_only_enabled">Использовать доменное имя только для маршрутизации и сохранять целевой адрес в виде IP.</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">Использовать локальную DNS</string>
     <string name="summary_pref_local_dns_enabled">Обслуживание выполняется DNS-модулем ядра (в настройках маршрутизации рекомендуется выбрать режим «Все, кроме LAN и Китая»)</string>
 
-    <string name="title_pref_fake_dns_enabled">Использовать поддельную DNS</string>
+    <string name="title_pref_fake_dns_enabled">Использовать поддельную DNS (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">Локальная DNS возвращает поддельные IP-адреса (быстрее, но может не работать с некоторыми приложениями)</string>
 
     <string name="title_pref_ipv6_enabled">Включить IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">Интервал автообновления (минут, не менее 15)</string>
 
     <string name="title_core_loglevel">Подробность ведения журнала</string>
-    <string name="title_outbound_domain_resolve_method">Предопределение исходящего домена</string>
+    <string name="title_outbound_domain_resolve_method">Предварительное разрешение исходящего домена (outbound)</string>
     <string name="title_mode">Режим</string>
     <string name="title_mode_help">Нажмите для получения дополнительной информации</string>
     <string name="title_language">Язык</string>
@@ -389,13 +389,13 @@
 
     <string name="import_subscription_success">Подписка импортирована</string>
     <string name="import_subscription_failure">Невозможно импортировать подписку</string>
-    <string name="title_fragment_settings">Настройки фрагментирования</string>
+    <string name="title_fragment_settings">Настройки фрагментирования (Fragment)</string>
     <string name="title_pref_fragment_packets">Фрагментирование пакетов</string>
     <string name="title_pref_fragment_length">Длина фрагмента (от — до)</string>
     <string name="title_pref_fragment_interval">Интервал фрагментов (от — до)</string>
     <string name="title_pref_fragment_enabled">Использовать фрагментирование</string>
     <string name="title_pref_fragment_maxsplit">Максимальное число фрагментов</string>
-    <string name="title_observatory_settings">Настройки наблюдения соединений</string>
+    <string name="title_observatory_settings">Настройки наблюдения соединений (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">Интервал leastPing</string>
     <string name="title_pref_observatory_least_load_interval">Интервал leastLoad</string>
     <string name="title_pref_observatory_least_load_method">HTTP-метод leastLoad</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">Тип политики группы</string>
     <string name="title_policy_group_subscription_id">Из группы подписки</string>
     <string name="title_policy_group_subscription_filter">Название фильтра</string>
-    <string name="title_policy_group_test_outbounds">Проверять исходящие соединения</string>
-    <string name="title_policy_group_fallback">Резервное исходящее соединение (необязательно)</string>
+    <string name="title_policy_group_test_outbounds">Проверять исходящие соединения (outbounds)</string>
+    <string name="title_policy_group_fallback">Резервное исходящее соединение (outbound, необязательно)</string>
 
     <string name="server_proxy_chain_members">Участники цепочки прокси</string>
     <string name="server_proxy_chain_pick_members">Нажмите здесь, чтобы выбрать участника</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>Наименьшая задержка</item>
-        <item>Наименьшая нагрузка</item>
-        <item>Случайно</item>
-        <item>По очереди</item>
+        <item>Наименьшая задержка (leastPing)</item>
+        <item>Наименьшая нагрузка (leastLoad)</item>
+        <item>Случайно (random)</item>
+        <item>По очереди (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">Локально</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">Ключ QUIC</string>
     <string name="server_lab_path_kcp">Сид KCP</string>
     <string name="server_lab_path_grpc">Служба gRPC</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">Отпечаток</string>
-    <string name="server_lab_stream_alpn">ALPN</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">Пропускать проверку сертификата (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">Адрес</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">Дополнительный ключ шифрования (необязательно)</string>
     <string name="server_lab_short_id">ShortID</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">Закрытый ключ</string>
     <string name="server_lab_reserved">Reserved (необязательно, через запятую)</string>
     <string name="server_lab_local_address">Локальный адрес (необязательно, IPv4/IPv6 через запятую)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">Режим XHTTP</string>
     <string name="server_lab_xhttp_extra">Необработанный JSON XHTTP Extra, формат: { XHTTPObject }</string>
     <string name="server_lab_final_mask">Необработанный JSON FinalMask, формат: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">ECHConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Проверять сертификат узла по имени</string>
     <string name="server_lab_pinned_ca256">Отпечаток сертификата (SHA-256)</string>
     <string name="server_lab_browser_dialer">Включить Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">Добавить файлы</string>
     <string name="menu_item_add_url">Добавить URL</string>
     <string name="menu_item_scan_qrcode">Сканировать QR-код</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">Загрузить файлы</string>
     <string name="title_user_asset_add_url">Добавить URL ресурса</string>
     <string name="msg_file_not_found">Файл не найден</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">домен:адрес,…</string>
 
     <string name="title_pref_delay_test_url">Сервис проверки задержки</string>
-    <string name="summary_pref_delay_test_url">URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">Параллельная проверка задержки</string>
 
     <string name="title_pref_ip_api_url">Сервис проверки текущего соединения</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">Разрешать соединения из LAN</string>
     <string name="summary_pref_proxy_sharing_enabled">Другие устройства могут подключаться, используя ваш IP-адрес, чтобы использовать локальный прокси. Используйте только в доверенной сети, чтобы избежать несанкционированного подключения.</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">Доступ к VPN для устройств LAN/точки доступа (root)</string>
     <string name="summary_root_lan_sharing">Направлять через VPN трафик устройств, подключённых к точке доступа Wi-Fi или по USB.</string>
 
-    <string name="title_logcat">Журнал</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">Копировать</string>
     <string name="logcat_clear">Очистить</string>
     <string name="logcat_share">Поделиться журналом</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">Импорт правил из QR-кода</string>
     <string name="routing_settings_export_rulesets_to_clipboard">Экспорт правил в буфер обмена</string>
     <string name="routing_settings_locked">Постоянное (сохранится при импорте правил)</string>
-    <string name="routing_settings_domain">Домен</string>
-    <string name="routing_settings_ip">IP</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (имя пакета — поддерживается только при использовании Xray TUN, включённом routeOnly и Android 10+)</string>
     <string name="routing_settings_process_select">Выбор названия пакета</string>
-    <string name="routing_settings_port">Порт</string>
-    <string name="routing_settings_protocol">Протокол</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">Сеть</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">Исходящее соединение</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">Проверить соединение</string>
     <string name="connection_test_testing">Проверка…</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">Kết nối ngay</string>
     <string name="app_tile_name">Kết nối ngay</string>
     <string name="app_tile_first_use">Vui lòng thêm một cấu hình vào v2rayNG để sử dụng!</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">URL không hợp lệ hoặc trống!</string>
     <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
     <string name="server_lab_need_inbound">Vui lòng đảm bảo cấu hình tùy chỉnh này không bị lỗi trước khi sử dụng!</string>
-    <string name="toast_malformed_josn">Cấu hình không hợp lệ!</string>
+    <string name="toast_malformed_json">Cấu hình không hợp lệ!</string>
     <string name="server_lab_request_host6">Host (SNI) (Không bắt buộc)</string>
     <string name="toast_action_not_allowed">Hành động này bị cấm!</string>
     <string name="server_obfs_password">Obfs password</string>
@@ -127,13 +128,18 @@
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_browser_dialer">Bật Browser Dialer</string>
+    <string name="server_lab_browser_dialer_tip">Chỉ hỗ trợ đầu ra xhttp (packet-up) và ws; các cài đặt liên quan đến TLS có thể bị bỏ qua hoặc xung đột</string>
+    <string name="toast_allow_insecure_deprecated">Nút hiện tại sử dụng kết nối không mã hóa. Hạ tầng trung gian mạng do các chính phủ độc tài kiểm soát có thể xem trực tiếp nội dung liên lạc của bạn.\nVì lý do bảo mật, không thể kết nối đến các nút như vậy bằng Xray core phiên bản 26.2.6 trở lên.\nNếu đây là nút do bạn tự dựng, hãy bật mã hóa an toàn như TLS hoặc ghim dấu vân tay chứng chỉ pinnedCA256.\nNếu đây là nút của nhà cung cấp dịch vụ, hãy liên hệ với họ để hoàn tất nâng cấp kỹ thuật. Nếu nhà cung cấp từ chối hợp tác, bạn nên chuyển sang nhà cung cấp coi trọng bảo mật người dùng hơn.\nĐể biết thêm thông tin, hãy truy cập https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
     <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
     <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">Không thể sao chép tệp tin, hãy dùng trình quản lý tệp!</string>
+    <string name="menu_item_add_asset">Thêm vào</string>
     <string name="menu_item_add_file">Thêm tệp</string>
+    <string name="menu_item_add_url">Thêm liên kết</string>
     <string name="menu_item_scan_qrcode">Quét mã QR</string>
     <string name="title_url">URL</string>
     <string name="menu_item_download_file">Tải xuống tệp tin</string>
@@ -155,7 +161,7 @@
     <string name="menu_item_import_proxy_app">Nhập từ Clipboard</string>
     <string name="per_app_proxy_settings">Per-app settings</string>
     <string name="per_app_proxy_settings_enable">Enable per-app</string>
-
+    <string name="app_picker_unknown_app">Ứng dụng không xác định (không nhận dạng được UID)</string>
 
     <!-- Preferences -->
     <string name="title_settings">Cài đặt</string>
@@ -167,6 +173,10 @@
     <string name="title_pref_is_booted">Auto connect at startup</string>
     <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
 
+
+    <string name="subscription_updater_job_tips">Tác vụ sẽ chạy trong nền và thông tin tiến độ sẽ hiển thị trong thông báo.</string>
+    <string name="title_pref_auto_test_after_update_subscription">Tự động kiểm tra sau khi cập nhật đăng ký</string>
+    <string name="summary_pref_auto_test_after_update_subscription">Quá trình kiểm tra tự động mất nhiều thời gian. Nếu bật, tác vụ sẽ chạy trong nền; nếu không, tác vụ sẽ chạy trên trang hiện tại.</string>
     <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
     <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>
     <string name="title_pref_auto_sort_after_test">Auto sort after testing</string>
@@ -175,15 +185,14 @@
     <string name="title_mux_settings">Cài đặt Mux</string>
     <string name="title_pref_mux_enabled">Bật Mux</string>
     <string name="summary_pref_mux_enabled">Giảm độ trễ nhưng có thể làm gián đoạn luồng, vì vậy không nên kích hoạt nó. \nCác phương pháp xử lý lưu lượng truy cập TCP, UDP và QUIC có sẵn bên dưới.</string>
-    <string name="title_pref_mux_concurency">Số lượng liên kết con tái sử dụng TCP (-1 đến 1024)</string>
-    <string name="title_pref_mux_xudp_concurency">Số lượng liên kết con tái sử dụng XUDP (-1 đến 1024)</string>
+    <string name="title_pref_mux_concurrency">Số lượng liên kết con tái sử dụng TCP (-1 đến 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">Số lượng liên kết con tái sử dụng XUDP (-1 đến 1024)</string>
     <string name="title_pref_mux_xudp_quic">Phương pháp xử lý lưu lượng QUIC</string>
     <string-array name="mux_xudp_quic_entries">
         <item>Từ chối</item>
         <item>Cho phép</item>
         <item>Bỏ qua</item>
     </string-array>
-
 
     <string name="title_pref_speed_enabled">Hiển thị tốc độ mạng</string>
     <string name="summary_pref_speed_enabled">Hiển thị tốc độ mạng hiện tại trên thanh thông báo. \nBiểu tượng trên thanh trạng thái có thể thay đổi tùy vào mức sử dụng.</string>
@@ -192,7 +201,6 @@
     <string name="summary_pref_sniffing_enabled">Phát hiện tên miền từ lưu lượng truy cập (Được bật theo mặc định). \nỞ Việt Nam: tắt để sử dụng Zalo.</string>
     <string name="title_pref_route_only_enabled">Bật RouteOnly</string>
     <string name="summary_pref_route_only_enabled">Chỉ sử dụng tên miền được đánh dấu để định tuyến và giữ địa chỉ đích làm địa chỉ IP.</string>
-
 
     <string name="title_pref_local_dns_enabled">Bật Local DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS được xử lý bởi module DNS của Xray-Core (Dùng nếu cần định tuyến Bypass cho mạng LAN và Địa chỉ nội địa).</string>
@@ -213,7 +221,9 @@
     <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
 
     <string name="title_pref_vpn_interface_address">VPN Interface Address</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+
 
     <string name="title_pref_domestic_dns">DNS nội địa (Không bắt buộc)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
@@ -260,18 +270,19 @@
 
     <string name="title_pref_group_all_display">Enable show all groups</string>
     <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+
     <!-- AboutActivity -->
     <string name="title_pref_feedback">Phản hồi lỗi</string>
     <string name="summary_pref_feedback">Phản hồi cải tiến hoặc lỗi lên GitHub</string>
     <string name="summary_pref_tg_group">Tham gia nhóm Telegram</string>
     <string name="toast_tg_app_not_found">Không tìm thấy ứng dụng Telegram!</string>
-
     <string name="title_privacy_policy">Chính sách bảo mật</string>
     <string name="title_qr_code">Mã QR</string>
     <string name="title_about">Giới thiệu</string>
     <string name="title_source_code">Mã nguồn</string>
     <string name="title_oss_license">Open Source licenses</string>
     <string name="title_tg_channel">Kênh Telegram</string>
+
     <string name="title_pref_promotion">Quảng bá server</string>
 
     <string name="title_pref_auto_update_subscription">Tự động cập nhật các gói đăng ký</string>
@@ -289,6 +300,12 @@
     <string name="summary_pref_use_hev_tunnel">When enabled, TUN will use hev-socks5-tunnel; otherwise, it will use xray-core.</string>
     <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
     <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
+    <string name="title_mode_settings">Cài đặt chế độ</string>
+    <string name="title_root_mode_enabled">Bật chế độ Root (dành cho người dùng Root)</string>
+    <string name="summary_root_mode_enabled">Bật proxy trong suốt cấp thấp bằng quyền Root. Chế độ này bỏ qua VPN hệ thống tiêu chuẩn của Android để trực tiếp tiếp quản toàn bộ lưu lượng mạng bên dưới. Sau khi bật, chế độ thông thường trước đây, định tuyến theo ứng dụng và các cài đặt VPN liên quan sẽ hoàn toàn mất hiệu lực.</string>
+    <string name="toast_root_required">Tính năng này yêu cầu quyền truy cập Root</string>
+    <string name="title_root_lan_sharing">Chia sẻ LAN / kết nối mạng (dành cho người dùng Root)</string>
+    <string name="summary_root_lan_sharing">Định tuyến thiết bị dùng điểm phát Wi-Fi và chia sẻ kết nối USB qua VPN</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">Sao chép</string>
@@ -303,6 +320,7 @@
     <string name="sub_setting_remarks">Tên gói đăng ký</string>
     <string name="sub_setting_url">URL gói đăng ký</string>
     <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_request_headers">Tiêu đề yêu cầu (định dạng JSON)</string>
     <string name="sub_setting_filter">Remarks regular filter</string>
     <string name="sub_setting_enable">Sử dụng gói đăng ký này</string>
     <string name="sub_auto_update">Bật tự động cập nhật</string>
@@ -318,9 +336,8 @@
     <string name="title_sort_by_test_results">Sắp xếp lại theo lần kiểm tra cuối cùng</string>
     <string name="title_filter_config">Lọc cấu hình theo các gói đăng ký</string>
     <string name="filter_config_all">All</string>
-    <string name="title_del_duplicate_config_count">Xoá %d cấu hình trùng lặp</string>
     <string name="summary_scan_qrcode">Click screen open the camera scan</string>
-
+    <string name="title_del_duplicate_config_count">Xoá %d cấu hình trùng lặp</string>
     <string name="title_del_config_count">Delete %d configurations</string>
     <string name="title_import_config_count">Import %d configurations</string>
     <string name="title_export_config_count">Export %d configurations</string>
@@ -350,11 +367,13 @@
     <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
-    <string name="routing_settings_process">process (Package Name — only supported when using Xray TUN, routeOnly enabled, and Android 10+)</string>
+    <string name="routing_settings_process">process (tên gói — chỉ được hỗ trợ khi dùng Xray TUN, bật routeOnly và chạy Android 10+)</string>
+    <string name="routing_settings_process_select">Chọn tên gói</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">Kiểm tra kết nối</string>
@@ -366,11 +385,10 @@
     <string name="connection_test_error_status_code">Mã lỗi: #%d</string>
     <string name="connection_connected">Đã kết nối, nhấn để kiểm tra kết nối mạng!</string>
     <string name="connection_not_connected">Chưa kết nối</string>
-    <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_task_left">Số tác vụ kiểm tra đang chạy: %s</string>
 
     <string name="import_subscription_success">Nhập gói đăng ký thành công!</string>
     <string name="import_subscription_failure">Nhập gói đăng ký không thành công!</string>
-
     <string name="title_fragment_settings">Fragment Settings</string>
     <string name="title_pref_fragment_packets">Fragment Packets</string>
     <string name="title_pref_fragment_length">Fragment Length (min-max)</string>
@@ -398,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
     <string name="title_policy_group_test_outbounds">Kiểm tra outbound</string>
     <string name="title_policy_group_fallback">Outbound dự phòng (tùy chọn)</string>
+
     <string name="server_proxy_chain_members">Proxy chain members</string>
     <string name="server_proxy_chain_pick_members">Tap here to pick member</string>
     <string name="server_proxy_chain_member_unselected">Select a member</string>
@@ -431,14 +450,25 @@
         <item>Chế độ VPN</item>
         <item>Chế độ Proxy</item>
     </string-array>
-    <string name="menu_item_add_asset">Thêm vào</string>
-    <string name="menu_item_add_url">Thêm liên kết</string>
+
+    <string-array name="browser_dialer_mode">
+        <item>Tắt</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
+    </string-array>
 
     <string-array name="ui_mode_night">
         <item>Theo hệ thống</item>
         <item>Sáng</item>
         <item>Tối</item>
     </string-array>
+
+    <string name="routing_preset_china_whitelist">Danh sách trắng Trung Quốc</string>
+    <string name="routing_preset_china_blacklist">Danh sách đen Trung Quốc</string>
+    <string name="routing_preset_global">Toàn cầu</string>
+    <string name="routing_preset_iran_whitelist">Danh sách trắng Iran</string>
+    <string name="routing_preset_russia_whitelist">Danh sách trắng Nga</string>
+
     <string-array name="vpn_bypass_lan">
         <item>Follow config</item>
         <item>Bypass</item>
@@ -450,6 +480,7 @@
         <item>Resolve and add to DNS Hosts</item>
         <item>Resolve and replace domain</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>Least Ping</item>
         <item>Least Load</item>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">QUIC key</string>
     <string name="server_lab_path_kcp">kcp seed</string>
     <string name="server_lab_path_grpc">gRPC serviceName</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">Bỏ qua xác minh chứng chỉ (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">Địa chỉ</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">ShortId</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved (Không bắt buộc)</string>
     <string name="server_lab_local_address">Địa chỉ cục bộ (IPv4 / IPv6, phân cách bằng dấu phẩy)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">EchConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Xác minh chứng chỉ ngang hàng theo tên</string>
     <string name="server_lab_pinned_ca256">Dấu vân tay chứng chỉ (SHA-256)</string>
     <string name="server_lab_browser_dialer">Bật Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">Thêm tệp</string>
     <string name="menu_item_add_url">Thêm liên kết</string>
     <string name="menu_item_scan_qrcode">Quét mã QR</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">Tải xuống tệp tin</string>
     <string name="title_user_asset_add_url">Thêm URL nội dung</string>
     <string name="msg_file_not_found">Không tìm thấy tập tin!</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">URL kiểm tra độ trễ thực </string>
-    <string name="summary_pref_delay_test_url">URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">Số lượt kiểm tra độ trễ thực đồng thời</string>
 
     <string name="title_pref_ip_api_url">URL kiểm tra thông tin kết nối hiện tại</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">Cho phép kết nối từ mạng LAN</string>
     <string name="summary_pref_proxy_sharing_enabled">Các thiết bị khác trong cùng mạng LAN có thể kết nối đến SOCKS / HTTP proxy trên thiết bị của bạn. \nChỉ bật tính năng này trong các mạng đáng tin cậy để tránh kết nối trái phép.</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">Chia sẻ VPN với thiết bị LAN / chia sẻ kết nối (dành cho người dùng Root)</string>
     <string name="summary_root_lan_sharing">Định tuyến lưu lượng từ thiết bị dùng điểm phát Wi-Fi và chia sẻ kết nối USB qua VPN.</string>
 
-    <string name="title_logcat">Logcat</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">Sao chép</string>
     <string name="logcat_clear">Xoá</string>
     <string name="logcat_share">Chia sẻ nhật ký</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">Nhập bộ quy tắc từ QRcode</string>
     <string name="routing_settings_export_rulesets_to_clipboard">Xuất bộ quy tắc vào bảng nhớ tạm</string>
     <string name="routing_settings_locked">Đã khóa; giữ quy tắc này khi nhập cài đặt sẵn</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (tên gói — chỉ được hỗ trợ khi dùng Xray TUN, bật routeOnly và chạy Android 10+)</string>
     <string name="routing_settings_process_select">Chọn tên gói</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">Kiểm tra kết nối</string>
     <string name="connection_test_testing">Đang kiểm tra kết nối mạng...</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">Bỏ qua xác minh chứng chỉ (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">Địa chỉ</string>
     <string name="server_lab_port3">Cổng</string>
     <string name="server_lab_id3">Mật khẩu</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">PublicKey</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">ShortId</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved (Không bắt buộc)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">Ưu tiên địa chỉ IPv6 khi phân giải tên miền</string>
 
     <string name="title_pref_remote_dns">DNS ngoại quốc (UDP / TCP / HTTPS / QUIC) (Không bắt buộc)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (Chỉ IPv4 / IPv6)</string>
     <string name="title_pref_vpn_bypass_lan">VPN có bỏ qua LAN không</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">DNS nội địa (Không bắt buộc)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS hosts (Định dạng: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">Cổng proxy cục bộ</string>
     <string name="title_pref_enable_local_proxy">Bật proxy cục bộ</string>
     <string name="summary_pref_enable_local_proxy">Khi tắt, proxy SOCKS sẽ không khả dụng nên việc cập nhật đăng ký và các thao tác tương tự không thể dùng proxy</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">Xác thực socks5 không hoàn toàn an toàn khi sử dụng UDP</string>
     <string name="summary_pref_socks_port">Cổng proxy cục bộ</string>
     <string name="title_pref_dynamic_socks_port">Bật cổng proxy cục bộ động</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">Các gói đăng ký</string>
     <string name="sub_setting_remarks">Tên gói đăng ký</string>
     <string name="sub_setting_url">URL gói đăng ký</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">Tiêu đề yêu cầu (định dạng JSON)</string>
     <string name="sub_setting_filter">Bộ lọc biểu thức chính quy cho tên ghi chú</string>
     <string name="sub_setting_enable">Sử dụng gói đăng ký này</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">Đã cập nhật %1$d cấu hình (%2$d thành công, %3$d thất bại, %4$d bỏ qua)</string>
     <string name="title_update_subscription_no_subscription">Không có đăng ký</string>
     <string name="toast_server_not_found_in_group">Không tìm thấy máy chủ đã chọn trong nhóm hiện tại</string>
-    <string name="toast_fragment_not_available">Màn hình hiện tại không khả dụng.</string>
     <string name="title_locate_selected_config">Tìm cấu hình đã chọn</string>
 
     <string name="tasker_start_service">Khởi động v2rayNG</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">Chọn tên gói</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">Kiểm tra kết nối</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">Cục bộ</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">URL không hợp lệ hoặc trống!</string>
     <string name="toast_insecure_url_protocol">Vui lòng không dùng địa chỉ đăng ký với giao thức HTTP không an toàn</string>
     <string name="server_lab_need_inbound">Vui lòng đảm bảo cấu hình tùy chỉnh này không bị lỗi trước khi sử dụng!</string>
-    <string name="toast_malformed_json">Cấu hình không hợp lệ!</string>
+    <string name="toast_malformed_json">Cấu hình không hợp lệ.</string>
     <string name="server_lab_request_host6">Host (SNI) (Không bắt buộc)</string>
     <string name="toast_action_not_allowed">Hành động này bị cấm!</string>
     <string name="server_obfs_password">Mật khẩu Obfs</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">Bật Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">Chỉ hỗ trợ đầu ra xhttp (packet-up) và ws; các cài đặt liên quan đến TLS có thể bị bỏ qua hoặc xung đột</string>
     <string name="toast_allow_insecure_deprecated">Nút hiện tại sử dụng kết nối không mã hóa. Hạ tầng trung gian mạng do các chính phủ độc tài kiểm soát có thể xem trực tiếp nội dung liên lạc của bạn.\nVì lý do bảo mật, không thể kết nối đến các nút như vậy bằng Xray core phiên bản 26.2.6 trở lên.\nNếu đây là nút do bạn tự dựng, hãy bật mã hóa an toàn như TLS hoặc ghim dấu vân tay chứng chỉ pinnedCA256.\nNếu đây là nút của nhà cung cấp dịch vụ, hãy liên hệ với họ để hoàn tất nâng cấp kỹ thuật. Nếu nhà cung cấp từ chối hợp tác, bạn nên chuyển sang nhà cung cấp coi trọng bảo mật người dùng hơn.\nĐể biết thêm thông tin, hãy truy cập https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">Lấy và điền dấu vân tay chứng chỉ</string>
+    <string name="pinned_ca256_action_fetch">Lấy dấu vân tay chứng chỉ</string>
     <string name="toast_fetch_cert_sha256_success">Đã lấy dấu vân tay chứng chỉ thành công</string>
     <string name="toast_fetch_cert_sha256_failed">Không thể lấy dấu vân tay chứng chỉ</string>
 
@@ -185,8 +185,8 @@
     <string name="title_mux_settings">Cài đặt Mux</string>
     <string name="title_pref_mux_enabled">Bật Mux</string>
     <string name="summary_pref_mux_enabled">Giảm độ trễ nhưng có thể làm gián đoạn luồng, vì vậy không nên kích hoạt nó. \nCác phương pháp xử lý lưu lượng truy cập TCP, UDP và QUIC có sẵn bên dưới.</string>
-    <string name="title_pref_mux_concurrency">Số lượng liên kết con tái sử dụng TCP (-1 đến 1024)</string>
-    <string name="title_pref_mux_xudp_concurrency">Số lượng liên kết con tái sử dụng XUDP (-1 đến 1024)</string>
+    <string name="title_pref_mux_concurrency">Số kết nối con TCP được ghép kênh (-1 đến 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">Số kết nối con XUDP được ghép kênh (-1 đến 1024)</string>
     <string name="title_pref_mux_xudp_quic">Phương pháp xử lý lưu lượng QUIC</string>
     <string-array name="mux_xudp_quic_entries">
         <item>Từ chối</item>
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">Hiển thị tốc độ mạng</string>
-    <string name="summary_pref_speed_enabled">Hiển thị tốc độ mạng hiện tại trên thanh thông báo. \nBiểu tượng trên thanh trạng thái có thể thay đổi tùy vào mức sử dụng.</string>
+    <string name="summary_pref_speed_enabled">Hiển thị tốc độ hiện tại trong thông báo.\nBiểu tượng cho biết lưu lượng proxy hay trực tiếp đang chiếm ưu thế.</string>
 
     <string name="title_pref_sniffing_enabled">Bật Sniffing</string>
-    <string name="summary_pref_sniffing_enabled">Phát hiện tên miền từ lưu lượng truy cập (Được bật theo mặc định). \nỞ Việt Nam: tắt để sử dụng Zalo.</string>
+    <string name="summary_pref_sniffing_enabled">Phát hiện tên miền đích từ lưu lượng truy cập (bật theo mặc định). \nỞ Việt Nam: tắt để sử dụng Zalo.</string>
     <string name="title_pref_route_only_enabled">Bật routeOnly</string>
     <string name="summary_pref_route_only_enabled">Chỉ sử dụng tên miền được đánh dấu để định tuyến và giữ địa chỉ đích làm địa chỉ IP.</string>
 
     <string name="title_pref_local_dns_enabled">Bật DNS cục bộ</string>
     <string name="summary_pref_local_dns_enabled">DNS được xử lý bởi module DNS của Xray-Core (Dùng nếu cần định tuyến Bypass cho mạng LAN và Địa chỉ nội địa).</string>
 
-    <string name="title_pref_fake_dns_enabled">Bật DNS giả (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">FakeDNS lấy tên miền mục tiêu bằng cách giả mạo DNS (Nhanh hơn, nhưng có thể không hoạt động cho một số ứng dụng).</string>
+    <string name="title_pref_fake_dns_enabled">Bật DNS ảo (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">FakeDNS trả về địa chỉ IP ảo khi phân giải tên miền (nhanh hơn nhưng có thể không hoạt động với một số ứng dụng).</string>
 
     <string name="title_pref_ipv6_enabled">Bật IPv6</string>
     <string name="summary_pref_ipv6_enabled">Thêm địa chỉ và tuyến IPv6 vào giao diện VPN</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">URL kiểm tra độ trễ thực </string>
     <string name="summary_pref_delay_test_url">URL</string>
-    <string name="title_pref_real_ping_concurrency">Số luồng kiểm tra độ trễ thực</string>
+    <string name="title_pref_real_ping_concurrency">Số lượt kiểm tra độ trễ thực đồng thời</string>
 
     <string name="title_pref_ip_api_url">URL kiểm tra thông tin kết nối hiện tại</string>
     <string name="summary_pref_ip_api_url">URL</string>
@@ -268,8 +268,8 @@
     <string name="title_pref_double_column_display">Bật hiển thị hai cột</string>
     <string name="summary_pref_double_column_display">Danh sách hồ sơ được hiển thị thành hai cột để màn hình chứa được nhiều nội dung hơn.</string>
 
-    <string name="title_pref_group_all_display">Hiển thị tất cả nhóm</string>
-    <string name="summary_pref_group_all_display">Thêm một trang "Tất cả thẻ"</string>
+    <string name="title_pref_group_all_display">Hiển thị thẻ nhóm “Tất cả”</string>
+    <string name="summary_pref_group_all_display">Gộp cấu hình từ mọi nhóm đăng ký vào một thẻ.</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">Phản hồi lỗi</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">Thời gian cập nhật tự động (Phút, giá trị tối thiểu là 15)</string>
 
     <string name="title_core_loglevel">Cấp độ nhật ký</string>
-    <string name="title_outbound_domain_resolve_method">Phương thức phân giải trước tên miền đầu ra (outbound)</string>
+    <string name="title_outbound_domain_resolve_method">Phân giải tên miền cho kết nối đi (outbound)</string>
     <string name="title_mode">Chế độ kết nối</string>
     <string name="title_mode_help">Nhấn vào đây nếu bạn cần trợ giúp!</string>
     <string name="title_language">Ngôn ngữ</string>
@@ -302,10 +302,10 @@
     <string name="title_pref_hev_tunnel_rw_timeout">Thời gian chờ đọc/ghi của Hev TUN (giây) (tcp, udp mặc định 300, 60)</string>
     <string name="title_mode_settings">Cài đặt chế độ</string>
     <string name="title_root_mode_enabled">Bật chế độ Root (dành cho người dùng Root)</string>
-    <string name="summary_root_mode_enabled">Bật proxy trong suốt cấp thấp bằng quyền Root. Chế độ này bỏ qua VPN hệ thống tiêu chuẩn của Android để trực tiếp tiếp quản toàn bộ lưu lượng mạng bên dưới. Sau khi bật, chế độ thông thường trước đây, định tuyến theo ứng dụng và các cài đặt VPN liên quan sẽ hoàn toàn mất hiệu lực.</string>
+    <string name="summary_root_mode_enabled">Dùng quyền Root cho proxy trong suốt cấp thấp. Chế độ Root xử lý trực tiếp lưu lượng mạng thay vì dùng dịch vụ VPN của Android. Khi chế độ này bật, chế độ thông thường, định tuyến theo ứng dụng và các cài đặt VPN liên quan sẽ không được áp dụng.</string>
     <string name="toast_root_required">Tính năng này yêu cầu quyền truy cập Root</string>
-    <string name="title_root_lan_sharing">Chia sẻ LAN / kết nối mạng (dành cho người dùng Root)</string>
-    <string name="summary_root_lan_sharing">Định tuyến thiết bị dùng điểm phát Wi-Fi và chia sẻ kết nối USB qua VPN</string>
+    <string name="title_root_lan_sharing">Chia sẻ VPN với thiết bị LAN / chia sẻ kết nối (dành cho người dùng Root)</string>
+    <string name="summary_root_lan_sharing">Định tuyến lưu lượng từ thiết bị dùng điểm phát Wi-Fi và chia sẻ kết nối USB qua VPN.</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">Sao chép</string>
@@ -345,7 +345,7 @@
     <string name="title_update_subscription_result">Đã cập nhật %1$d cấu hình (%2$d thành công, %3$d thất bại, %4$d bỏ qua)</string>
     <string name="title_update_subscription_no_subscription">Không có đăng ký</string>
     <string name="toast_server_not_found_in_group">Không tìm thấy máy chủ đã chọn trong nhóm hiện tại</string>
-    <string name="toast_fragment_not_available">Không thể xác định màn hình hiện tại</string>
+    <string name="toast_fragment_not_available">Màn hình hiện tại không khả dụng.</string>
     <string name="title_locate_selected_config">Tìm cấu hình đã chọn</string>
 
     <string name="tasker_start_service">Khởi động v2rayNG</string>
@@ -385,7 +385,7 @@
     <string name="connection_test_error_status_code">Mã lỗi: #%d</string>
     <string name="connection_connected">Đã kết nối, nhấn để kiểm tra kết nối mạng!</string>
     <string name="connection_not_connected">Chưa kết nối</string>
-    <string name="connection_running_task_left">Số tác vụ kiểm tra đang chạy: %s</string>
+    <string name="connection_running_task_left">Số lượt kiểm tra đang chạy: %s</string>
 
     <string name="import_subscription_success">Nhập gói đăng ký thành công!</string>
     <string name="import_subscription_failure">Nhập gói đăng ký không thành công!</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">Loại nhóm chính sách</string>
     <string name="title_policy_group_subscription_id">Từ nhóm đăng ký</string>
     <string name="title_policy_group_subscription_filter">Bộ lọc biểu thức chính quy cho tên ghi chú</string>
-    <string name="title_policy_group_test_outbounds">Kiểm tra kết nối đi (outbounds)</string>
-    <string name="title_policy_group_fallback">Kết nối đi dự phòng (outbound, tùy chọn)</string>
+    <string name="title_policy_group_test_outbounds">Kiểm tra các kết nối đi (outbounds)</string>
+    <string name="title_policy_group_fallback">Kết nối dự phòng (outbound, tùy chọn)</string>
 
     <string name="server_proxy_chain_members">Thành viên chuỗi proxy</string>
     <string name="server_proxy_chain_pick_members">Chạm vào đây để chọn thành viên</string>
@@ -485,7 +485,7 @@
         <item>Ping thấp nhất (leastPing)</item>
         <item>Tải thấp nhất (leastLoad)</item>
         <item>Ngẫu nhiên (random)</item>
-        <item>Lần lượt (roundRobin)</item>
+        <item>Luân phiên (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">Cục bộ</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -7,14 +7,14 @@
     <string name="navigation_drawer_open">Mở Menu ứng dụng</string>
     <string name="navigation_drawer_close">Đóng Menu ứng dụng</string>
     <string name="migration_success">Đã chuyển dữ liệu!</string>
-    <string name="action_stop_service">Stop service</string>
+    <string name="action_stop_service">Dừng dịch vụ</string>
     <string name="migration_fail">Không thể chuyển dữ liệu!</string>
-    <string name="pull_down_to_refresh">Please pull down to refresh!</string>
+    <string name="pull_down_to_refresh">Kéo xuống để làm mới!</string>
 
     <!-- Notifications -->
     <string name="notification_action_stop_v2ray">Ngắt kết nối v2rayNG</string>
     <string name="toast_permission_denied">Vui lòng cấp quyền cần thiết cho v2rayNG! Bạn đã từ chối các quyền cần thiết như Camera hay Bộ nhớ?</string>
-    <string name="toast_permission_denied_notification">Unable to obtain the notification permission</string>
+    <string name="toast_permission_denied_notification">Không thể nhận quyền thông báo</string>
     <string name="notification_action_more">Nhấn để biết thêm...</string>
     <string name="toast_services_start">Đang khởi động v2rayNG...</string>
     <string name="toast_services_stop">Đã dừng v2rayNG!</string>
@@ -25,21 +25,21 @@
     <string name="title_server">v2rayNG</string>
     <string name="menu_item_add_config">Thêm cấu hình</string>
     <string name="menu_item_save_config">Lưu cấu hình</string>
-    <string name="menu_item_edit_config">Edit configuration</string>
+    <string name="menu_item_edit_config">Chỉnh sửa cấu hình</string>
     <string name="menu_item_del_config">Xoá cấu hình</string>
     <string name="menu_item_import_config_qrcode">Nhập cấu hình từ mã QR</string>
     <string name="menu_item_import_config_clipboard">Nhập cấu hình từ Clipboard</string>
-    <string name="menu_item_import_config_local">Import config from locally</string>
-    <string name="menu_item_import_config_policy_group">Add [Policy group]</string>
-    <string name="menu_item_import_config_proxy_chain">Add [Proxy chain]</string>
+    <string name="menu_item_import_config_local">Nhập cấu hình từ thiết bị</string>
+    <string name="menu_item_import_config_policy_group">Thêm [Nhóm chính sách]</string>
+    <string name="menu_item_import_config_proxy_chain">Thêm [Chuỗi proxy]</string>
     <string name="menu_item_import_config_manually_vmess">Nhập thủ công [VMess]</string>
     <string name="menu_item_import_config_manually_vless">Nhập thủ công [VLESS]</string>
     <string name="menu_item_import_config_manually_ss">Nhập thủ công [ShadowSocks]</string>
     <string name="menu_item_import_config_manually_socks">Nhập thủ công [SOCKS]</string>
-    <string name="menu_item_import_config_manually_http">Type manually[HTTP]</string>
+    <string name="menu_item_import_config_manually_http">Nhập thủ công [HTTP]</string>
     <string name="menu_item_import_config_manually_trojan">Nhập thủ công [Trojan]</string>
     <string name="menu_item_import_config_manually_wireguard">Nhập thủ công [WireGuard]</string>
-    <string name="menu_item_import_config_manually_hysteria2">Type manually[Hysteria2]</string>
+    <string name="menu_item_import_config_manually_hysteria2">Nhập thủ công [Hysteria2]</string>
     <string name="confirm_delete_visible_profiles">Bạn có chắc muốn xóa tất cả cấu hình đang hiển thị không?</string>
     <string name="confirm_delete_duplicate_profiles">Bạn có chắc muốn xóa tất cả cấu hình trùng lặp đang hiển thị không?</string>
     <string name="confirm_delete_invalid_profiles">Vui lòng kiểm tra các cấu hình trước. Bạn có chắc muốn xóa tất cả cấu hình không hợp lệ đang hiển thị không?</string>
@@ -112,28 +112,28 @@
     <string name="server_lab_content">Nội dung</string>
     <string name="toast_none_data_clipboard">Không có dữ liệu nào trong Clipboard!</string>
     <string name="toast_invalid_url">URL không hợp lệ hoặc trống!</string>
-    <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
+    <string name="toast_insecure_url_protocol">Vui lòng không dùng địa chỉ đăng ký với giao thức HTTP không an toàn</string>
     <string name="server_lab_need_inbound">Vui lòng đảm bảo cấu hình tùy chỉnh này không bị lỗi trước khi sử dụng!</string>
     <string name="toast_malformed_json">Cấu hình không hợp lệ!</string>
     <string name="server_lab_request_host6">Host (SNI) (Không bắt buộc)</string>
     <string name="toast_action_not_allowed">Hành động này bị cấm!</string>
-    <string name="server_obfs_password">Obfs password</string>
-    <string name="server_lab_port_hop">Port Hopping</string>
-    <string name="server_lab_port_hop_interval">Port Hopping Interval</string>
-    <string name="server_lab_bandwidth_down">Bandwidth down (Supported units: k/m/g/t)</string>
-    <string name="server_lab_bandwidth_up">Bandwidth up (Supported units: k/m/g/t)</string>
+    <string name="server_obfs_password">Mật khẩu Obfs</string>
+    <string name="server_lab_port_hop">Nhảy cổng</string>
+    <string name="server_lab_port_hop_interval">Khoảng thời gian đổi cổng</string>
+    <string name="server_lab_bandwidth_down">Băng thông tải xuống (đơn vị hỗ trợ: k/m/g/t)</string>
+    <string name="server_lab_bandwidth_up">Băng thông tải lên (đơn vị hỗ trợ: k/m/g/t)</string>
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
-    <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
+    <string name="server_lab_verify_peer_cert_by_name">Xác minh chứng chỉ ngang hàng theo tên</string>
+    <string name="server_lab_pinned_ca256">Dấu vân tay chứng chỉ (SHA-256)</string>
     <string name="server_lab_browser_dialer">Bật Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">Chỉ hỗ trợ đầu ra xhttp (packet-up) và ws; các cài đặt liên quan đến TLS có thể bị bỏ qua hoặc xung đột</string>
     <string name="toast_allow_insecure_deprecated">Nút hiện tại sử dụng kết nối không mã hóa. Hạ tầng trung gian mạng do các chính phủ độc tài kiểm soát có thể xem trực tiếp nội dung liên lạc của bạn.\nVì lý do bảo mật, không thể kết nối đến các nút như vậy bằng Xray core phiên bản 26.2.6 trở lên.\nNếu đây là nút do bạn tự dựng, hãy bật mã hóa an toàn như TLS hoặc ghim dấu vân tay chứng chỉ pinnedCA256.\nNếu đây là nút của nhà cung cấp dịch vụ, hãy liên hệ với họ để hoàn tất nâng cấp kỹ thuật. Nếu nhà cung cấp từ chối hợp tác, bạn nên chuyển sang nhà cung cấp coi trọng bảo mật người dùng hơn.\nĐể biết thêm thông tin, hãy truy cập https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
-    <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
-    <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
+    <string name="pinned_ca256_action_fetch">Lấy và điền dấu vân tay chứng chỉ</string>
+    <string name="toast_fetch_cert_sha256_success">Đã lấy dấu vân tay chứng chỉ thành công</string>
+    <string name="toast_fetch_cert_sha256_failed">Không thể lấy dấu vân tay chứng chỉ</string>
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">Không thể sao chép tệp tin, hãy dùng trình quản lý tệp!</string>
@@ -146,7 +146,7 @@
     <string name="title_user_asset_add_url">Thêm URL nội dung</string>
     <string name="msg_file_not_found">Không tìm thấy tập tin!</string>
     <string name="msg_remark_is_duplicate">Nhận xét đã tồn tại!</string>
-    <string name="asset_geo_files_sources">Geo files source (optional)</string>
+    <string name="asset_geo_files_sources">Nguồn tệp Geo (tùy chọn)</string>
 
     <!-- PerAppProxyActivity -->
     <string name="msg_dialog_progress">Đang tải...</string>
@@ -159,8 +159,8 @@
     <string name="msg_downloading_content">Đang tải xuống nội dung...</string>
     <string name="menu_item_export_proxy_app">Xuất và Sao chép</string>
     <string name="menu_item_import_proxy_app">Nhập từ Clipboard</string>
-    <string name="per_app_proxy_settings">Per-app settings</string>
-    <string name="per_app_proxy_settings_enable">Enable per-app</string>
+    <string name="per_app_proxy_settings">Cài đặt theo ứng dụng</string>
+    <string name="per_app_proxy_settings_enable">Bật cài đặt theo ứng dụng</string>
     <string name="app_picker_unknown_app">Ứng dụng không xác định (không nhận dạng được UID)</string>
 
     <!-- Preferences -->
@@ -170,17 +170,17 @@
     <string name="title_vpn_settings">Cài đặt VPN</string>
     <string name="title_pref_per_app_proxy">Proxy theo Ứng dụng</string>
     <string name="summary_pref_per_app_proxy">- Bình thường: Ứng dụng đã chọn sẽ kết nối thông qua Proxy, chưa chọn sẽ kết nối trực tiếp. \n- Chế độ Bypass: Ứng dụng đã chọn sẽ kết nối trực tiếp, chưa chọn sẽ kết nối qua Proxy. \n- Nếu bạn đang ở Trung Quốc thì vào Menu, chọn Tự động chọn ứng dụng Proxy.</string>
-    <string name="title_pref_is_booted">Auto connect at startup</string>
-    <string name="summary_pref_is_booted">Automatically connects to the selected server at startup, which may be unsuccessful</string>
+    <string name="title_pref_is_booted">Tự động kết nối khi khởi động</string>
+    <string name="summary_pref_is_booted">Tự động kết nối với máy chủ đã chọn khi khởi động; thao tác này có thể không thành công</string>
 
 
     <string name="subscription_updater_job_tips">Tác vụ sẽ chạy trong nền và thông tin tiến độ sẽ hiển thị trong thông báo.</string>
     <string name="title_pref_auto_test_after_update_subscription">Tự động kiểm tra sau khi cập nhật đăng ký</string>
     <string name="summary_pref_auto_test_after_update_subscription">Quá trình kiểm tra tự động mất nhiều thời gian. Nếu bật, tác vụ sẽ chạy trong nền; nếu không, tác vụ sẽ chạy trên trang hiện tại.</string>
-    <string name="title_pref_auto_remove_invalid_after_test">Auto delete invalid config after testing</string>
-    <string name="summary_pref_auto_remove_invalid_after_test">Test results may not be accurate; deleted config cannot be recovered.</string>
-    <string name="title_pref_auto_sort_after_test">Auto sort after testing</string>
-    <string name="summary_pref_auto_sort_after_test">Test results may not be accurate;</string>
+    <string name="title_pref_auto_remove_invalid_after_test">Tự động xóa cấu hình không hợp lệ sau khi kiểm tra</string>
+    <string name="summary_pref_auto_remove_invalid_after_test">Kết quả kiểm tra có thể không chính xác; cấu hình đã xóa không thể khôi phục.</string>
+    <string name="title_pref_auto_sort_after_test">Tự động sắp xếp sau khi kiểm tra</string>
+    <string name="summary_pref_auto_sort_after_test">Kết quả kiểm tra có thể không chính xác;</string>
 
     <string name="title_mux_settings">Cài đặt Mux</string>
     <string name="title_pref_mux_enabled">Bật Mux</string>
@@ -202,7 +202,7 @@
     <string name="title_pref_route_only_enabled">Bật RouteOnly</string>
     <string name="summary_pref_route_only_enabled">Chỉ sử dụng tên miền được đánh dấu để định tuyến và giữ địa chỉ đích làm địa chỉ IP.</string>
 
-    <string name="title_pref_local_dns_enabled">Bật Local DNS</string>
+    <string name="title_pref_local_dns_enabled">Bật DNS cục bộ</string>
     <string name="summary_pref_local_dns_enabled">DNS được xử lý bởi module DNS của Xray-Core (Dùng nếu cần định tuyến Bypass cho mạng LAN và Địa chỉ nội địa).</string>
 
     <string name="title_pref_fake_dns_enabled">Bật FakeDNS</string>
@@ -218,58 +218,58 @@
     <string name="summary_pref_remote_dns">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (Chỉ IPv4 / IPv6)</string>
-    <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
+    <string name="title_pref_vpn_bypass_lan">VPN có bỏ qua LAN không</string>
 
-    <string name="title_pref_vpn_interface_address">VPN Interface Address</string>
+    <string name="title_pref_vpn_interface_address">Địa chỉ giao diện VPN</string>
 
-    <string name="title_pref_vpn_mtu">VPN MTU (default 1500)</string>
+    <string name="title_pref_vpn_mtu">VPN MTU (mặc định 1500)</string>
 
 
     <string name="title_pref_domestic_dns">DNS nội địa (Không bắt buộc)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
 
-    <string name="title_pref_dns_hosts">DNS hosts (Format: domain:address,…)</string>
+    <string name="title_pref_dns_hosts">DNS hosts (Định dạng: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">URL kiểm tra độ trễ thực </string>
     <string name="summary_pref_delay_test_url">URL</string>
     <string name="title_pref_real_ping_concurrency">Số luồng kiểm tra độ trễ thực</string>
 
-    <string name="title_pref_ip_api_url">Current connection info test url</string>
-    <string name="summary_pref_ip_api_url">Url</string>
+    <string name="title_pref_ip_api_url">URL kiểm tra thông tin kết nối hiện tại</string>
+    <string name="summary_pref_ip_api_url">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">Cho phép kết nối từ mạng LAN</string>
     <string name="summary_pref_proxy_sharing_enabled">Các thiết bị khác trong cùng mạng LAN có thể kết nối đến SOCKS / HTTP proxy trên thiết bị của bạn. \nChỉ bật tính năng này trong các mạng đáng tin cậy để tránh kết nối trái phép.</string>
     <string name="toast_warning_pref_proxysharing_short">Đang bật cho phép kết nối từ mạng LAN</string>
 
-    <string name="title_pref_socks_port">Cổng Proxy Local</string>
+    <string name="title_pref_socks_port">Cổng proxy cục bộ</string>
     <string name="title_pref_enable_local_proxy">Bật proxy cục bộ</string>
-    <string name="summary_pref_enable_local_proxy">When disabled, no SOCKS proxy is available, so subscription updates and similar actions cannot use the proxy</string>
+    <string name="summary_pref_enable_local_proxy">Khi tắt, proxy SOCKS sẽ không khả dụng nên việc cập nhật đăng ký và các thao tác tương tự không thể dùng proxy</string>
     <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">Xác thực socks5 không hoàn toàn an toàn khi sử dụng UDP</string>
-    <string name="summary_pref_socks_port">Cổng Proxy Local</string>
-    <string name="title_pref_dynamic_socks_port">Enable dynamic local proxy port</string>
-    <string name="summary_pref_dynamic_socks_port">Generate a random local proxy port each time the inbound is created</string>
-    <string name="title_pref_socks_username">Tên người dùng Proxy Local (Không bắt buộc)</string>
+    <string name="summary_pref_socks_port">Cổng proxy cục bộ</string>
+    <string name="title_pref_dynamic_socks_port">Bật cổng proxy cục bộ động</string>
+    <string name="summary_pref_dynamic_socks_port">Tạo một cổng proxy cục bộ ngẫu nhiên mỗi khi inbound được tạo</string>
+    <string name="title_pref_socks_username">Tên người dùng proxy cục bộ (Không bắt buộc)</string>
     <string name="summary_pref_socks_username">Tên người dùng</string>
-    <string name="title_pref_socks_password">Mật khẩu Proxy Local (Không bắt buộc)</string>
+    <string name="title_pref_socks_password">Mật khẩu proxy cục bộ (Không bắt buộc)</string>
     <string name="summary_pref_socks_password">Mật khẩu</string>
 
-    <string name="title_pref_local_dns_port">Cổng Local DNS</string>
-    <string name="summary_pref_local_dns_port">Cổng Local DNS</string>
+    <string name="title_pref_local_dns_port">Cổng DNS cục bộ</string>
+    <string name="summary_pref_local_dns_port">Cổng DNS cục bộ</string>
 
     <string name="title_pref_confirm_remove">Xác nhận xóa tệp cấu hình</string>
     <string name="summary_pref_confirm_remove">Yêu cầu xác nhận từ người dùng khi thực hiện xóa tệp cấu hình.</string>
 
 
-    <string name="title_pref_append_http_proxy">Append HTTP Proxy to VPN</string>
-    <string name="summary_pref_append_http_proxy">HTTP proxy will be used directly from (browser/ some supported apps), without going through the virtual NIC device (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">Thêm proxy HTTP vào VPN</string>
+    <string name="summary_pref_append_http_proxy">Proxy HTTP sẽ được trình duyệt hoặc một số ứng dụng hỗ trợ dùng trực tiếp mà không đi qua thiết bị NIC ảo (Android 10+)</string>
 
-    <string name="title_pref_double_column_display">Enable double column display</string>
-    <string name="summary_pref_double_column_display">The profile list is displayed in double columns, allowing more content to be displayed on the screen.</string>
+    <string name="title_pref_double_column_display">Bật hiển thị hai cột</string>
+    <string name="summary_pref_double_column_display">Danh sách hồ sơ được hiển thị thành hai cột để màn hình chứa được nhiều nội dung hơn.</string>
 
-    <string name="title_pref_group_all_display">Enable show all groups</string>
-    <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+    <string name="title_pref_group_all_display">Hiển thị tất cả nhóm</string>
+    <string name="summary_pref_group_all_display">Thêm một trang "Tất cả thẻ"</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">Phản hồi lỗi</string>
@@ -280,7 +280,7 @@
     <string name="title_qr_code">Mã QR</string>
     <string name="title_about">Giới thiệu</string>
     <string name="title_source_code">Mã nguồn</string>
-    <string name="title_oss_license">Open Source licenses</string>
+    <string name="title_oss_license">Giấy phép mã nguồn mở</string>
     <string name="title_tg_channel">Kênh Telegram</string>
 
     <string name="title_pref_promotion">Quảng bá server</string>
@@ -290,16 +290,16 @@
     <string name="title_pref_auto_update_interval">Thời gian cập nhật tự động (Phút, giá trị tối thiểu là 15)</string>
 
     <string name="title_core_loglevel">Cấp độ nhật ký</string>
-    <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
+    <string name="title_outbound_domain_resolve_method">Phương thức phân giải trước tên miền outbound</string>
     <string name="title_mode">Chế độ kết nối</string>
     <string name="title_mode_help">Nhấn vào đây nếu bạn cần trợ giúp!</string>
     <string name="title_language">Ngôn ngữ</string>
     <string name="title_ui_settings">Cài đặt UI</string>
     <string name="title_pref_ui_mode_night">Cài đặt chế độ UI</string>
-    <string name="title_pref_use_hev_tunnel">Enable Hev TUN Feature</string>
-    <string name="summary_pref_use_hev_tunnel">When enabled, TUN will use hev-socks5-tunnel; otherwise, it will use xray-core.</string>
-    <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
-    <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
+    <string name="title_pref_use_hev_tunnel">Bật tính năng Hev TUN</string>
+    <string name="summary_pref_use_hev_tunnel">Khi bật, TUN sẽ dùng hev-socks5-tunnel; nếu không, TUN sẽ dùng xray-core.</string>
+    <string name="title_pref_hev_tunnel_loglevel">Mức nhật ký Hev TUN</string>
+    <string name="title_pref_hev_tunnel_rw_timeout">Thời gian chờ đọc/ghi của Hev TUN (giây) (tcp, udp mặc định 300, 60)</string>
     <string name="title_mode_settings">Cài đặt chế độ</string>
     <string name="title_root_mode_enabled">Bật chế độ Root (dành cho người dùng Root)</string>
     <string name="summary_root_mode_enabled">Bật proxy trong suốt cấp thấp bằng quyền Root. Chế độ này bỏ qua VPN hệ thống tiêu chuẩn của Android để trực tiếp tiếp quản toàn bộ lưu lượng mạng bên dưới. Sau khi bật, chế độ thông thường trước đây, định tuyến theo ứng dụng và các cài đặt VPN liên quan sẽ hoàn toàn mất hiệu lực.</string>
@@ -321,32 +321,32 @@
     <string name="sub_setting_url">URL gói đăng ký</string>
     <string name="sub_setting_user_agent">User Agent</string>
     <string name="sub_setting_request_headers">Tiêu đề yêu cầu (định dạng JSON)</string>
-    <string name="sub_setting_filter">Remarks regular filter</string>
+    <string name="sub_setting_filter">Bộ lọc biểu thức chính quy cho tên ghi chú</string>
     <string name="sub_setting_enable">Sử dụng gói đăng ký này</string>
     <string name="sub_auto_update">Bật tự động cập nhật</string>
-    <string name="sub_allow_insecure_url">Allow insecure HTTP address</string>
-    <string name="sub_setting_pre_profile">Previous proxy configuration remarks</string>
-    <string name="sub_setting_next_profile">Next proxy configuration remarks</string>
-    <string name="sub_setting_pre_profile_tip">The configuration remarks exists and is unique</string>
+    <string name="sub_allow_insecure_url">Cho phép địa chỉ HTTP không an toàn</string>
+    <string name="sub_setting_pre_profile">Tên ghi chú của cấu hình proxy trước đó</string>
+    <string name="sub_setting_next_profile">Tên ghi chú của cấu hình proxy tiếp theo</string>
+    <string name="sub_setting_pre_profile_tip">Tên ghi chú của cấu hình phải tồn tại và là duy nhất</string>
     <string name="toast_invalid_update_interval">Khoảng thời gian cập nhật không hợp lệ. Giá trị tối thiểu là 15 phút.</string>
     <string name="title_sub_update">Cập nhật các gói đăng ký</string>
     <string name="title_ping_all_server">Ping tất cả máy chủ</string>
     <string name="title_real_ping_all_server">Kiểm tra HTTP tất cả máy chủ</string>
-    <string name="title_user_asset_setting">Asset files</string>
+    <string name="title_user_asset_setting">Tệp tài nguyên</string>
     <string name="title_sort_by_test_results">Sắp xếp lại theo lần kiểm tra cuối cùng</string>
     <string name="title_filter_config">Lọc cấu hình theo các gói đăng ký</string>
-    <string name="filter_config_all">All</string>
-    <string name="summary_scan_qrcode">Click screen open the camera scan</string>
+    <string name="filter_config_all">Tất cả</string>
+    <string name="summary_scan_qrcode">Chạm vào màn hình để mở camera và quét</string>
     <string name="title_del_duplicate_config_count">Xoá %d cấu hình trùng lặp</string>
-    <string name="title_del_config_count">Delete %d configurations</string>
-    <string name="title_import_config_count">Import %d configurations</string>
-    <string name="title_export_config_count">Export %d configurations</string>
-    <string name="title_update_config_count">Update %d configurations</string>
-    <string name="title_update_subscription_result">Updated %1$d configs (%2$d success, %3$d failed, %4$d skipped)</string>
-    <string name="title_update_subscription_no_subscription">No subscriptions</string>
-    <string name="toast_server_not_found_in_group">Selected server not found in current group</string>
-    <string name="toast_fragment_not_available">Unable to locate current view</string>
-    <string name="title_locate_selected_config">Locate the selected config</string>
+    <string name="title_del_config_count">Xóa %d cấu hình</string>
+    <string name="title_import_config_count">Nhập %d cấu hình</string>
+    <string name="title_export_config_count">Xuất %d cấu hình</string>
+    <string name="title_update_config_count">Cập nhật %d cấu hình</string>
+    <string name="title_update_subscription_result">Đã cập nhật %1$d cấu hình (%2$d thành công, %3$d thất bại, %4$d bỏ qua)</string>
+    <string name="title_update_subscription_no_subscription">Không có đăng ký</string>
+    <string name="toast_server_not_found_in_group">Không tìm thấy máy chủ đã chọn trong nhóm hiện tại</string>
+    <string name="toast_fragment_not_available">Không thể xác định màn hình hiện tại</string>
+    <string name="title_locate_selected_config">Tìm cấu hình đã chọn</string>
 
     <string name="tasker_start_service">Khởi động v2rayNG</string>
     <string name="tasker_setting_confirm">Xác nhận</string>
@@ -357,14 +357,14 @@
     <string name="routing_settings_tips">Phân cách bằng dấu phẩy (,). Chọn một trong: domain, ip hoặc process</string>
     <string name="routing_settings_save">Lưu lại</string>
     <string name="routing_settings_delete">Xoá</string>
-    <string name="routing_settings_rule_title">Routing Rule Settings</string>
-    <string name="routing_settings_add_rule">Add rule</string>
+    <string name="routing_settings_rule_title">Cài đặt quy tắc định tuyến</string>
+    <string name="routing_settings_add_rule">Thêm quy tắc</string>
     <string name="routing_settings_import_predefined_rulesets">Nhập các bộ quy tắc được xác định trước</string>
-    <string name="routing_settings_import_rulesets_tip">Existing rulesets will be deleted, are you sure to continue?</string>
-    <string name="routing_settings_import_rulesets_from_clipboard">Import ruleset from clipboard</string>
+    <string name="routing_settings_import_rulesets_tip">Các bộ quy tắc hiện có sẽ bị xóa. Bạn có chắc muốn tiếp tục không?</string>
+    <string name="routing_settings_import_rulesets_from_clipboard">Nhập bộ quy tắc từ bảng nhớ tạm</string>
     <string name="routing_settings_import_rulesets_from_qrcode">Nhập bộ quy tắc từ QRcode</string>
-    <string name="routing_settings_export_rulesets_to_clipboard">Export ruleset to clipboard</string>
-    <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
+    <string name="routing_settings_export_rulesets_to_clipboard">Xuất bộ quy tắc vào bảng nhớ tạm</string>
+    <string name="routing_settings_locked">Đã khóa; giữ quy tắc này khi nhập cài đặt sẵn</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
     <string name="routing_settings_process">process (tên gói — chỉ được hỗ trợ khi dùng Xray TUN, bật routeOnly và chạy Android 10+)</string>
@@ -378,7 +378,7 @@
 
     <string name="connection_test_pending">Kiểm tra kết nối</string>
     <string name="connection_test_testing">Đang kiểm tra kết nối mạng...</string>
-    <string name="connection_test_testing_count">Testing %d configurations…</string>
+    <string name="connection_test_testing_count">Đang kiểm tra %d cấu hình…</string>
     <string name="connection_test_available">Kiểm tra thành công: thời gian truy cập Google là %d ms</string>
     <string name="connection_test_error">Lỗi kết nối mạng, hãy thử đổi cấu hình hoặc kiểm tra lại! Mã lỗi: %s</string>
     <string name="connection_test_fail">Không có kết nối mạng!</string>
@@ -389,12 +389,12 @@
 
     <string name="import_subscription_success">Nhập gói đăng ký thành công!</string>
     <string name="import_subscription_failure">Nhập gói đăng ký không thành công!</string>
-    <string name="title_fragment_settings">Fragment Settings</string>
-    <string name="title_pref_fragment_packets">Fragment Packets</string>
-    <string name="title_pref_fragment_length">Fragment Length (min-max)</string>
-    <string name="title_pref_fragment_interval">Fragment Interval (min-max)</string>
-    <string name="title_pref_fragment_enabled">Enable Fragment</string>
-    <string name="title_pref_fragment_maxsplit">Fragment Max Split</string>
+    <string name="title_fragment_settings">Cài đặt phân mảnh</string>
+    <string name="title_pref_fragment_packets">Gói tin cần phân mảnh</string>
+    <string name="title_pref_fragment_length">Độ dài phân mảnh (tối thiểu-tối đa)</string>
+    <string name="title_pref_fragment_interval">Khoảng phân mảnh (tối thiểu-tối đa)</string>
+    <string name="title_pref_fragment_enabled">Bật phân mảnh</string>
+    <string name="title_pref_fragment_maxsplit">Số lần chia nhỏ tối đa</string>
     <string name="title_observatory_settings">Cài đặt giám sát kết nối</string>
     <string name="title_pref_observatory_least_ping_interval">Khoảng thời gian leastPing</string>
     <string name="title_pref_observatory_least_load_interval">Khoảng thời gian leastLoad</string>
@@ -404,37 +404,37 @@
     <string name="toast_invalid_observatory_duration">Khoảng thời gian không hợp lệ. Dùng giá trị như 3m hoặc 30s.</string>
     <string name="toast_invalid_observatory_sampling">Lấy mẫu không hợp lệ. Dùng một số dương.</string>
 
-    <string name="update_check_for_update">Check for update</string>
-    <string name="update_already_latest_version">Already on the latest version</string>
-    <string name="update_new_version_found">New version found: %s</string>
-    <string name="update_now">Update now</string>
-    <string name="update_check_pre_release">Check Pre-release</string>
-    <string name="update_checking_for_update">Checking for update…</string>
+    <string name="update_check_for_update">Kiểm tra bản cập nhật</string>
+    <string name="update_already_latest_version">Đã dùng phiên bản mới nhất</string>
+    <string name="update_new_version_found">Đã tìm thấy phiên bản mới: %s</string>
+    <string name="update_now">Cập nhật ngay</string>
+    <string name="update_check_pre_release">Kiểm tra bản phát hành thử</string>
+    <string name="update_checking_for_update">Đang kiểm tra bản cập nhật…</string>
 
-    <string name="title_policy_group_type">Policy group type</string>
-    <string name="title_policy_group_subscription_id">From subscription group</string>
-    <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
+    <string name="title_policy_group_type">Loại nhóm chính sách</string>
+    <string name="title_policy_group_subscription_id">Từ nhóm đăng ký</string>
+    <string name="title_policy_group_subscription_filter">Bộ lọc biểu thức chính quy cho tên ghi chú</string>
     <string name="title_policy_group_test_outbounds">Kiểm tra outbound</string>
     <string name="title_policy_group_fallback">Outbound dự phòng (tùy chọn)</string>
 
-    <string name="server_proxy_chain_members">Proxy chain members</string>
-    <string name="server_proxy_chain_pick_members">Tap here to pick member</string>
-    <string name="server_proxy_chain_member_unselected">Select a member</string>
-    <string name="server_proxy_chain_members_unselected">Please select member for each chain row</string>
-    <string name="server_proxy_chain_members_insufficient">Insufficient members</string>
-    <string name="server_proxy_chain_members_invalid">Invalid chain members: %1$s</string>
+    <string name="server_proxy_chain_members">Thành viên chuỗi proxy</string>
+    <string name="server_proxy_chain_pick_members">Chạm vào đây để chọn thành viên</string>
+    <string name="server_proxy_chain_member_unselected">Chọn một thành viên</string>
+    <string name="server_proxy_chain_members_unselected">Vui lòng chọn thành viên cho từng hàng trong chuỗi</string>
+    <string name="server_proxy_chain_members_insufficient">Không đủ thành viên</string>
+    <string name="server_proxy_chain_members_invalid">Thành viên chuỗi không hợp lệ: %1$s</string>
 
     <!-- BackupActivity -->
-    <string name="title_configuration_backup_restore">Backup &amp; Restore</string>
+    <string name="title_configuration_backup_restore">Sao lưu &amp; khôi phục</string>
     <string name="title_configuration_backup">Sao lưu cấu hình</string>
     <string name="title_configuration_restore">Khôi phục cấu hình</string>
     <string name="title_configuration_share">Chia sẻ cấu hình</string>
-    <string name="title_webdav_config_setting">WebDAV Settings</string>
-    <string name="title_webdav_config_setting_unknown">Please configure WebDAV first.</string>
-    <string name="title_webdav_url">WebDAV server URL</string>
-    <string name="title_webdav_user">Username</string>
-    <string name="title_webdav_pass">Password</string>
-    <string name="title_webdav_remote_path">Remote directory (optional)</string>
+    <string name="title_webdav_config_setting">Cài đặt WebDAV</string>
+    <string name="title_webdav_config_setting_unknown">Vui lòng cấu hình WebDAV trước.</string>
+    <string name="title_webdav_url">URL máy chủ WebDAV</string>
+    <string name="title_webdav_user">Tên người dùng</string>
+    <string name="title_webdav_pass">Mật khẩu</string>
+    <string name="title_webdav_remote_path">Thư mục từ xa (không bắt buộc)</string>
 
     <string name="share_method_qrcode">Xuất ra mã QR (Chụp màn hình để lưu)</string>
     <string name="share_method_clipboard">Sao chép vào Clipboard</string>
@@ -470,25 +470,25 @@
     <string name="routing_preset_russia_whitelist">Danh sách trắng Nga</string>
 
     <string-array name="vpn_bypass_lan">
-        <item>Follow config</item>
-        <item>Bypass</item>
-        <item>Not Bypass</item>
+        <item>Theo cấu hình</item>
+        <item>Bỏ qua</item>
+        <item>Không bỏ qua</item>
     </string-array>
 
     <string-array name="outbound_domain_resolve_method">
-        <item>Do not resolve</item>
-        <item>Resolve and add to DNS Hosts</item>
-        <item>Resolve and replace domain</item>
+        <item>Không phân giải</item>
+        <item>Phân giải và thêm vào DNS Hosts</item>
+        <item>Phân giải và thay thế tên miền</item>
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>Least Ping</item>
-        <item>Least Load</item>
-        <item>Random</item>
-        <item>Round Robin</item>
+        <item>Ping thấp nhất</item>
+        <item>Tải thấp nhất</item>
+        <item>Ngẫu nhiên</item>
+        <item>Lần lượt</item>
     </string-array>
 
-    <string name="backup_location_local">Local</string>
+    <string name="backup_location_local">Cục bộ</string>
     <string name="backup_location_webdav">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -79,7 +79,7 @@
     <string name="server_lab_stream_security">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
-    <string name="server_lab_allow_insecure">Bỏ qua xác minh chứng chỉ</string>
+    <string name="server_lab_allow_insecure">Bỏ qua xác minh chứng chỉ (allowInsecure)</string>
     <string name="server_lab_sni">SNI</string>
     <string name="server_lab_address3">Địa chỉ</string>
     <string name="server_lab_port3">Cổng</string>
@@ -88,7 +88,7 @@
     <string name="server_lab_id4">Mật khẩu (Không bắt buộc)</string>
     <string name="server_lab_security4">Tên người dùng (Không bắt buộc)</string>
     <string name="server_lab_encryption">Mã hóa</string>
-    <string name="server_lab_flow">Kiểm soát lưu lượng (Flow)</string>
+    <string name="server_lab_flow">Kiểm soát lưu lượng (flow)</string>
     <string name="server_lab_public_key">PublicKey</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">ShortId</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">Bật DNS cục bộ</string>
     <string name="summary_pref_local_dns_enabled">DNS được xử lý bởi module DNS của Xray-Core (Dùng nếu cần định tuyến Bypass cho mạng LAN và Địa chỉ nội địa).</string>
 
-    <string name="title_pref_fake_dns_enabled">Bật FakeDNS</string>
+    <string name="title_pref_fake_dns_enabled">Bật DNS giả (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">FakeDNS lấy tên miền mục tiêu bằng cách giả mạo DNS (Nhanh hơn, nhưng có thể không hoạt động cho một số ứng dụng).</string>
 
     <string name="title_pref_ipv6_enabled">Bật IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">Thời gian cập nhật tự động (Phút, giá trị tối thiểu là 15)</string>
 
     <string name="title_core_loglevel">Cấp độ nhật ký</string>
-    <string name="title_outbound_domain_resolve_method">Phương thức phân giải trước tên miền outbound</string>
+    <string name="title_outbound_domain_resolve_method">Phương thức phân giải trước tên miền đầu ra (outbound)</string>
     <string name="title_mode">Chế độ kết nối</string>
     <string name="title_mode_help">Nhấn vào đây nếu bạn cần trợ giúp!</string>
     <string name="title_language">Ngôn ngữ</string>
@@ -389,13 +389,13 @@
 
     <string name="import_subscription_success">Nhập gói đăng ký thành công!</string>
     <string name="import_subscription_failure">Nhập gói đăng ký không thành công!</string>
-    <string name="title_fragment_settings">Cài đặt phân mảnh</string>
+    <string name="title_fragment_settings">Cài đặt phân mảnh (Fragment)</string>
     <string name="title_pref_fragment_packets">Gói tin cần phân mảnh</string>
     <string name="title_pref_fragment_length">Độ dài phân mảnh (tối thiểu-tối đa)</string>
     <string name="title_pref_fragment_interval">Khoảng phân mảnh (tối thiểu-tối đa)</string>
     <string name="title_pref_fragment_enabled">Bật phân mảnh</string>
     <string name="title_pref_fragment_maxsplit">Số lần chia nhỏ tối đa</string>
-    <string name="title_observatory_settings">Cài đặt giám sát kết nối</string>
+    <string name="title_observatory_settings">Cài đặt giám sát kết nối (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">Khoảng thời gian leastPing</string>
     <string name="title_pref_observatory_least_load_interval">Khoảng thời gian leastLoad</string>
     <string name="title_pref_observatory_least_load_method">Phương thức HTTP leastLoad</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">Loại nhóm chính sách</string>
     <string name="title_policy_group_subscription_id">Từ nhóm đăng ký</string>
     <string name="title_policy_group_subscription_filter">Bộ lọc biểu thức chính quy cho tên ghi chú</string>
-    <string name="title_policy_group_test_outbounds">Kiểm tra outbound</string>
-    <string name="title_policy_group_fallback">Outbound dự phòng (tùy chọn)</string>
+    <string name="title_policy_group_test_outbounds">Kiểm tra kết nối đi (outbounds)</string>
+    <string name="title_policy_group_fallback">Kết nối đi dự phòng (outbound, tùy chọn)</string>
 
     <string name="server_proxy_chain_members">Thành viên chuỗi proxy</string>
     <string name="server_proxy_chain_pick_members">Chạm vào đây để chọn thành viên</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>Ping thấp nhất</item>
-        <item>Tải thấp nhất</item>
-        <item>Ngẫu nhiên</item>
-        <item>Lần lượt</item>
+        <item>Ping thấp nhất (leastPing)</item>
+        <item>Tải thấp nhất (leastLoad)</item>
+        <item>Ngẫu nhiên (random)</item>
+        <item>Lần lượt (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">Cục bộ</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -199,7 +199,7 @@
 
     <string name="title_pref_sniffing_enabled">Bật Sniffing</string>
     <string name="summary_pref_sniffing_enabled">Phát hiện tên miền từ lưu lượng truy cập (Được bật theo mặc định). \nỞ Việt Nam: tắt để sử dụng Zalo.</string>
-    <string name="title_pref_route_only_enabled">Bật RouteOnly</string>
+    <string name="title_pref_route_only_enabled">Bật routeOnly</string>
     <string name="summary_pref_route_only_enabled">Chỉ sử dụng tên miền được đánh dấu để định tuyến và giữ địa chỉ đích làm địa chỉ IP.</string>
 
     <string name="title_pref_local_dns_enabled">Bật DNS cục bộ</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -318,7 +318,7 @@
     <string name="title_export_all">导出配置至剪贴板</string>
     <string name="title_sub_setting">订阅分组设置</string>
     <string name="sub_setting_remarks">备注</string>
-    <string name="sub_setting_url">可选地址 (url)</string>
+    <string name="sub_setting_url">可选地址 (URL)</string>
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">请求头（JSON 格式）</string>
     <string name="sub_setting_filter">别名正则过滤</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">QUIC 加密密钥</string>
     <string name="server_lab_path_kcp">kcp seed</string>
     <string name="server_lab_path_grpc">gRPC serviceName</string>
-    <string name="server_lab_stream_security">传输层安全 (TLS)</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">跳过证书验证 (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">服务器地址</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">PreSharedKey (optional)</string>
     <string name="server_lab_short_id">ShortId</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved (可选，逗号隔开)</string>
     <string name="server_lab_local_address">本地地址 (可选 IPv4/IPv6，逗号隔开)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">XHTTP 模式</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra 原始 JSON，格式： { XHTTPObject }</string>
     <string name="server_lab_final_mask">FinalMask 原始 JSON 格式: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">EchConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">按名称验证对端证书</string>
     <string name="server_lab_pinned_ca256">证书指纹 (SHA-256)</string>
     <string name="server_lab_browser_dialer">启用 Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">添加文件</string>
     <string name="menu_item_add_url">添加链接</string>
     <string name="menu_item_scan_qrcode">扫描 QRcode</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">下载文件</string>
     <string name="title_user_asset_add_url">添加资产网址</string>
     <string name="msg_file_not_found">文件未找到</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">domain: address,…</string>
 
     <string name="title_pref_delay_test_url">真连接延迟测试网址 </string>
-    <string name="summary_pref_delay_test_url">URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">真连接延迟并发测试数</string>
 
     <string name="title_pref_ip_api_url">当前连接信息测试网址</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">允许来自局域网的连接</string>
     <string name="summary_pref_proxy_sharing_enabled">其他设备可以使用 socks/http 协议通过您的 IP 地址连接到代理, 仅在受信任的网络中启用以避免未经授权的连接</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">与局域网 / 热点设备共享 VPN (仅限 Root 用户)</string>
     <string name="summary_root_lan_sharing">将 Wi-Fi 热点和 USB 网络共享设备的流量通过 VPN 转发。</string>
 
-    <string name="title_logcat">Logcat</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">复制</string>
     <string name="logcat_clear">清除</string>
     <string name="logcat_share">分享日志</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">从 QRcode 导入规则集</string>
     <string name="routing_settings_export_rulesets_to_clipboard">导出规则集至剪贴板</string>
     <string name="routing_settings_locked">锁定中，导入预设时不删除此规则</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (包名 — 仅在使用 Xray TUN、开启 routeOnly 且 Android 10+ 时可用)</string>
     <string name="routing_settings_process_select">选择包名</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">"检查网络连接"</string>
     <string name="connection_test_testing">"测试中…"</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -126,7 +126,7 @@
     <string name="server_lab_xhttp_extra">XHTTP Extra 原始 JSON，格式： { XHTTPObject }</string>
     <string name="server_lab_final_mask">FinalMask 原始 JSON 格式: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
+    <string name="server_lab_verify_peer_cert_by_name">按名称验证对端证书</string>
     <string name="server_lab_pinned_ca256">证书指纹 (SHA-256)</string>
     <string name="server_lab_browser_dialer">启用 Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">仅支持 xhttp (packet-up) 和 ws。与优选域名冲突，utls, alpn, ech 等 TLS 设置将被忽略</string>
@@ -189,9 +189,9 @@
     <string name="title_pref_mux_xudp_concurrency">XUDP 复用子链接数（可填 -1 至 1024）</string>
     <string name="title_pref_mux_xudp_quic">QUIC 流量处理方式</string>
     <string-array name="mux_xudp_quic_entries">
-        <item>不代理</item>
-        <item>多路复用</item>
-        <item>原生</item>
+        <item>拒绝</item>
+        <item>允许</item>
+        <item>跳过</item>
     </string-array>
 
     <string name="title_pref_speed_enabled">启用速度显示</string>
@@ -232,7 +232,7 @@
     <string name="summary_pref_dns_hosts">domain: address,…</string>
 
     <string name="title_pref_delay_test_url">真连接延迟测试网址 </string>
-    <string name="summary_pref_delay_test_url">Url</string>
+    <string name="summary_pref_delay_test_url">URL</string>
     <string name="title_pref_real_ping_concurrency">真连接延迟测试并发数量</string>
 
     <string name="title_pref_ip_api_url">当前连接信息测试网址</string>
@@ -280,7 +280,7 @@
     <string name="title_qr_code">二维码</string>
     <string name="title_about">关于</string>
     <string name="title_source_code">源代码</string>
-    <string name="title_oss_license">Open Source licenses</string>
+    <string name="title_oss_license">开源许可证</string>
     <string name="title_tg_channel">Telegram 频道</string>
 
     <string name="title_pref_promotion">推广</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">无效的网址</string>
     <string name="toast_insecure_url_protocol">请不要使用不安全的 HTTP 协议订阅地址</string>
     <string name="server_lab_need_inbound">确保 inbounds port 和设置中的一致</string>
-    <string name="toast_malformed_json">配置格式错误</string>
+    <string name="toast_malformed_json">配置格式无效。</string>
     <string name="server_lab_request_host6">Host (SNI) (可选)</string>
     <string name="toast_action_not_allowed">禁止此项操作</string>
     <string name="server_obfs_password">混淆密码</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">启用 Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">仅支持 xhttp (packet-up) 和 ws。与优选域名冲突，utls, alpn, ech 等 TLS 设置将被忽略</string>
     <string name="toast_allow_insecure_deprecated">当前节点使用未加密连接，您的通信可能会被威权政府掌控的网络中间设施直接查看\n为了安全，此类节点无法通过 26.2.6+ 版本的 Xray 核心连接\n如果是自建节点请启用 TLS 等安全加密，或固定证书 pinnedCA256\n如果机场节点请联系服务商完成技术升级，如服务商拒绝配合，建议更换更重视用户安全的服务商\n更多的信息，请访问 https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">获取并填充指纹证书</string>
+    <string name="pinned_ca256_action_fetch">获取证书指纹</string>
     <string name="toast_fetch_cert_sha256_success">获取指纹证书完成</string>
     <string name="toast_fetch_cert_sha256_failed">获取证书指纹失败</string>
 
@@ -185,8 +185,8 @@
     <string name="title_mux_settings">Mux 多路复用 设置</string>
     <string name="title_pref_mux_enabled">启用 Mux 多路复用</string>
     <string name="summary_pref_mux_enabled">减低延时，但可能会断流，建议不要启用。\nTCP，UDP 及 QUIC 流量处理方式下方可选。</string>
-    <string name="title_pref_mux_concurrency">TCP 复用子链接数（可填 -1 至 1024）</string>
-    <string name="title_pref_mux_xudp_concurrency">XUDP 复用子链接数（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_concurrency">TCP 复用子连接数（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP 复用子连接数（可填 -1 至 1024）</string>
     <string name="title_pref_mux_xudp_quic">QUIC 流量处理方式</string>
     <string-array name="mux_xudp_quic_entries">
         <item>拒绝</item>
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">启用速度显示</string>
-    <string name="summary_pref_speed_enabled">在通知中显示当前速度\n小图标显示流量的路由情况</string>
+    <string name="summary_pref_speed_enabled">在通知中显示当前速度。\n图标指示代理流量或直连流量哪一方占主导。</string>
 
     <string name="title_pref_sniffing_enabled">启用流量探测 (Sniffing)</string>
-    <string name="summary_pref_sniffing_enabled">从流量中探测域名 (默认启用)</string>
+    <string name="summary_pref_sniffing_enabled">从流量中探测目标域名（默认启用）。</string>
     <string name="title_pref_route_only_enabled">启用 routeOnly</string>
     <string name="summary_pref_route_only_enabled">将嗅探得到的域名仅用于路由，代理目标地址仍为 IP</string>
 
     <string name="title_pref_local_dns_enabled">启用本地 DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS 请求导入 core 由 DNS 模块处理（推荐启用 如果需要路由绕过局域网及大陆地址)</string>
 
-    <string name="title_pref_fake_dns_enabled">启用虚拟 DNS (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">本地返回虚构解析结果 (减低延时 但个别应用可能无法使用)</string>
+    <string name="title_pref_fake_dns_enabled">启用伪造 DNS (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">FakeDNS 在解析域名时返回虚构的 IP 地址（速度更快，但可能不适用于某些应用）。</string>
 
     <string name="title_pref_ipv6_enabled">启用 IPv6</string>
     <string name="summary_pref_ipv6_enabled">为 VPN 接口添加 IPv6 地址和路由</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">真连接延迟测试网址 </string>
     <string name="summary_pref_delay_test_url">URL</string>
-    <string name="title_pref_real_ping_concurrency">真连接延迟测试并发数量</string>
+    <string name="title_pref_real_ping_concurrency">真连接延迟并发测试数</string>
 
     <string name="title_pref_ip_api_url">当前连接信息测试网址</string>
     <string name="summary_pref_ip_api_url">URL</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">删除配置是否需要用户二次确认</string>
 
 
-    <string name="title_pref_append_http_proxy">追加 HTTP 代理至 VPN</string>
-    <string name="summary_pref_append_http_proxy">浏览器 / 一些支持的应用 将直接使用 HTTP 代理, 而不经过虚拟网卡设备 (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">将 HTTP 代理添加到 VPN</string>
+    <string name="summary_pref_append_http_proxy">浏览器和部分受支持的应用将直接使用 HTTP 代理，而不经过虚拟网卡（Android 10+）。</string>
 
     <string name="title_pref_double_column_display">启用双列显示</string>
     <string name="summary_pref_double_column_display">配置列表以双列显示，允许在屏幕上显示更多内容。</string>
 
-    <string name="title_pref_group_all_display">启用显示所有组</string>
-    <string name="summary_pref_group_all_display">添加一个额外的“所有选项卡”页面</string>
+    <string name="title_pref_group_all_display">显示“全部”组标签页</string>
+    <string name="summary_pref_group_all_display">在一个标签页中汇总所有订阅组的配置。</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">反馈</string>
@@ -302,10 +302,10 @@
     <string name="title_pref_hev_tunnel_rw_timeout">HevTun 读写超时(秒) (tcp,udp 默认 300,60)</string>
     <string name="title_mode_settings">模式设置</string>
     <string name="title_root_mode_enabled">启用 Root 模式 (仅限 Root 用户)</string>
-    <string name="summary_root_mode_enabled">通过 Root 权限启用底层透明代理。此模式将不再通过 Android 常规系统 VPN 建立连接，而是直接接管系统底层所有网络流量。开启后，原有的常规模式、应用分流及相关 VPN 设置将直接失效。</string>
+    <string name="summary_root_mode_enabled">使用 Root 权限实现底层透明代理。Root 模式不使用 Android 的 VPN 服务，而是直接处理网络流量。启用期间，常规模式、应用分流及相关 VPN 设置不会生效。</string>
     <string name="toast_root_required">此功能需要 Root 权限</string>
-    <string name="title_root_lan_sharing">局域网 / 热点网络共享 (仅限 Root 用户)</string>
-    <string name="summary_root_lan_sharing">允许通过 Wi-Fi 热点和 USB 共享网络连接的设备走 VPN 代理流量</string>
+    <string name="title_root_lan_sharing">与局域网 / 热点设备共享 VPN (仅限 Root 用户)</string>
+    <string name="summary_root_lan_sharing">将 Wi-Fi 热点和 USB 网络共享设备的流量通过 VPN 转发。</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">复制</string>
@@ -345,7 +345,7 @@
     <string name="title_update_subscription_result">更新了 %1$d 个配置（%2$d 个成功，%3$d 个失败，%4$d 个跳过）</string>
     <string name="title_update_subscription_no_subscription">无订阅</string>
     <string name="toast_server_not_found_in_group">当前分组中未找到选中的服务器</string>
-    <string name="toast_fragment_not_available">无法定位当前视图</string>
+    <string name="toast_fragment_not_available">当前页面不可用。</string>
     <string name="title_locate_selected_config">定位所选配置</string>
 
     <string name="tasker_start_service">启动服务</string>
@@ -385,7 +385,7 @@
     <string name="connection_test_error_status_code">"状态码无效（#%d）"</string>
     <string name="connection_connected">"已连接，点击测试连接"</string>
     <string name="connection_not_connected">"未连接"</string>
-    <string name="connection_running_task_left">运行中的测试任务数：%s</string>
+    <string name="connection_running_task_left">正在运行的测试：%s</string>
 
     <string name="import_subscription_success">订阅导入成功</string>
     <string name="import_subscription_failure">导入订阅失败</string>
@@ -413,7 +413,7 @@
 
     <string name="title_policy_group_type">策略组类型</string>
     <string name="title_policy_group_subscription_id">来自订阅分组</string>
-    <string name="title_policy_group_subscription_filter">别名正则过滤</string>
+    <string name="title_policy_group_subscription_filter">备注正则筛选</string>
     <string name="title_policy_group_test_outbounds">测试出站 (outbounds)</string>
     <string name="title_policy_group_fallback">备用出站 (outbound，可选)</string>
 

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -197,7 +197,7 @@
     <string name="title_pref_speed_enabled">启用速度显示</string>
     <string name="summary_pref_speed_enabled">在通知中显示当前速度\n小图标显示流量的路由情况</string>
 
-    <string name="title_pref_sniffing_enabled">启用流量探测</string>
+    <string name="title_pref_sniffing_enabled">启用流量探测 (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">从流量中探测域名 (默认启用)</string>
     <string name="title_pref_route_only_enabled">启用 routeOnly</string>
     <string name="summary_pref_route_only_enabled">将嗅探得到的域名仅用于路由，代理目标地址仍为 IP</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">启用本地 DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS 请求导入 core 由 DNS 模块处理（推荐启用 如果需要路由绕过局域网及大陆地址)</string>
 
-    <string name="title_pref_fake_dns_enabled">启用虚拟 DNS</string>
+    <string name="title_pref_fake_dns_enabled">启用虚拟 DNS (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">本地返回虚构解析结果 (减低延时 但个别应用可能无法使用)</string>
 
     <string name="title_pref_ipv6_enabled">启用 IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">自动更新间隔（分钟，最小值 15）</string>
 
     <string name="title_core_loglevel">日志级别</string>
-    <string name="title_outbound_domain_resolve_method">Outbound 域名预解析方式</string>
+    <string name="title_outbound_domain_resolve_method">出站域名预解析方式 (outbound)</string>
     <string name="title_mode">模式</string>
     <string name="title_mode_help">点此查看更多帮助</string>
     <string name="title_language">语言</string>
@@ -395,7 +395,7 @@
     <string name="title_pref_fragment_interval">分片间隔（最小 - 最大）</string>
     <string name="title_pref_fragment_enabled">启用分片（Fragment）</string>
     <string name="title_pref_fragment_maxsplit">分片最大分割数</string>
-    <string name="title_observatory_settings">连接观测设置</string>
+    <string name="title_observatory_settings">连接观测设置 (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">leastPing 探测间隔</string>
     <string name="title_pref_observatory_least_load_interval">leastLoad 探测间隔</string>
     <string name="title_pref_observatory_least_load_method">leastLoad HTTP 方法</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">策略组类型</string>
     <string name="title_policy_group_subscription_id">来自订阅分组</string>
     <string name="title_policy_group_subscription_filter">别名正则过滤</string>
-    <string name="title_policy_group_test_outbounds">测试出站</string>
-    <string name="title_policy_group_fallback">备用出站（可选）</string>
+    <string name="title_policy_group_test_outbounds">测试出站 (outbounds)</string>
+    <string name="title_policy_group_fallback">备用出站 (outbound，可选)</string>
 
     <string name="server_proxy_chain_members">代理链成员</string>
     <string name="server_proxy_chain_pick_members">点此选择成员</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>最低延迟</item>
-        <item>最稳定</item>
-        <item>随机选择</item>
-        <item>轮询</item>
+        <item>最低延迟 (leastPing)</item>
+        <item>最低负载 (leastLoad)</item>
+        <item>随机选择 (random)</item>
+        <item>轮询 (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">本地</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">跳过证书验证 (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">服务器地址</string>
     <string name="server_lab_port3">服务器端口</string>
     <string name="server_lab_id3">密码</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">PublicKey</string>
     <string name="server_lab_preshared_key">PreSharedKey (optional)</string>
     <string name="server_lab_short_id">ShortId</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved (可选，逗号隔开)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">解析域名时优先使用 IPv6 地址</string>
 
     <string name="title_pref_remote_dns">远程 DNS (udp/tcp/https/quic)(可选)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (仅支持 IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">VPN 是否绕过局域网</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">境内 DNS (可选)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS hosts (格式: 域名: 地址,…)</string>
     <string name="summary_pref_dns_hosts">domain: address,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">本地代理端口</string>
     <string name="title_pref_enable_local_proxy">启用本地代理</string>
     <string name="summary_pref_enable_local_proxy">不开启时没有 socks 代理，无法通过代理更新订阅等</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">使用 UDP 时，socks5 认证并不完全安全</string>
     <string name="summary_pref_socks_port">本地代理端口</string>
     <string name="title_pref_dynamic_socks_port">启用动态本地代理端口</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">订阅分组设置</string>
     <string name="sub_setting_remarks">备注</string>
     <string name="sub_setting_url">可选地址 (url)</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">请求头（JSON 格式）</string>
     <string name="sub_setting_filter">别名正则过滤</string>
     <string name="sub_setting_enable">启用更新</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">更新了 %1$d 个配置（%2$d 个成功，%3$d 个失败，%4$d 个跳过）</string>
     <string name="title_update_subscription_no_subscription">无订阅</string>
     <string name="toast_server_not_found_in_group">当前分组中未找到选中的服务器</string>
-    <string name="toast_fragment_not_available">当前页面不可用。</string>
     <string name="title_locate_selected_config">定位所选配置</string>
 
     <string name="tasker_start_service">启动服务</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">选择包名</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">"检查网络连接"</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">本地</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">开关</string>
     <string name="app_tile_name">开关</string>
     <string name="app_tile_first_use">初次使用此功能请先用 APP 添加配置</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">无效的网址</string>
     <string name="toast_insecure_url_protocol">请不要使用不安全的 HTTP 协议订阅地址</string>
     <string name="server_lab_need_inbound">确保 inbounds port 和设置中的一致</string>
-    <string name="toast_malformed_josn">配置格式错误</string>
+    <string name="toast_malformed_json">配置格式错误</string>
     <string name="server_lab_request_host6">Host (SNI) (可选)</string>
     <string name="toast_action_not_allowed">禁止此项操作</string>
     <string name="server_obfs_password">混淆密码</string>
@@ -127,7 +128,7 @@
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">证书指纹 (SHA-256)</string>
-    <string name="server_lab_browser_dialer">启用浏览器转发</string>
+    <string name="server_lab_browser_dialer">启用 Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">仅支持 xhttp (packet-up) 和 ws。与优选域名冲突，utls, alpn, ech 等 TLS 设置将被忽略</string>
     <string name="toast_allow_insecure_deprecated">当前节点使用未加密连接，您的通信可能会被威权政府掌控的网络中间设施直接查看\n为了安全，此类节点无法通过 26.2.6+ 版本的 Xray 核心连接\n如果是自建节点请启用 TLS 等安全加密，或固定证书 pinnedCA256\n如果机场节点请联系服务商完成技术升级，如服务商拒绝配合，建议更换更重视用户安全的服务商\n更多的信息，请访问 https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">获取并填充指纹证书</string>
@@ -136,7 +137,9 @@
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">失败, 请使用文件管理器</string>
+    <string name="menu_item_add_asset">添加</string>
     <string name="menu_item_add_file">添加文件</string>
+    <string name="menu_item_add_url">添加链接</string>
     <string name="menu_item_scan_qrcode">扫描 QRcode</string>
     <string name="title_url">URL</string>
     <string name="menu_item_download_file">下载文件</string>
@@ -158,6 +161,7 @@
     <string name="menu_item_import_proxy_app">从剪贴板导入</string>
     <string name="per_app_proxy_settings">分应用设置</string>
     <string name="per_app_proxy_settings_enable">启用分应用</string>
+    <string name="app_picker_unknown_app">未知应用（无法识别 UID）</string>
 
     <!-- Preferences -->
     <string name="title_settings">设置</string>
@@ -168,6 +172,7 @@
     <string name="summary_pref_per_app_proxy">常规: 勾选的 App 被代理, 未勾选的直连;\n绕行模式: 勾选的 App 直连, 未勾选的被代理.\n不明白者在菜单中选择自动选中需代理应用</string>
     <string name="title_pref_is_booted">开机时自动连接</string>
     <string name="summary_pref_is_booted">开机时自动连接选择的服务器，可能会不成功</string>
+
 
     <string name="subscription_updater_job_tips">任务将在后台运行，在通知中会显示进度信息</string>
     <string name="title_pref_auto_test_after_update_subscription">更新订阅后自动测试</string>
@@ -180,8 +185,8 @@
     <string name="title_mux_settings">Mux 多路复用 设置</string>
     <string name="title_pref_mux_enabled">启用 Mux 多路复用</string>
     <string name="summary_pref_mux_enabled">减低延时，但可能会断流，建议不要启用。\nTCP，UDP 及 QUIC 流量处理方式下方可选。</string>
-    <string name="title_pref_mux_concurency">TCP 复用子链接数（可填 -1 至 1024）</string>
-    <string name="title_pref_mux_xudp_concurency">XUDP 复用子链接数（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_concurrency">TCP 复用子链接数（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP 复用子链接数（可填 -1 至 1024）</string>
     <string name="title_pref_mux_xudp_quic">QUIC 流量处理方式</string>
     <string-array name="mux_xudp_quic_entries">
         <item>不代理</item>
@@ -216,7 +221,9 @@
     <string name="title_pref_vpn_bypass_lan">VPN 是否绕过局域网</string>
 
     <string name="title_pref_vpn_interface_address">VPN 接口地址</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (默认 1500)</string>
+
 
     <string name="title_pref_domestic_dns">境内 DNS (可选)</string>
     <string name="summary_pref_domestic_dns">DNS</string>
@@ -240,15 +247,15 @@
     <string name="summary_pref_enable_local_proxy">不开启时没有 socks 代理，无法通过代理更新订阅等</string>
     <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">使用 UDP 时，socks5 认证并不完全安全</string>
-     <string name="summary_pref_socks_port">本地代理端口</string>
-     <string name="title_pref_dynamic_socks_port">启用动态本地代理端口</string>
-     <string name="summary_pref_dynamic_socks_port">每次生成 inbound 时随机生成一个本地代理端口</string>
-     <string name="title_pref_socks_username">本地代理用户名 (可选)</string>
-     <string name="summary_pref_socks_username">用户名</string>
-     <string name="title_pref_socks_password">本地代理密码 (可选)</string>
-     <string name="summary_pref_socks_password">密码</string>
+    <string name="summary_pref_socks_port">本地代理端口</string>
+    <string name="title_pref_dynamic_socks_port">启用动态本地代理端口</string>
+    <string name="summary_pref_dynamic_socks_port">每次生成 inbound 时随机生成一个本地代理端口</string>
+    <string name="title_pref_socks_username">本地代理用户名 (可选)</string>
+    <string name="summary_pref_socks_username">用户名</string>
+    <string name="title_pref_socks_password">本地代理密码 (可选)</string>
+    <string name="summary_pref_socks_password">密码</string>
 
-     <string name="title_pref_local_dns_port">本地 DNS 端口</string>
+    <string name="title_pref_local_dns_port">本地 DNS 端口</string>
     <string name="summary_pref_local_dns_port">本地 DNS 端口</string>
 
     <string name="title_pref_confirm_remove">删除配置确认</string>
@@ -300,7 +307,6 @@
     <string name="title_root_lan_sharing">局域网 / 热点网络共享 (仅限 Root 用户)</string>
     <string name="summary_root_lan_sharing">允许通过 Wi-Fi 热点和 USB 共享网络连接的设备走 VPN 代理流量</string>
 
-
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">复制</string>
     <string name="logcat_clear">清除</string>
@@ -330,9 +336,8 @@
     <string name="title_sort_by_test_results">按测试结果排序</string>
     <string name="title_filter_config">过滤配置</string>
     <string name="filter_config_all">所有</string>
-    <string name="title_del_duplicate_config_count">删除 %d 个重复配置</string>
     <string name="summary_scan_qrcode">点击屏幕打开相机扫描</string>
-
+    <string name="title_del_duplicate_config_count">删除 %d 个重复配置</string>
     <string name="title_del_config_count">删除 %d 个配置</string>
     <string name="title_import_config_count">导入 %d 个配置</string>
     <string name="title_export_config_count">导出 %d 个配置</string>
@@ -362,12 +367,13 @@
     <string name="routing_settings_locked">锁定中，导入预设时不删除此规则</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
-    <string name="routing_settings_process">process (包名 — 仅在使用 Xray 的 TUN、开启 routeOnly 且 Android 10+ 时可用)</string>
+    <string name="routing_settings_process">process (包名 — 仅在使用 Xray TUN、开启 routeOnly 且 Android 10+ 时可用)</string>
     <string name="routing_settings_process_select">选择包名</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">"检查网络连接"</string>
@@ -379,12 +385,10 @@
     <string name="connection_test_error_status_code">"状态码无效（#%d）"</string>
     <string name="connection_connected">"已连接，点击测试连接"</string>
     <string name="connection_not_connected">"未连接"</string>
-    <string name="connection_runing_task_left">运行中的测试任务数：%s</string>
+    <string name="connection_running_task_left">运行中的测试任务数：%s</string>
 
     <string name="import_subscription_success">订阅导入成功</string>
     <string name="import_subscription_failure">导入订阅失败</string>
-    <string name="menu_item_add_asset">添加</string>
-    <string name="menu_item_add_url">添加链接</string>
     <string name="title_fragment_settings">分片（Fragment）设置</string>
     <string name="title_pref_fragment_packets">分片方式</string>
     <string name="title_pref_fragment_length">分片包长（最小 - 最大）</string>
@@ -412,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">别名正则过滤</string>
     <string name="title_policy_group_test_outbounds">测试出站</string>
     <string name="title_policy_group_fallback">备用出站（可选）</string>
+
     <string name="server_proxy_chain_members">代理链成员</string>
     <string name="server_proxy_chain_pick_members">点此选择成员</string>
     <string name="server_proxy_chain_member_unselected">请选择成员</string>
@@ -426,7 +431,7 @@
     <string name="title_configuration_share">分享配置</string>
     <string name="title_webdav_config_setting">WebDAV 设置</string>
     <string name="title_webdav_config_setting_unknown">请先设置 WebDAV</string>
-    <string name="title_webdav_url">WebDAV 服务器地址</string>WebDAV server address
+    <string name="title_webdav_url">WebDAV 服务器地址</string>
     <string name="title_webdav_user">用户名</string>
     <string name="title_webdav_pass">密码</string>
     <string name="title_webdav_remote_path">远程文件夹名（可选）</string>
@@ -444,6 +449,12 @@
     <string-array name="mode_entries">
         <item>VPN</item>
         <item>仅代理</item>
+    </string-array>
+
+    <string-array name="browser_dialer_mode">
+        <item>禁用</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
     </string-array>
 
     <string-array name="ui_mode_night">
@@ -469,6 +480,7 @@
         <item>解析后添加至 DNS Hosts</item>
         <item>解析后替换原域名</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>最低延迟</item>
         <item>最稳定</item>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -197,7 +197,7 @@
     <string name="title_pref_speed_enabled">啟用速度顯示</string>
     <string name="summary_pref_speed_enabled">在通知中顯示當前速度\n小圖示顯示流量的轉送狀況</string>
 
-    <string name="title_pref_sniffing_enabled">啟用流量監聽</string>
+    <string name="title_pref_sniffing_enabled">啟用流量監聽 (Sniffing)</string>
     <string name="summary_pref_sniffing_enabled">從流量中監聽網域 (預設啟用)</string>
     <string name="title_pref_route_only_enabled">啟用 routeOnly</string>
     <string name="summary_pref_route_only_enabled">將嗅探得到的網域只用於路由，代理目標位址仍為 IP</string>
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">啟用本機 DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS 請求匯入 core 由 DNS 模組處理 (建議啟用，如果需要轉送略過區域網路及中國大陸)</string>
 
-    <string name="title_pref_fake_dns_enabled">啟用假 DNS</string>
+    <string name="title_pref_fake_dns_enabled">啟用假 DNS (FakeDNS)</string>
     <string name="summary_pref_fake_dns_enabled">本機退回假解析結果 (減低延時，但個別應用可能無法使用)</string>
 
     <string name="title_pref_ipv6_enabled">啟用 IPv6</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">自動更新間隔（分鐘，最小值 15）</string>
 
     <string name="title_core_loglevel">記錄層級</string>
-    <string name="title_outbound_domain_resolve_method">出口網域預解析方式</string>
+    <string name="title_outbound_domain_resolve_method">出站網域預解析方式 (outbound)</string>
     <string name="title_mode">模式</string>
     <string name="title_mode_help">輕觸以檢視說明</string>
     <string name="title_language">語言</string>
@@ -395,7 +395,7 @@
     <string name="title_pref_fragment_interval">分片間隔（最小-最大）</string>
     <string name="title_pref_fragment_enabled">啟用分片（Fragment）</string>
     <string name="title_pref_fragment_maxsplit">分片最大分割數</string>
-    <string name="title_observatory_settings">連線觀測設定</string>
+    <string name="title_observatory_settings">連線觀測設定 (Observatory)</string>
     <string name="title_pref_observatory_least_ping_interval">leastPing 探測間隔</string>
     <string name="title_pref_observatory_least_load_interval">leastLoad 探測間隔</string>
     <string name="title_pref_observatory_least_load_method">leastLoad HTTP 方法</string>
@@ -414,8 +414,8 @@
     <string name="title_policy_group_type">策略群組類型</string>
     <string name="title_policy_group_subscription_id">來自訂閱分組</string>
     <string name="title_policy_group_subscription_filter">別名正規過濾</string>
-    <string name="title_policy_group_test_outbounds">測試出口</string>
-    <string name="title_policy_group_fallback">備用出口（選填）</string>
+    <string name="title_policy_group_test_outbounds">測試出站 (outbounds)</string>
+    <string name="title_policy_group_fallback">備用出站 (outbound，選填)</string>
 
     <string name="server_proxy_chain_members">代理鏈成員</string>
     <string name="server_proxy_chain_pick_members">點此選擇成員</string>
@@ -482,10 +482,10 @@
     </string-array>
 
     <string-array name="policy_group_type">
-        <item>最低延遲</item>
-        <item>最少卡頓</item>
-        <item>隨機選擇</item>
-        <item>輪詢</item>
+        <item>最低延遲 (leastPing)</item>
+        <item>最低負載 (leastLoad)</item>
+        <item>隨機選擇 (random)</item>
+        <item>輪詢 (roundRobin)</item>
     </string-array>
 
     <string name="backup_location_local">本地</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">跳過憑證驗證 (allowInsecure)</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">伺服器位址</string>
     <string name="server_lab_port3">伺服器埠</string>
     <string name="server_lab_id3">密碼</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">PublicKey</string>
     <string name="server_lab_preshared_key">PreSharedKey (optional)</string>
     <string name="server_lab_short_id">ShortId</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved (可選，逗號隔開)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">解析網域名稱時優先使用 IPv6 位址</string>
 
     <string name="title_pref_remote_dns">遠端 DNS (udp/tcp/https/quic)(可選)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (僅支援 IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">VPN 是否繞過區域網</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">境内 DNS (可选)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS hosts (格式: 網域:位址,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">本地代理埠</string>
     <string name="title_pref_enable_local_proxy">啟用本地代理</string>
     <string name="summary_pref_enable_local_proxy">未開啟時沒有 socks 代理，無法透過代理更新訂閱等</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">使用 UDP 時，socks5 認證並不完全安全</string>
     <string name="summary_pref_socks_port">本地代理埠</string>
     <string name="title_pref_dynamic_socks_port">啟用動態本地代理埠</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">訂閱分組設定</string>
     <string name="sub_setting_remarks">備註</string>
     <string name="sub_setting_url">可選位址(url)</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">請求頭（JSON 格式）</string>
     <string name="sub_setting_filter">別名正規過濾</string>
     <string name="sub_setting_enable">啟用更新</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">更新了 %1$d 個配置（%2$d 個成功，%3$d 個失敗，%4$d 個跳過）</string>
     <string name="title_update_subscription_no_subscription">無訂閱</string>
     <string name="toast_server_not_found_in_group">當前分組中未找到選中的伺服器</string>
-    <string name="toast_fragment_not_available">目前畫面無法使用。</string>
     <string name="title_locate_selected_config">尋找所選設定檔</string>
 
     <string name="tasker_start_service">啟動服務</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">選擇包名</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">"測試連線能力"</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">本地</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">QUIC 加密金鑰</string>
     <string name="server_lab_path_kcp">kcp seed</string>
     <string name="server_lab_path_grpc">gRPC serviceName</string>
-    <string name="server_lab_stream_security">傳輸層安全 (TLS)</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">跳過憑證驗證 (allowInsecure)</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">伺服器位址</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">PreSharedKey (optional)</string>
     <string name="server_lab_short_id">ShortId</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved (可選，逗號隔開)</string>
     <string name="server_lab_local_address">本機位址 (可選 IPv4/IPv6，逗號隔開)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">XHTTP 模式</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra 原始 JSON，格式： { XHTTPObject }</string>
     <string name="server_lab_final_mask">FinalMask 原始 JSON 格式: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">EchConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">依名稱驗證對端憑證</string>
     <string name="server_lab_pinned_ca256">證書指紋 (SHA-256)</string>
     <string name="server_lab_browser_dialer">啟用 Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">新增檔案</string>
     <string name="menu_item_add_url">新增連結</string>
     <string name="menu_item_scan_qrcode">掃描二維碼</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">下載檔案</string>
     <string name="title_user_asset_add_url">新增資產網址</string>
     <string name="msg_file_not_found">文件未找到</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">真連線延遲測試網址 </string>
-    <string name="summary_pref_delay_test_url">URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">同時執行的真實延遲測試數</string>
 
     <string name="title_pref_ip_api_url">目前連線資訊測試網址</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">允許來自區域網路的連線</string>
     <string name="summary_pref_proxy_sharing_enabled">其他裝置可以使用 socks/http 協定透過您的 IP 位址連線到 Proxy，僅在受信任的網路中啟用以避免未經授權的連線</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">與區域網路 / 熱點裝置共用 VPN (僅限 Root 使用者)</string>
     <string name="summary_root_lan_sharing">將 Wi-Fi 熱點和 USB 網路共享裝置的流量透過 VPN 轉送。</string>
 
-    <string name="title_logcat">Logcat</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">複製</string>
     <string name="logcat_clear">清除</string>
     <string name="logcat_share">分享日誌</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">從二維碼匯入規則集</string>
     <string name="routing_settings_export_rulesets_to_clipboard">匯出規則集至剪貼簿</string>
     <string name="routing_settings_locked">鎖定中，匯入預設時不刪除此規則</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (套件名稱 — 僅在使用 Xray TUN、開啟 routeOnly 且 Android 10+ 時可用)</string>
     <string name="routing_settings_process_select">選擇包名</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">"測試連線能力"</string>
     <string name="connection_test_testing">"測試中……"</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -25,7 +25,7 @@
     <string name="title_server">設定檔</string>
     <string name="menu_item_add_config">新增設定</string>
     <string name="menu_item_save_config">儲存設定</string>
-    <string name="menu_item_edit_config">編輯設定</string>
+    <string name="menu_item_edit_config">編輯設定檔</string>
     <string name="menu_item_del_config">刪除設定</string>
     <string name="menu_item_import_config_qrcode">從 QR Code 匯入設定</string>
     <string name="menu_item_import_config_clipboard">從剪貼簿匯入設定</string>
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">URL 無效</string>
     <string name="toast_insecure_url_protocol">請不要使用不安全的 HTTP 協定訂閱位址</string>
     <string name="server_lab_need_inbound">​​確保 inbounds port 和設定中的一致</string>
-    <string name="toast_malformed_json">設定格式不正確</string>
+    <string name="toast_malformed_json">設定檔格式不正確。</string>
     <string name="server_lab_request_host6">Host (SNI) (可選)</string>
     <string name="toast_action_not_allowed">禁止此項操作</string>
     <string name="server_obfs_password">混淆密碼</string>
@@ -131,7 +131,7 @@
     <string name="server_lab_browser_dialer">啟用 Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">僅支援 xhttp (packet-up) 和 ws 出站；與 TLS 相關的設定可能會被忽略或發生衝突</string>
     <string name="toast_allow_insecure_deprecated">目前節點使用未加密連線，您的通訊可能會被威權政府掌控的網路中間設施直接查看\n為了安全，此類節點無法通過 26.2.6+ 版本的 Xray 核心連線\n如果是自建節點請啟用 TLS 等安全加密，或固定憑證 pinnedCA256\n如果機場節點請聯繫服務商完成技術升級，如服務商拒絕配合，建議更換更重視用戶安全的服務商\n更多的資訊，請訪問 https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">獲取並填充指紋證書</string>
+    <string name="pinned_ca256_action_fetch">取得憑證指紋</string>
     <string name="toast_fetch_cert_sha256_success">獲取指紋證書完成</string>
     <string name="toast_fetch_cert_sha256_failed">獲取證書指紋失敗</string>
 
@@ -185,8 +185,8 @@
     <string name="title_mux_settings">Mux 設定</string>
     <string name="title_pref_mux_enabled">啟用 Mux 多路復用</string>
     <string name="summary_pref_mux_enabled">減低延時 但可能會斷流\nTCP，UDP 及 QUIC 流量處理方式下方可選</string>
-    <string name="title_pref_mux_concurrency">TCP 復用子鏈接數（可填 -1 至 1024）</string>
-    <string name="title_pref_mux_xudp_concurrency">XUDP 復用子鏈接數（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_concurrency">TCP 多工子連線數（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP 多工子連線數（可填 -1 至 1024）</string>
     <string name="title_pref_mux_xudp_quic">QUIC 流量處理方式</string>
     <string-array name="mux_xudp_quic_entries">
         <item>拒絕</item>
@@ -195,18 +195,18 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">啟用速度顯示</string>
-    <string name="summary_pref_speed_enabled">在通知中顯示當前速度\n小圖示顯示流量的轉送狀況</string>
+    <string name="summary_pref_speed_enabled">在通知中顯示目前速度。\n圖示會指出代理流量或直接連線流量何者較多。</string>
 
-    <string name="title_pref_sniffing_enabled">啟用流量監聽 (Sniffing)</string>
-    <string name="summary_pref_sniffing_enabled">從流量中監聽網域 (預設啟用)</string>
+    <string name="title_pref_sniffing_enabled">啟用流量探測 (Sniffing)</string>
+    <string name="summary_pref_sniffing_enabled">從流量中探測目標網域（預設啟用）。</string>
     <string name="title_pref_route_only_enabled">啟用 routeOnly</string>
     <string name="summary_pref_route_only_enabled">將嗅探得到的網域只用於路由，代理目標位址仍為 IP</string>
 
     <string name="title_pref_local_dns_enabled">啟用本機 DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS 請求匯入 core 由 DNS 模組處理 (建議啟用，如果需要轉送略過區域網路及中國大陸)</string>
 
-    <string name="title_pref_fake_dns_enabled">啟用假 DNS (FakeDNS)</string>
-    <string name="summary_pref_fake_dns_enabled">本機退回假解析結果 (減低延時，但個別應用可能無法使用)</string>
+    <string name="title_pref_fake_dns_enabled">啟用偽造 DNS (FakeDNS)</string>
+    <string name="summary_pref_fake_dns_enabled">FakeDNS 解析網域時會傳回虛構的 IP 位址（速度較快，但可能不適用於部分應用程式）。</string>
 
     <string name="title_pref_ipv6_enabled">啟用 IPv6</string>
     <string name="summary_pref_ipv6_enabled">為 VPN 介面新增 IPv6 位址和路由</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">真連線延遲測試網址 </string>
     <string name="summary_pref_delay_test_url">URL</string>
-    <string name="title_pref_real_ping_concurrency">真連線延遲測試並發數量</string>
+    <string name="title_pref_real_ping_concurrency">同時執行的真實延遲測試數</string>
 
     <string name="title_pref_ip_api_url">目前連線資訊測試網址</string>
     <string name="summary_pref_ip_api_url">URL</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">刪除設定檔是否需要用戶二次確認</string>
 
 
-    <string name="title_pref_append_http_proxy">追加 HTTP 代理至 VPN</string>
-    <string name="summary_pref_append_http_proxy">瀏覽器 / 一些支援的應用 將直接使用 HTTP 代理, 而不經過虛擬網卡設備 (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">將 HTTP 代理加入 VPN</string>
+    <string name="summary_pref_append_http_proxy">瀏覽器和部分支援的應用程式會直接使用 HTTP 代理，而不經過虛擬網路介面（Android 10+）。</string>
 
     <string name="title_pref_double_column_display">啟用雙列顯示</string>
     <string name="summary_pref_double_column_display">設定檔清單以雙列顯示，允許在螢幕上顯示更多內容。</string>
 
-    <string name="title_pref_group_all_display">啟用顯示所有群組</string>
-    <string name="summary_pref_group_all_display">新增一個額外的「所有選項卡」頁面</string>
+    <string name="title_pref_group_all_display">顯示「全部」群組分頁</string>
+    <string name="summary_pref_group_all_display">在一個分頁中彙整所有訂閱群組的設定檔。</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">意見回饋</string>
@@ -302,10 +302,10 @@
     <string name="title_pref_hev_tunnel_rw_timeout">HevTun 讀寫逾時(秒) (tcp,udp 預設 300,60)</string>
     <string name="title_mode_settings">模式設定</string>
     <string name="title_root_mode_enabled">啟用 Root 模式 (僅限 Root 使用者)</string>
-    <string name="summary_root_mode_enabled">透過 Root 權限啟用底層透明代理。此模式將不再透過 Android 常規系統 VPN 建立連線，而是直接接管系統底層所有網路流量。開啟後，原有的常规模式、應用分流及相關 VPN 設定將直接失效。</string>
+    <string name="summary_root_mode_enabled">使用 Root 權限實作底層透明代理。Root 模式不使用 Android 的 VPN 服務，而是直接處理網路流量。啟用期間，一般模式、個別應用程式路由及相關 VPN 設定不會生效。</string>
     <string name="toast_root_required">此功能需要 Root 權限</string>
-    <string name="title_root_lan_sharing">區域網路 / 熱點網路共享 (僅限 Root 使用者)</string>
-    <string name="summary_root_lan_sharing">允許透過 Wi-Fi 熱點和 USB 共享網路連線的裝置走 VPN 代理流量</string>
+    <string name="title_root_lan_sharing">與區域網路 / 熱點裝置共用 VPN (僅限 Root 使用者)</string>
+    <string name="summary_root_lan_sharing">將 Wi-Fi 熱點和 USB 網路共享裝置的流量透過 VPN 轉送。</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">複製</string>
@@ -345,8 +345,8 @@
     <string name="title_update_subscription_result">更新了 %1$d 個配置（%2$d 個成功，%3$d 個失敗，%4$d 個跳過）</string>
     <string name="title_update_subscription_no_subscription">無訂閱</string>
     <string name="toast_server_not_found_in_group">當前分組中未找到選中的伺服器</string>
-    <string name="toast_fragment_not_available">無法定位當前視圖</string>
-    <string name="title_locate_selected_config">定位所選配置</string>
+    <string name="toast_fragment_not_available">目前畫面無法使用。</string>
+    <string name="title_locate_selected_config">尋找所選設定檔</string>
 
     <string name="tasker_start_service">啟動服務</string>
     <string name="tasker_setting_confirm">確定</string>
@@ -385,7 +385,7 @@
     <string name="connection_test_error_status_code">"錯誤碼：(#%d)"</string>
     <string name="connection_connected">"已連線，輕觸以檢查連線能力"</string>
     <string name="connection_not_connected">"未連線"</string>
-    <string name="connection_running_task_left">運行中的測試任務數：%s</string>
+    <string name="connection_running_task_left">正在執行的測試：%s</string>
 
     <string name="import_subscription_success">匯入訂閱成功</string>
     <string name="import_subscription_failure">匯入訂閱失敗</string>
@@ -413,7 +413,7 @@
 
     <string name="title_policy_group_type">策略群組類型</string>
     <string name="title_policy_group_subscription_id">來自訂閱分組</string>
-    <string name="title_policy_group_subscription_filter">別名正規過濾</string>
+    <string name="title_policy_group_subscription_filter">備註正規表示式篩選</string>
     <string name="title_policy_group_test_outbounds">測試出站 (outbounds)</string>
     <string name="title_policy_group_fallback">備用出站 (outbound，選填)</string>
 

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name" translatable="false">v2rayNG</string>
     <string name="app_widget_name">開關</string>
     <string name="app_tile_name">開關</string>
     <string name="app_tile_first_use">首次使用此功能，請使用此應用程式新增伺服器</string>
@@ -20,7 +21,7 @@
     <string name="toast_services_success">啟動服務成功</string>
     <string name="toast_services_failure">啟動服務失敗</string>
 
-    <!-- ServerActivity -->
+    <!--ServerActivity-->
     <string name="title_server">設定檔</string>
     <string name="menu_item_add_config">新增設定</string>
     <string name="menu_item_save_config">儲存設定</string>
@@ -113,7 +114,7 @@
     <string name="toast_invalid_url">URL 無效</string>
     <string name="toast_insecure_url_protocol">請不要使用不安全的 HTTP 協定訂閱位址</string>
     <string name="server_lab_need_inbound">​​確保 inbounds port 和設定中的一致</string>
-    <string name="toast_malformed_josn">設定格式不正確</string>
+    <string name="toast_malformed_json">設定格式不正確</string>
     <string name="server_lab_request_host6">Host (SNI) (可選)</string>
     <string name="toast_action_not_allowed">禁止此項操作</string>
     <string name="server_obfs_password">混淆密碼</string>
@@ -127,6 +128,8 @@
     <string name="server_lab_ech_config_list">EchConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
     <string name="server_lab_pinned_ca256">證書指紋 (SHA-256)</string>
+    <string name="server_lab_browser_dialer">啟用 Browser Dialer</string>
+    <string name="server_lab_browser_dialer_tip">僅支援 xhttp (packet-up) 和 ws 出站；與 TLS 相關的設定可能會被忽略或發生衝突</string>
     <string name="toast_allow_insecure_deprecated">目前節點使用未加密連線，您的通訊可能會被威權政府掌控的網路中間設施直接查看\n為了安全，此類節點無法通過 26.2.6+ 版本的 Xray 核心連線\n如果是自建節點請啟用 TLS 等安全加密，或固定憑證 pinnedCA256\n如果機場節點請聯繫服務商完成技術升級，如服務商拒絕配合，建議更換更重視用戶安全的服務商\n更多的資訊，請訪問 https://github.com/2dust/v2rayN/discussions/9460</string>
     <string name="pinned_ca256_action_fetch">獲取並填充指紋證書</string>
     <string name="toast_fetch_cert_sha256_success">獲取指紋證書完成</string>
@@ -134,7 +137,9 @@
 
     <!-- UserAssetActivity -->
     <string name="toast_asset_copy_failed">失敗，請使用檔案總管</string>
+    <string name="menu_item_add_asset">新增資源</string>
     <string name="menu_item_add_file">新增檔案</string>
+    <string name="menu_item_add_url">新增連結</string>
     <string name="menu_item_scan_qrcode">掃描二維碼</string>
     <string name="title_url">URL</string>
     <string name="menu_item_download_file">下載檔案</string>
@@ -156,7 +161,7 @@
     <string name="menu_item_import_proxy_app">從剪貼簿匯入</string>
     <string name="per_app_proxy_settings">分應用設置</string>
     <string name="per_app_proxy_settings_enable">根據應用分流</string>
-
+    <string name="app_picker_unknown_app">未知應用程式（無法識別 UID）</string>
 
     <!-- Preferences -->
     <string name="title_settings">設定</string>
@@ -167,6 +172,7 @@
     <string name="summary_pref_per_app_proxy">常規：勾選的 App 啟用 Proxy，未勾選的直接連線；\n繞行模式：勾選的 App 直接連線，未勾選的啟用 Proxy。\n可在選單中選擇自動選中需 Proxy 應用</string>
     <string name="title_pref_is_booted">開機時自動連線</string>
     <string name="summary_pref_is_booted">開機時自動連線選擇的伺服器，可能會不成功</string>
+
 
     <string name="subscription_updater_job_tips">任務將在背景運行，在通知中會顯示進度資訊</string>
     <string name="title_pref_auto_test_after_update_subscription">更新訂閱後自動測試</string>
@@ -179,8 +185,8 @@
     <string name="title_mux_settings">Mux 設定</string>
     <string name="title_pref_mux_enabled">啟用 Mux 多路復用</string>
     <string name="summary_pref_mux_enabled">減低延時 但可能會斷流\nTCP，UDP 及 QUIC 流量處理方式下方可選</string>
-    <string name="title_pref_mux_concurency">TCP 復用子鏈接數（可填 -1 至 1024）</string>
-    <string name="title_pref_mux_xudp_concurency">XUDP 復用子鏈接數（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_concurrency">TCP 復用子鏈接數（可填 -1 至 1024）</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP 復用子鏈接數（可填 -1 至 1024）</string>
     <string name="title_pref_mux_xudp_quic">QUIC 流量處理方式</string>
     <string-array name="mux_xudp_quic_entries">
         <item>不代理</item>
@@ -195,7 +201,6 @@
     <string name="summary_pref_sniffing_enabled">從流量中監聽網域 (預設啟用)</string>
     <string name="title_pref_route_only_enabled">啟用 routeOnly</string>
     <string name="summary_pref_route_only_enabled">將嗅探得到的網域只用於路由，代理目標位址仍為 IP</string>
-
 
     <string name="title_pref_local_dns_enabled">啟用本機 DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS 請求匯入 core 由 DNS 模組處理 (建議啟用，如果需要轉送略過區域網路及中國大陸)</string>
@@ -216,10 +221,13 @@
     <string name="title_pref_vpn_bypass_lan">VPN 是否繞過區域網</string>
 
     <string name="title_pref_vpn_interface_address">VPN 介面位址</string>
+
     <string name="title_pref_vpn_mtu">VPN MTU (預設 1500)</string>
 
-    <string name="summary_pref_domestic_dns">DNS</string>
+
     <string name="title_pref_domestic_dns">境内 DNS (可选)</string>
+    <string name="summary_pref_domestic_dns">DNS</string>
+
     <string name="title_pref_dns_hosts">DNS hosts (格式: 網域:位址,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
@@ -299,7 +307,6 @@
     <string name="title_root_lan_sharing">區域網路 / 熱點網路共享 (僅限 Root 使用者)</string>
     <string name="summary_root_lan_sharing">允許透過 Wi-Fi 熱點和 USB 共享網路連線的裝置走 VPN 代理流量</string>
 
-
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">複製</string>
     <string name="logcat_clear">清除</string>
@@ -360,12 +367,13 @@
     <string name="routing_settings_locked">鎖定中，匯入預設時不刪除此規則</string>
     <string name="routing_settings_domain">domain</string>
     <string name="routing_settings_ip">ip</string>
-    <string name="routing_settings_process">process (套件名稱 — 僅在使用 Xray 的 TUN、開啟 routeOnly 且 Android 10+ 時可用)</string>
+    <string name="routing_settings_process">process (套件名稱 — 僅在使用 Xray TUN、開啟 routeOnly 且 Android 10+ 時可用)</string>
     <string name="routing_settings_process_select">選擇包名</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
     <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
+    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">"測試連線能力"</string>
@@ -377,12 +385,10 @@
     <string name="connection_test_error_status_code">"錯誤碼：(#%d)"</string>
     <string name="connection_connected">"已連線，輕觸以檢查連線能力"</string>
     <string name="connection_not_connected">"未連線"</string>
-    <string name="connection_runing_task_left">運行中的測試任務數：%s</string>
+    <string name="connection_running_task_left">運行中的測試任務數：%s</string>
 
     <string name="import_subscription_success">匯入訂閱成功</string>
     <string name="import_subscription_failure">匯入訂閱失敗</string>
-    <string name="menu_item_add_asset">新增資源</string>
-    <string name="menu_item_add_url">新增連結</string>
     <string name="title_fragment_settings">分片（Fragment） 設定</string>
     <string name="title_pref_fragment_packets">分片方式</string>
     <string name="title_pref_fragment_length">分片包長（最小-最大）</string>
@@ -410,6 +416,7 @@
     <string name="title_policy_group_subscription_filter">別名正規過濾</string>
     <string name="title_policy_group_test_outbounds">測試出口</string>
     <string name="title_policy_group_fallback">備用出口（選填）</string>
+
     <string name="server_proxy_chain_members">代理鏈成員</string>
     <string name="server_proxy_chain_pick_members">點此選擇成員</string>
     <string name="server_proxy_chain_member_unselected">請選擇成員</string>
@@ -444,6 +451,12 @@
         <item>僅代理</item>
     </string-array>
 
+    <string-array name="browser_dialer_mode">
+        <item>停用</item>
+        <item>OkHttp</item>
+        <item>WebView</item>
+    </string-array>
+
     <string-array name="ui_mode_night">
         <item>跟隨系統</item>
         <item>淺色</item>
@@ -467,6 +480,7 @@
         <item>解析後加入 DNS Hosts</item>
         <item>解析後替換原網域名稱</item>
     </string-array>
+
     <string-array name="policy_group_type">
         <item>最低延遲</item>
         <item>最少卡頓</item>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -318,7 +318,7 @@
     <string name="title_export_all">匯出設定至剪貼簿</string>
     <string name="title_sub_setting">訂閱分組設定</string>
     <string name="sub_setting_remarks">備註</string>
-    <string name="sub_setting_url">可選位址(url)</string>
+    <string name="sub_setting_url">可選位址(URL)</string>
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">請求頭（JSON 格式）</string>
     <string name="sub_setting_filter">別名正規過濾</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -7,7 +7,7 @@
     <string name="navigation_drawer_open">開啟導覽匣</string>
     <string name="navigation_drawer_close">關閉導覽匣</string>
     <string name="migration_success">資料遷移成功！</string>
-    <string name="action_stop_service">Stop service</string>
+    <string name="action_stop_service">停止服務</string>
     <string name="migration_fail">資料遷移失敗！</string>
     <string name="pull_down_to_refresh">請下拉刷新!</string>
 
@@ -25,7 +25,7 @@
     <string name="title_server">設定檔</string>
     <string name="menu_item_add_config">新增設定</string>
     <string name="menu_item_save_config">儲存設定</string>
-    <string name="menu_item_edit_config">Edit configuration</string>
+    <string name="menu_item_edit_config">編輯設定</string>
     <string name="menu_item_del_config">刪除設定</string>
     <string name="menu_item_import_config_qrcode">從 QR Code 匯入設定</string>
     <string name="menu_item_import_config_clipboard">從剪貼簿匯入設定</string>
@@ -126,7 +126,7 @@
     <string name="server_lab_xhttp_extra">XHTTP Extra 原始 JSON，格式： { XHTTPObject }</string>
     <string name="server_lab_final_mask">FinalMask 原始 JSON 格式: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
+    <string name="server_lab_verify_peer_cert_by_name">依名稱驗證對端憑證</string>
     <string name="server_lab_pinned_ca256">證書指紋 (SHA-256)</string>
     <string name="server_lab_browser_dialer">啟用 Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">僅支援 xhttp (packet-up) 和 ws 出站；與 TLS 相關的設定可能會被忽略或發生衝突</string>
@@ -189,9 +189,9 @@
     <string name="title_pref_mux_xudp_concurrency">XUDP 復用子鏈接數（可填 -1 至 1024）</string>
     <string name="title_pref_mux_xudp_quic">QUIC 流量處理方式</string>
     <string-array name="mux_xudp_quic_entries">
-        <item>不代理</item>
-        <item>多路復用</item>
-        <item>原生</item>
+        <item>拒絕</item>
+        <item>允許</item>
+        <item>略過</item>
     </string-array>
 
     <string name="title_pref_speed_enabled">啟用速度顯示</string>
@@ -232,7 +232,7 @@
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">真連線延遲測試網址 </string>
-    <string name="summary_pref_delay_test_url">Url</string>
+    <string name="summary_pref_delay_test_url">URL</string>
     <string name="title_pref_real_ping_concurrency">真連線延遲測試並發數量</string>
 
     <string name="title_pref_ip_api_url">目前連線資訊測試網址</string>
@@ -280,7 +280,7 @@
     <string name="title_qr_code">QR 碼</string>
     <string name="title_about">關於</string>
     <string name="title_source_code">原始碼</string>
-    <string name="title_oss_license">Open Source licenses</string>
+    <string name="title_oss_license">開放原始碼授權</string>
     <string name="title_tg_channel">Telegram 頻道</string>
 
     <string name="title_pref_promotion">推廣</string>

--- a/V2rayNG/app/src/main/res/values/arrays.xml
+++ b/V2rayNG/app/src/main/res/values/arrays.xml
@@ -205,7 +205,7 @@
         <item>6</item>
     </string-array>
 
-    <string-array name="vpn_interface_address">
+    <string-array name="vpn_interface_address" translatable="false">
         <item>10.10.14.x</item>
         <item>10.1.0.x</item>
         <item>10.0.0.x</item>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">Invalid URL</string>
     <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
     <string name="server_lab_need_inbound">Ensure inbounds port is consistent with the settings</string>
-    <string name="toast_malformed_json">Config malformed</string>
+    <string name="toast_malformed_json">Invalid configuration.</string>
     <string name="server_lab_request_host6">Host(SNI)(Optional)</string>
     <string name="toast_action_not_allowed">Action not allowed</string>
     <string name="server_obfs_password">Obfs password</string>
@@ -126,12 +126,12 @@
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
     <string name="server_lab_ech_config_list">EchConfigList</string>
-    <string name="server_lab_verify_peer_cert_by_name">Verify Peer Cert By Name</string>
+    <string name="server_lab_verify_peer_cert_by_name">Verify peer certificate by name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
     <string name="server_lab_browser_dialer">Enable Browser Dialer</string>
     <string name="server_lab_browser_dialer_tip">Only supports xhttp (packet-up) and ws outbound; TLS-related settings may be ignored or conflict</string>
     <string name="toast_allow_insecure_deprecated">Current node uses an unencrypted connection. Your communication may be directly viewed by network intermediate facilities controlled by authoritarian governments.\nFor security reasons, such nodes cannot be connected via Xray core version 26.2.6+.\nIf it is a self-built node, please enable security encryption such as TLS, or pin the certificate pinnedCA256.\nIf it is a provider node, please contact the service provider to complete the technical upgrade. If the service provider refuses to cooperate, it is recommended to switch to a provider that pays more attention to user security.\nFor more information, please visit https://github.com/2dust/v2rayN/discussions/9460</string>
-    <string name="pinned_ca256_action_fetch">Fetch and fill certificate fingerprint</string>
+    <string name="pinned_ca256_action_fetch">Fetch certificate fingerprint</string>
     <string name="toast_fetch_cert_sha256_success">Certificate fingerprint fetched successfully</string>
     <string name="toast_fetch_cert_sha256_failed">Failed to fetch certificate fingerprint</string>
 
@@ -146,7 +146,7 @@
     <string name="title_user_asset_add_url">Add asset URL</string>
     <string name="msg_file_not_found">File not found</string>
     <string name="msg_remark_is_duplicate">The remarks already exists</string>
-    <string name="asset_geo_files_sources">Geo files source (optional)</string>
+    <string name="asset_geo_files_sources">Geo file source (optional)</string>
 
     <!-- PerAppProxyActivity -->
     <string name="msg_dialog_progress">Loading</string>
@@ -161,7 +161,7 @@
     <string name="menu_item_import_proxy_app">Import from Clipboard</string>
     <string name="per_app_proxy_settings">Per-app settings</string>
     <string name="per_app_proxy_settings_enable">Enable per-app</string>
-    <string name="app_picker_unknown_app">Unknown app (unidentified UID)</string>
+    <string name="app_picker_unknown_app">Unknown app (UID not recognized)</string>
 
     <!-- Preferences -->
     <string name="title_settings">Settings</string>
@@ -185,8 +185,8 @@
     <string name="title_mux_settings">Mux Settings</string>
     <string name="title_pref_mux_enabled">Enable Mux</string>
     <string name="summary_pref_mux_enabled">Faster, but it may cause unstable connectivity\nCustomize how to handle TCP, UDP and QUIC below</string>
-    <string name="title_pref_mux_concurrency">TCP connections（range -1 to 1024）</string>
-    <string name="title_pref_mux_xudp_concurrency">XUDP connections（range -1 to 1024）</string>
+    <string name="title_pref_mux_concurrency">TCP connections (range -1 to 1024)</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP connections (range -1 to 1024)</string>
     <string name="title_pref_mux_xudp_quic">Handling of QUIC in mux tunnel</string>
     <string-array name="mux_xudp_quic_entries">
         <item>reject</item>
@@ -195,10 +195,10 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">Enable speed display</string>
-    <string name="summary_pref_speed_enabled">Display current speed in the notification.\nNotification icon would change based on usage.</string>
+    <string name="summary_pref_speed_enabled">Show current speeds in the notification.\nThe icon indicates whether proxy or direct traffic is dominant.</string>
 
     <string name="title_pref_sniffing_enabled">Enable Sniffing</string>
-    <string name="summary_pref_sniffing_enabled">Try sniff domain from the packet (default on)</string>
+    <string name="summary_pref_sniffing_enabled">Detect destination domains from traffic (enabled by default).</string>
     <string name="title_pref_route_only_enabled">Enable routeOnly</string>
     <string name="summary_pref_route_only_enabled">Use the sniffed domain name for routing only, and keep the target address as the IP address.</string>
 
@@ -206,7 +206,7 @@
     <string name="summary_pref_local_dns_enabled">DNS processed by core‘s DNS module (Recommended if you need routing bypassing LAN and mainland addresses)</string>
 
     <string name="title_pref_fake_dns_enabled">Enable FakeDNS</string>
-    <string name="summary_pref_fake_dns_enabled">Local DNS returns fake IP addresses (faster, but it may not work for some apps)</string>
+    <string name="summary_pref_fake_dns_enabled">FakeDNS returns synthetic IP addresses for domain lookups (faster, but may not work with some apps).</string>
 
     <string name="title_pref_ipv6_enabled">Enable IPv6</string>
     <string name="summary_pref_ipv6_enabled">Add IPv6 address and routes to the VPN interface</string>
@@ -233,7 +233,7 @@
 
     <string name="title_pref_delay_test_url">True delay test url </string>
     <string name="summary_pref_delay_test_url">Url</string>
-    <string name="title_pref_real_ping_concurrency">True delay test concurrency</string>
+    <string name="title_pref_real_ping_concurrency">Concurrent real-delay tests</string>
 
     <string name="title_pref_ip_api_url">Current connection info test url</string>
     <string name="summary_pref_ip_api_url">Url</string>
@@ -249,7 +249,7 @@
     <string name="summary_pref_socks_enable_udp">SOCKS5 authentication is not fully secure when using UDP.</string>
     <string name="summary_pref_socks_port">Local proxy port</string>
     <string name="title_pref_dynamic_socks_port">Enable dynamic local proxy port</string>
-    <string name="summary_pref_dynamic_socks_port">Generate a random local proxy port each time the inbound is created</string>
+    <string name="summary_pref_dynamic_socks_port">Use a random local proxy port for each inbound</string>
     <string name="title_pref_socks_username">Local proxy username (optional)</string>
     <string name="summary_pref_socks_username">Username</string>
     <string name="title_pref_socks_password">Local proxy password (optional)</string>
@@ -262,14 +262,14 @@
     <string name="summary_pref_confirm_remove">Whether deleting a config requires a second confirmation by the user</string>
 
 
-    <string name="title_pref_append_http_proxy">Append HTTP Proxy to VPN</string>
-    <string name="summary_pref_append_http_proxy">HTTP proxy will be used directly from (browser/ some supported apps), without going through the virtual NIC device (Android 10+)</string>
+    <string name="title_pref_append_http_proxy">Add HTTP proxy to VPN</string>
+    <string name="summary_pref_append_http_proxy">Allow browsers and supported apps to use the HTTP proxy directly instead of the virtual network interface (Android 10+).</string>
 
-    <string name="title_pref_double_column_display">Enable double column display</string>
-    <string name="summary_pref_double_column_display">The profile list is displayed in double columns, allowing more content to be displayed on the screen.</string>
+    <string name="title_pref_double_column_display">Use two-column layout</string>
+    <string name="summary_pref_double_column_display">Display the profile list in two columns to fit more content on screen.</string>
 
-    <string name="title_pref_group_all_display">Enable show all groups</string>
-    <string name="summary_pref_group_all_display">Add an extra "All Tabs" page</string>
+    <string name="title_pref_group_all_display">Show an "All" group tab</string>
+    <string name="summary_pref_group_all_display">Combine profiles from every subscription group in one tab.</string>
 
     <!-- AboutActivity -->
     <string name="title_pref_feedback">Feedback</string>
@@ -290,7 +290,7 @@
     <string name="title_pref_auto_update_interval">Auto Update Interval (Minutes, Min value 15)</string>
 
     <string name="title_core_loglevel">Log Level</string>
-    <string name="title_outbound_domain_resolve_method">Outbound domain pre-resolve method</string>
+    <string name="title_outbound_domain_resolve_method">Outbound domain resolution</string>
     <string name="title_mode">Mode</string>
     <string name="title_mode_help">Click me for more help</string>
     <string name="title_language">Language</string>
@@ -301,11 +301,11 @@
     <string name="title_pref_hev_tunnel_loglevel">Hev Tun Log Level</string>
     <string name="title_pref_hev_tunnel_rw_timeout">Hev Tun read/write timeout (seconds) (tcp,udp default 300,60)</string>
     <string name="title_mode_settings">Mode Settings</string>
-    <string name="title_root_mode_enabled">Root mode enabled (Root Users)</string>
-    <string name="summary_root_mode_enabled">Enable low-level transparent proxying via root privileges. This mode bypasses the standard Android system VPN to directly take over all underlying network traffic. Once enabled, the original regular mode, per-app routing, and related VPN settings will become completely invalid.</string>
+    <string name="title_root_mode_enabled">Enable root mode (root users)</string>
+    <string name="summary_root_mode_enabled">Use root access for low-level transparent proxying. Root mode handles network traffic directly instead of using the Android VPN service. Standard mode, per-app routing, and VPN-related settings do not apply while root mode is enabled.</string>
     <string name="toast_root_required">Root access is required for this feature</string>
-    <string name="title_root_lan_sharing">LAN / tethering sharing (Root Users)</string>
-    <string name="summary_root_lan_sharing">Route Wi-Fi hotspot and USB-tethered devices through the VPN</string>
+    <string name="title_root_lan_sharing">Share VPN with LAN / tethered devices (root users)</string>
+    <string name="summary_root_lan_sharing">Route traffic from Wi-Fi hotspot and USB-tethered devices through the VPN.</string>
 
     <string name="title_logcat">Logcat</string>
     <string name="logcat_copy">Copy</string>
@@ -345,8 +345,8 @@
     <string name="title_update_subscription_result">Updated %1$d configs (%2$d success, %3$d failed, %4$d skipped)</string>
     <string name="title_update_subscription_no_subscription">No subscriptions</string>
     <string name="toast_server_not_found_in_group">Selected server not found in current group</string>
-    <string name="toast_fragment_not_available">Unable to locate current view</string>
-    <string name="title_locate_selected_config">Locate the selected config</string>
+    <string name="toast_fragment_not_available">Current screen is unavailable.</string>
+    <string name="title_locate_selected_config">Find selected configuration</string>
 
     <string name="tasker_start_service">Start Service</string>
     <string name="tasker_setting_confirm">Confirm</string>
@@ -385,7 +385,7 @@
     <string name="connection_test_error_status_code">Error code: #%d</string>
     <string name="connection_connected">Connected, tap to check connection</string>
     <string name="connection_not_connected">Not connected</string>
-    <string name="connection_running_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_task_left">Tests running: %s</string>
 
     <string name="import_subscription_success">Subscription imported Successfully</string>
     <string name="import_subscription_failure">Import subscription failed</string>
@@ -413,7 +413,7 @@
 
     <string name="title_policy_group_type">Policy group type</string>
     <string name="title_policy_group_subscription_id">From subscription group</string>
-    <string name="title_policy_group_subscription_filter">Remarks regular filter</string>
+    <string name="title_policy_group_subscription_filter">Remarks regex filter</string>
     <string name="title_policy_group_test_outbounds">Test outbounds</string>
     <string name="title_policy_group_fallback">Fallback outbound (optional)</string>
 

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -231,12 +231,12 @@
     <string name="title_pref_dns_hosts">DNS hosts (Format: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
-    <string name="title_pref_delay_test_url">True delay test url </string>
-    <string name="summary_pref_delay_test_url">Url</string>
+    <string name="title_pref_delay_test_url">True delay test URL </string>
+    <string name="summary_pref_delay_test_url">URL</string>
     <string name="title_pref_real_ping_concurrency">Concurrent real-delay tests</string>
 
-    <string name="title_pref_ip_api_url">Current connection info test url</string>
-    <string name="summary_pref_ip_api_url">Url</string>
+    <string name="title_pref_ip_api_url">Current connection info test URL</string>
+    <string name="summary_pref_ip_api_url">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">Allow connections from the LAN</string>
     <string name="summary_pref_proxy_sharing_enabled">Other devices can connect to proxy by your IP address through local proxy. Only enable in trusted networks to avoid unauthorized connections</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -76,9 +76,9 @@
     <string name="server_lab_path_quic">QUIC key</string>
     <string name="server_lab_path_kcp">kcp seed</string>
     <string name="server_lab_path_grpc">gRPC serviceName</string>
-    <string name="server_lab_stream_security">TLS</string>
+    <string name="server_lab_stream_security" translatable="false">TLS</string>
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
-    <string name="server_lab_stream_alpn">Alpn</string>
+    <string name="server_lab_stream_alpn" translatable="false">ALPN</string>
     <string name="server_lab_allow_insecure">allowInsecure</string>
     <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">address</string>
@@ -93,7 +93,7 @@
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">ShortId</string>
     <string name="server_lab_spider_x" translatable="false">SpiderX</string>
-    <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
+    <string name="server_lab_mldsa65_verify" translatable="false">mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved(Optional, separated by commas)</string>
     <string name="server_lab_local_address">Local address (optional IPv4/IPv6, separated by commas)</string>
@@ -125,7 +125,7 @@
     <string name="server_lab_xhttp_mode">XHTTP Mode</string>
     <string name="server_lab_xhttp_extra">XHTTP Extra raw JSON, format: { XHTTPObject }</string>
     <string name="server_lab_final_mask">finalMask raw JSON, format: { FinalMaskObject }</string>
-    <string name="server_lab_ech_config_list">EchConfigList</string>
+    <string name="server_lab_ech_config_list" translatable="false">echConfigList</string>
     <string name="server_lab_verify_peer_cert_by_name">Verify peer certificate by name</string>
     <string name="server_lab_pinned_ca256">Certificate fingerprint (SHA-256)</string>
     <string name="server_lab_browser_dialer">Enable Browser Dialer</string>
@@ -141,7 +141,7 @@
     <string name="menu_item_add_file">Add files</string>
     <string name="menu_item_add_url">Add URL</string>
     <string name="menu_item_scan_qrcode">Scan QRcode</string>
-    <string name="title_url">URL</string>
+    <string name="title_url" translatable="false">URL</string>
     <string name="menu_item_download_file">Download files</string>
     <string name="title_user_asset_add_url">Add asset URL</string>
     <string name="msg_file_not_found">File not found</string>
@@ -232,11 +232,11 @@
     <string name="summary_pref_dns_hosts">domain:address,…</string>
 
     <string name="title_pref_delay_test_url">True delay test URL </string>
-    <string name="summary_pref_delay_test_url">URL</string>
+    <string name="summary_pref_delay_test_url" translatable="false">URL</string>
     <string name="title_pref_real_ping_concurrency">Concurrent real-delay tests</string>
 
     <string name="title_pref_ip_api_url">Current connection info test URL</string>
-    <string name="summary_pref_ip_api_url">URL</string>
+    <string name="summary_pref_ip_api_url" translatable="false">URL</string>
 
     <string name="title_pref_proxy_sharing_enabled">Allow connections from the LAN</string>
     <string name="summary_pref_proxy_sharing_enabled">Other devices can connect to proxy by your IP address through local proxy. Only enable in trusted networks to avoid unauthorized connections</string>
@@ -307,7 +307,7 @@
     <string name="title_root_lan_sharing">Share VPN with LAN / tethered devices (root users)</string>
     <string name="summary_root_lan_sharing">Route traffic from Wi-Fi hotspot and USB-tethered devices through the VPN.</string>
 
-    <string name="title_logcat">Logcat</string>
+    <string name="title_logcat" translatable="false">Logcat</string>
     <string name="logcat_copy">Copy</string>
     <string name="logcat_clear">Clear</string>
     <string name="logcat_share">Share log</string>
@@ -364,16 +364,16 @@
     <string name="routing_settings_import_rulesets_from_qrcode">Import ruleset from QRcode</string>
     <string name="routing_settings_export_rulesets_to_clipboard">Export ruleset to clipboard</string>
     <string name="routing_settings_locked">Locked, keep this rule when import presets</string>
-    <string name="routing_settings_domain">domain</string>
-    <string name="routing_settings_ip">ip</string>
+    <string name="routing_settings_domain" translatable="false">domain</string>
+    <string name="routing_settings_ip" translatable="false">ip</string>
     <string name="routing_settings_process">process (Package Name — only supported when using Xray TUN, routeOnly enabled, and Android 10+)</string>
     <string name="routing_settings_process_select">Select package name</string>
-    <string name="routing_settings_port">port</string>
-    <string name="routing_settings_protocol">protocol</string>
+    <string name="routing_settings_port" translatable="false">port</string>
+    <string name="routing_settings_protocol" translatable="false">protocol</string>
     <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
-    <string name="routing_settings_network">network</string>
+    <string name="routing_settings_network" translatable="false">network</string>
     <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
-    <string name="routing_settings_outbound_tag">outboundTag</string>
+    <string name="routing_settings_outbound_tag" translatable="false">outboundTag</string>
 
     <string name="connection_test_pending">Check Connectivity</string>
     <string name="connection_test_testing">Testing…</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@
     <string name="server_lab_stream_fingerprint">Fingerprint</string>
     <string name="server_lab_stream_alpn">Alpn</string>
     <string name="server_lab_allow_insecure">allowInsecure</string>
-    <string name="server_lab_sni">SNI</string>
+    <string name="server_lab_sni" translatable="false">SNI</string>
     <string name="server_lab_address3">address</string>
     <string name="server_lab_port3">port</string>
     <string name="server_lab_id3">password</string>
@@ -92,7 +92,7 @@
     <string name="server_lab_public_key">PublicKey</string>
     <string name="server_lab_preshared_key">PreSharedKey(optional)</string>
     <string name="server_lab_short_id">ShortId</string>
-    <string name="server_lab_spider_x">SpiderX</string>
+    <string name="server_lab_spider_x" translatable="false">SpiderX</string>
     <string name="server_lab_mldsa65_verify">Mldsa65Verify</string>
     <string name="server_lab_secret_key">SecretKey</string>
     <string name="server_lab_reserved">Reserved(Optional, separated by commas)</string>
@@ -215,7 +215,7 @@
     <string name="summary_pref_prefer_ipv6">Prefer IPv6 addresses when resolving domain names</string>
 
     <string name="title_pref_remote_dns">Remote DNS (udp/tcp/https/quic)(Optional)</string>
-    <string name="summary_pref_remote_dns">DNS</string>
+    <string name="summary_pref_remote_dns" translatable="false">DNS</string>
 
     <string name="title_pref_vpn_dns">VPN DNS (only IPv4/v6)</string>
     <string name="title_pref_vpn_bypass_lan">Does VPN bypass LAN</string>
@@ -226,7 +226,7 @@
 
 
     <string name="title_pref_domestic_dns">Domestic DNS (Optional)</string>
-    <string name="summary_pref_domestic_dns">DNS</string>
+    <string name="summary_pref_domestic_dns" translatable="false">DNS</string>
 
     <string name="title_pref_dns_hosts">DNS hosts (Format: domain:address,…)</string>
     <string name="summary_pref_dns_hosts">domain:address,…</string>
@@ -245,7 +245,7 @@
     <string name="title_pref_socks_port">Local proxy port</string>
     <string name="title_pref_enable_local_proxy">Enable local proxy</string>
     <string name="summary_pref_enable_local_proxy">When disabled, no SOCKS proxy is available, so subscription updates and similar actions cannot use the proxy</string>
-    <string name="title_pref_socks_enable_udp">SOCKS5 UDP</string>
+    <string name="title_pref_socks_enable_udp" translatable="false">SOCKS5 UDP</string>
     <string name="summary_pref_socks_enable_udp">SOCKS5 authentication is not fully secure when using UDP.</string>
     <string name="summary_pref_socks_port">Local proxy port</string>
     <string name="title_pref_dynamic_socks_port">Enable dynamic local proxy port</string>
@@ -319,7 +319,7 @@
     <string name="title_sub_setting">Subscription group setting</string>
     <string name="sub_setting_remarks">remarks</string>
     <string name="sub_setting_url">Optional URL</string>
-    <string name="sub_setting_user_agent">User Agent</string>
+    <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">Request Headers (JSON format)</string>
     <string name="sub_setting_filter">Remarks regular filter</string>
     <string name="sub_setting_enable">Enable update</string>
@@ -345,7 +345,6 @@
     <string name="title_update_subscription_result">Updated %1$d configs (%2$d success, %3$d failed, %4$d skipped)</string>
     <string name="title_update_subscription_no_subscription">No subscriptions</string>
     <string name="toast_server_not_found_in_group">Selected server not found in current group</string>
-    <string name="toast_fragment_not_available">Current screen is unavailable.</string>
     <string name="title_locate_selected_config">Find selected configuration</string>
 
     <string name="tasker_start_service">Start Service</string>
@@ -371,9 +370,9 @@
     <string name="routing_settings_process_select">Select package name</string>
     <string name="routing_settings_port">port</string>
     <string name="routing_settings_protocol">protocol</string>
-    <string name="routing_settings_protocol_tip">[http,tls,bittorrent]</string>
+    <string name="routing_settings_protocol_tip" translatable="false">[http,tls,bittorrent]</string>
     <string name="routing_settings_network">network</string>
-    <string name="routing_settings_outbound_tag_hint" translatable="false">proxy / direct / block / &lt;remarks&gt;</string>
+    <string name="routing_settings_outbound_tag_hint">proxy / direct / block / &lt;%1$s&gt;</string>
     <string name="routing_settings_outbound_tag">outboundTag</string>
 
     <string name="connection_test_pending">Check Connectivity</string>
@@ -489,6 +488,6 @@
     </string-array>
 
     <string name="backup_location_local">Local</string>
-    <string name="backup_location_webdav">WebDAV</string>
+    <string name="backup_location_webdav" translatable="false">WebDAV</string>
 
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -205,7 +205,7 @@
     <string name="title_pref_local_dns_enabled">Enable local DNS</string>
     <string name="summary_pref_local_dns_enabled">DNS processed by core‘s DNS module (Recommended if you need routing bypassing LAN and mainland addresses)</string>
 
-    <string name="title_pref_fake_dns_enabled">Enable fake DNS</string>
+    <string name="title_pref_fake_dns_enabled">Enable FakeDNS</string>
     <string name="summary_pref_fake_dns_enabled">Local DNS returns fake IP addresses (faster, but it may not work for some apps)</string>
 
     <string name="title_pref_ipv6_enabled">Enable IPv6</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="toast_invalid_url">Invalid URL</string>
     <string name="toast_insecure_url_protocol">Please do not use the insecure HTTP protocol subscription address</string>
     <string name="server_lab_need_inbound">Ensure inbounds port is consistent with the settings</string>
-    <string name="toast_malformed_josn">Config malformed</string>
+    <string name="toast_malformed_json">Config malformed</string>
     <string name="server_lab_request_host6">Host(SNI)(Optional)</string>
     <string name="toast_action_not_allowed">Action not allowed</string>
     <string name="server_obfs_password">Obfs password</string>
@@ -185,8 +185,8 @@
     <string name="title_mux_settings">Mux Settings</string>
     <string name="title_pref_mux_enabled">Enable Mux</string>
     <string name="summary_pref_mux_enabled">Faster, but it may cause unstable connectivity\nCustomize how to handle TCP, UDP and QUIC below</string>
-    <string name="title_pref_mux_concurency">TCP connections（range -1 to 1024）</string>
-    <string name="title_pref_mux_xudp_concurency">XUDP connections（range -1 to 1024）</string>
+    <string name="title_pref_mux_concurrency">TCP connections（range -1 to 1024）</string>
+    <string name="title_pref_mux_xudp_concurrency">XUDP connections（range -1 to 1024）</string>
     <string name="title_pref_mux_xudp_quic">Handling of QUIC in mux tunnel</string>
     <string-array name="mux_xudp_quic_entries">
         <item>reject</item>
@@ -195,8 +195,7 @@
     </string-array>
 
     <string name="title_pref_speed_enabled">Enable speed display</string>
-    <string name="summary_pref_speed_enabled">Display current speed in the notification.\nNotification icon would change based on
-        usage.</string>
+    <string name="summary_pref_speed_enabled">Display current speed in the notification.\nNotification icon would change based on usage.</string>
 
     <string name="title_pref_sniffing_enabled">Enable Sniffing</string>
     <string name="summary_pref_sniffing_enabled">Try sniff domain from the packet (default on)</string>
@@ -386,7 +385,7 @@
     <string name="connection_test_error_status_code">Error code: #%d</string>
     <string name="connection_connected">Connected, tap to check connection</string>
     <string name="connection_not_connected">Not connected</string>
-    <string name="connection_runing_task_left">Number of running test tasks: %s</string>
+    <string name="connection_running_task_left">Number of running test tasks: %s</string>
 
     <string name="import_subscription_success">Subscription imported Successfully</string>
     <string name="import_subscription_failure">Import subscription failed</string>


### PR DESCRIPTION
## Context

Partially fixes #6005.

This is part 1 of 3 extracted from the broader localization audit in #6021, following the request to split that PR into independently reviewable changes. This part is limited to synchronizing and correcting the Android resource files, completing their translations, and updating the few code references required by corrected resource identifiers or resource behavior.

## What changed

### Synchronize every maintained locale

- Align English, Arabic, Bangla, Bakhtiari, Persian, Russian, Vietnamese, Simplified Chinese, and Traditional Chinese to the same 399 named resources.
- Keep every resource at the same physical row, with the same type, order, formatting placeholders, and translatability metadata in all nine files.
- Add resources that were missing from individual locales, including browser-dialer settings, insecure-protocol warnings, unknown-app text, subscription-worker text, automatic subscription-test settings, mode/root settings, request headers, routing fields, browser-dialer modes, and preset rulesets.
- Use localized wording where a dependable translation is available; retain exact Xray and protocol terminology where translating it would change or obscure the meaning.
- Expand localized string arrays to one item per line while preserving cross-locale row alignment.

### Correct identifiers and references

- Correct `title_pref_mux_concurency` to `title_pref_mux_concurrency`.
- Correct `title_pref_mux_xudp_concurency` to `title_pref_mux_xudp_concurrency`.
- Correct `connection_runing_task_left` to `connection_running_task_left`.
- Correct `toast_malformed_josn` to `toast_malformed_json` and update its call site.
- Remove the unused pre-Compose `toast_fragment_not_available` resource.
- Restore the routing outbound-tag placeholder in Compose and substitute each locale's own translation of `remarks` while preserving the literal `proxy`, `direct`, and `block` tags.

### Improve translation accuracy

- Make routing terminology consistent with the corresponding Settings labels, including `routeOnly` behavior.
- Correct awkward or overly literal wording in both English and translated resources.
- Keep Xray's `reject`, `allow`, `skip`, `leastLoad`, `mldsa65Verify`, `echConfigList`, and other core terms semantically exact.
- Correct translations whose previous wording described a different action or setting, including XUDP-over-QUIC handling, current-load selection, certificate verification, destination-domain detection, speed-notification behavior, and remarks regex filtering.
- Fill the remaining Bakhtiari English fallbacks using established vocabulary while leaving strictly technical tokens intact.
- Standardize `URL` and `ALPN` capitalization.

### Exclude fixed technical values from translation

- Mark 23 fixed acronyms, product names, syntax examples, and raw configuration keys as non-translatable, including `TLS`, `ALPN`, `SNI`, `DNS`, `URL`, `Logcat`, `WebDAV`, `mldsa65Verify`, `echConfigList`, and the raw routing keys.
- Mark the selectable VPN interface address patterns non-translatable.
- Leave genuine UI concepts such as path, fingerprint, public key, and explanatory text available to translators.

## Why

Several locale files lacked identifiers that already existed in the English source, causing Android to fall back to another available resource. Other identifiers were misspelled differently between code and resources, and a few technical labels had drifted away from the Xray fields they describe. Keeping the files structurally identical makes missing resources and future drift visible during review, while the wording corrections ensure the localized UI still describes the code path that actually consumes each string.

## Scope

This PR intentionally does not include the other two portions extracted from #6021:

1. moving additional hardcoded user-facing and accessibility text into resources; or
2. applying the selected app locale consistently in non-activity contexts and services.

Those changes will be submitted separately.

## Validation

- Refreshed against current `upstream/master`; this branch is zero commits behind its base.
- Verified all nine `strings.xml` files parse and contain exactly 399 named resources.
- Verified identical identifiers, resource types, order, physical rows, format placeholders, and `translatable` attributes across locales.
- Verified every non-translatable value is identical across locales.
- Verified no stale misspelled identifiers remain in code or resources.
- Verified localized string arrays contain no wrapped or inline item fragments.
- Verified `git diff --check` for the complete branch.
- `:app:processPlaystoreDebugResources` passes on the final resources.
- `:app:compilePlaystoreDebugKotlin` passes with the matching upstream AndroidLib AAR.
