### PR TITLE
fix: handle multiple '#' symbols in fixIllegalUrl

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/Utils.kt
@@ -400,8 +400,15 @@ object Utils {
      * @return The URL string with illegal characters replaced.
      */
     fun fixIllegalUrl(str: String): String {
-        return str.replace(" ", "%20")
+        val fixed = str.replace(" ", "%20")
             .replace("|", "%7C")
+
+        val parts = fixed.split("#", limit = 2)
+        return if (parts.size == 2) {
+            "${parts[0]}#${parts[1].replace("#", "%23")}"
+        } else {
+            fixed
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where URIs containing multiple # symbols in server remarks (e.g., `vless://...?foo=bar#foo#bar`) fail to parse with `URISyntaxException`.