### PR TITLE
fix: localize runtime-generated UI text (5/3)

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -179,7 +179,7 @@ object AppConfig {
     const val MSG_STATE_STOP_SUCCESS = 41
     const val MSG_STATE_RESTART = 5
     const val MSG_MEASURE_DELAY = 6
-    const val MSG_MEASURE_DELAY_SUCCESS = 61
+    const val MSG_MEASURE_DELAY_RESULT = 61
     const val MSG_MEASURE_CONFIG_START = 7
     const val MSG_MEASURE_CONFIG_CANCEL = 71
     const val MSG_MEASURE_CONFIG_SUCCESS = 72

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -11,9 +11,9 @@ import android.os.ParcelFileDescriptor
 import android.system.OsConstants
 import androidx.core.content.ContextCompat
 import com.v2ray.ang.AppConfig
-import com.v2ray.ang.R
 import com.v2ray.ang.contracts.IDialerService
 import com.v2ray.ang.contracts.ServiceControl
+import com.v2ray.ang.dto.ConnectionTestResult
 import com.v2ray.ang.dto.OutboundTrafficStat
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.enums.BrowserDialerMode
@@ -321,28 +321,34 @@ object CoreServiceManager {
                 time = coreController.measureDelay(SettingsManager.getDelayTestUrl())
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to measure delay", e)
-                errorStr = e.message?.substringAfter("\":") ?: "empty message"
+                errorStr = e.message?.substringAfter("\":").orEmpty()
             }
             if (time == -1L) {
                 try {
                     time = coreController.measureDelay(SettingsManager.getDelayTestUrl(true))
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to measure delay", e)
-                    errorStr = e.message?.substringAfter("\":") ?: "empty message"
+                    errorStr = e.message?.substringAfter("\":").orEmpty()
                 }
             }
 
-            val result = if (time >= 0) {
-                service.getString(R.string.connection_test_available, time)
-            } else {
-                service.getString(R.string.connection_test_error, errorStr)
-            }
-            MessageHelper.sendMsg2UI(service, AppConfig.MSG_MEASURE_DELAY_SUCCESS, result)
+            val result = ConnectionTestResult(
+                delayMillis = time,
+                errorMessage = errorStr,
+            )
+            MessageHelper.sendMsg2UI(service, AppConfig.MSG_MEASURE_DELAY_RESULT, result)
 
             // Only fetch IP info if the delay test was successful
             if (time >= 0) {
                 SpeedtestManager.getRemoteIPInfo()?.let { ip ->
-                    MessageHelper.sendMsg2UI(service, AppConfig.MSG_MEASURE_DELAY_SUCCESS, "$result\n$ip")
+                    MessageHelper.sendMsg2UI(
+                        service,
+                        AppConfig.MSG_MEASURE_DELAY_RESULT,
+                        result.copy(
+                            country = ip.country,
+                            ipAddress = ip.ipAddress,
+                        ),
+                    )
                 }
             }
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/ConnectionTestResult.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/ConnectionTestResult.kt
@@ -1,0 +1,11 @@
+package com.v2ray.ang.dto
+
+import java.io.Serializable
+
+/** Locale-neutral result sent from the daemon for presentation by the UI process. */
+data class ConnectionTestResult(
+    val delayMillis: Long,
+    val errorMessage: String = "",
+    val country: String? = null,
+    val ipAddress: String? = null,
+) : Serializable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServerAffiliationInfo.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServerAffiliationInfo.kt
@@ -1,10 +1,3 @@
 package com.v2ray.ang.dto.entities
 
-data class ServerAffiliationInfo(var testDelayMillis: Long = 0L) {
-    fun getTestDelayString(): String {
-        if (testDelayMillis == 0L) {
-            return ""
-        }
-        return testDelayMillis.toString() + "ms"
-    }
-}
+data class ServerAffiliationInfo(var testDelayMillis: Long = 0L)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServersCache.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/ServersCache.kt
@@ -4,5 +4,4 @@ data class ServersCache(
     val guid: String,
     val profile: ProfileItem,
     val testDelayMillis: Long = 0L,
-    val testDelayString: String = "",
 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SpeedtestManager.kt
@@ -13,6 +13,11 @@ import java.net.UnknownHostException
 
 object SpeedtestManager {
 
+    data class RemoteEndpointInfo(
+        val country: String?,
+        val ipAddress: String?,
+    )
+
     /**
      * Measures the time taken to establish a TCP connection to a given URL and port.
      *
@@ -48,7 +53,7 @@ object SpeedtestManager {
         return -1
     }
 
-    fun getRemoteIPInfo(): String? {
+    fun getRemoteIPInfo(): RemoteEndpointInfo? {
         val url = MmkvManager.decodeSettingsString(AppConfig.PREF_IP_API_URL)
             .takeIf { !it.isNullOrBlank() } ?: AppConfig.IP_API_URL
 
@@ -81,6 +86,9 @@ object SpeedtestManager {
             ipInfo.location?.country_code
         ).firstOrNull { !it.isNullOrBlank() }
 
-        return "(${country ?: "unknown"}) ${ip ?: "unknown"}"
+        return RemoteEndpointInfo(
+            country = country,
+            ipAddress = ip,
+        )
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/checkupdate/CheckUpdateViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/checkupdate/CheckUpdateViewModel.kt
@@ -42,12 +42,8 @@ class CheckUpdateViewModel(application: Application) : BaseViewModel(application
                     toastSuccess(R.string.update_already_latest_version)
                 }
             } catch (e: Exception) {
-                LogUtil.e(AppConfig.TAG, "Failed to check for updates: ${e.message}")
-                if (e.message == null) {
-                    toastError(R.string.toast_failure)
-                } else {
-                    toastError(e.message.orEmpty())
-                }
+                LogUtil.e(AppConfig.TAG, "Failed to check for updates", e)
+                toastError(R.string.toast_failure)
             }
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/FormFields.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/FormFields.kt
@@ -78,6 +78,7 @@ fun FormDropdownField(
     editable: Boolean = false,
     enabled: Boolean = true,
     placeholder: String? = null,
+    supportingText: String? = null,
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
     val menuScrollState = rememberScrollState()
@@ -104,6 +105,7 @@ fun FormDropdownField(
             enabled = enabled,
             label = { Text(label) },
             placeholder = { if (placeholder != null) Text(placeholder) },
+            supportingText = supportingText?.let { { Text(it) } },
             trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
             colors = OutlinedTextFieldDefaults.colors(
                 focusedContainerColor = Color.Transparent,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatActivity.kt
@@ -37,12 +37,14 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.FileProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
-import com.v2ray.ang.extension.toast
+import com.v2ray.ang.extension.toastError
 import com.v2ray.ang.ui.base.BaseComponentActivity
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.verticalScrollbar
+import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -91,8 +93,9 @@ class LogcatActivity : BaseComponentActivity() {
 
                 uri to logFile.name
             } catch (e: Exception) {
+                LogUtil.e(AppConfig.TAG, "Failed to share Logcat", e)
                 withContext(Dispatchers.Main) {
-                    toast(e.localizedMessage ?: e.toString())
+                    toastError(R.string.toast_failure)
                 }
                 return@launch
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -1,7 +1,17 @@
 package com.v2ray.ang.ui.main
 
+import com.v2ray.ang.dto.ConnectionTestResult
 import com.v2ray.ang.dto.GroupMapItem
 import com.v2ray.ang.dto.LocateTarget
+
+/** Locale-neutral state formatted only when it reaches the main UI. */
+sealed interface MainStatus {
+    data object Disconnected : MainStatus
+    data object Connected : MainStatus
+    data object Testing : MainStatus
+    data class TestProgress(val progress: String) : MainStatus
+    data class ConnectionTest(val result: ConnectionTestResult) : MainStatus
+}
 
 /**
  * Main UI state
@@ -12,7 +22,7 @@ data class MainUiState(
     val selectedGuid: String? = null,
     val isRunning: Boolean = false,
     val isTesting: Boolean = false,
-    val statusText: String = "",
+    val status: MainStatus = MainStatus.Disconnected,
     val locateTarget: LocateTarget? = null,
     val confirmRemove: Boolean = false,
     val doubleColumnDisplay: Boolean = false,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -8,12 +8,14 @@ import androidx.core.content.ContextCompat
 import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
+import com.v2ray.ang.dto.ConnectionTestResult
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.ServerAffiliationInfo
 import com.v2ray.ang.dto.entities.SubscriptionCache
 import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.MmkvManager
@@ -52,14 +54,12 @@ class MainRepository(
                 AppConfig.MSG_STATE_RUNNING -> MainServiceEvent.StateRunning
                 AppConfig.MSG_STATE_NOT_RUNNING -> MainServiceEvent.StateNotRunning
                 AppConfig.MSG_STATE_START_SUCCESS -> MainServiceEvent.StateStartSuccess
-                AppConfig.MSG_STATE_START_FAILURE -> MainServiceEvent.StateStartFailure(
-                    safeIntent.getStringExtra("content").orEmpty()
-                )
+                AppConfig.MSG_STATE_START_FAILURE -> MainServiceEvent.StateStartFailure
 
                 AppConfig.MSG_STATE_STOP_SUCCESS -> MainServiceEvent.StateStopSuccess
-                AppConfig.MSG_MEASURE_DELAY_SUCCESS -> MainServiceEvent.MeasureDelaySuccess(
-                    safeIntent.getStringExtra("content").orEmpty()
-                )
+                AppConfig.MSG_MEASURE_DELAY_RESULT -> safeIntent
+                    .serializable<ConnectionTestResult>("content")
+                    ?.let { MainServiceEvent.MeasureDelayResult(it) }
 
                 AppConfig.MSG_MEASURE_CONFIG_SUCCESS -> MainServiceEvent.MeasureConfigSuccess
                 AppConfig.MSG_MEASURE_CONFIG_NOTIFY -> MainServiceEvent.MeasureConfigNotify(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -44,7 +44,7 @@ fun MainScreen(
     val groups = uiState.groups
     val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
     val isRunning = uiState.isRunning
-    val displayText = uiState.statusText
+    val displayText = mainViewModel.formatStatus(uiState.status)
     val selectedGuid = uiState.selectedGuid
     val doubleColumnDisplay = uiState.doubleColumnDisplay
     val confirmRemove = uiState.confirmRemove

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextOverflow
@@ -249,7 +250,6 @@ private fun ServerItemRow(
         statistics = profile.description.nullIfBlank()
             ?: AngConfigManager.generateDescription(profile),
         typeDescription = getProtocolDescription(profile),
-        testResult = serverCache.testDelayString,
         testDelayMillis = serverCache.testDelayMillis,
         isSelected = serverCache.guid == selectedGuid,
         subscriptionRemarks = subRemarks,
@@ -283,7 +283,6 @@ private fun ServerItemColumn(
             remarks = profile.remarks,
             statistics = profile.description.nullIfBlank() ?: AngConfigManager.generateDescription(profile),
             typeDescription = getProtocolDescription(profile),
-            testResult = serverCache.testDelayString,
             testDelayMillis = serverCache.testDelayMillis,
             isSelected = serverCache.guid == selectedGuid,
             subscriptionRemarks = subRemarks,
@@ -303,7 +302,6 @@ fun ServerListItem(
     remarks: String,
     statistics: String,
     typeDescription: String,
-    testResult: String,
     testDelayMillis: Long,
     isSelected: Boolean,
     subscriptionRemarks: String,
@@ -316,6 +314,12 @@ fun ServerListItem(
     modifier: Modifier = Modifier,
     dragModifier: Modifier = Modifier
 ) {
+    val testResult = if (testDelayMillis == 0L) {
+        ""
+    } else {
+        stringResource(R.string.server_test_delay_value, testDelayMillis)
+    }
+
     Row(
         modifier = modifier
             .fillMaxWidth()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
@@ -1,12 +1,14 @@
 package com.v2ray.ang.ui.main
 
+import com.v2ray.ang.dto.ConnectionTestResult
+
 sealed class MainServiceEvent {
     data object StateRunning : MainServiceEvent()
     data object StateNotRunning : MainServiceEvent()
     data object StateStartSuccess : MainServiceEvent()
-    data class StateStartFailure(val errorMessage: String) : MainServiceEvent()
+    data object StateStartFailure : MainServiceEvent()
     data object StateStopSuccess : MainServiceEvent()
-    data class MeasureDelaySuccess(val content: String) : MainServiceEvent()
+    data class MeasureDelayResult(val result: ConnectionTestResult) : MainServiceEvent()
     data object MeasureConfigSuccess : MainServiceEvent()
     data class MeasureConfigNotify(val progress: String) : MainServiceEvent()
     data class MeasureConfigFinish(val finishedCount: String?) : MainServiceEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
+import com.v2ray.ang.dto.ConnectionTestResult
 import com.v2ray.ang.dto.GroupMapItem
 import com.v2ray.ang.dto.LocateTarget
 import com.v2ray.ang.dto.TestServiceMessage
@@ -45,15 +46,11 @@ class MainViewModel(
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
     private val preloadDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1)
 
-    private val disconnectedText: String = dataSource.getString(R.string.connection_not_connected)
-    private val connectedText: String = dataSource.getString(R.string.connection_connected)
-
     // ---------- UI state ----------
     private val _uiState = MutableStateFlow(
         MainUiState(
             selectedGroupId = dataSource.getSelectedSubscriptionId(),
             selectedGuid = dataSource.getSelectServer(),
-            statusText = disconnectedText,
             confirmRemove = dataSource.getConfirmRemove(),
             doubleColumnDisplay = dataSource.getDoubleColumnDisplay()
         )
@@ -105,19 +102,14 @@ class MainViewModel(
                 updateRunningState(true)
             }
 
-            is MainServiceEvent.StateStartFailure -> {
-                val error = event.errorMessage
-                if (error.isNotBlank()) {
-                    toastError(error)
-                } else {
-                    toastError(R.string.toast_services_failure)
-                }
+            MainServiceEvent.StateStartFailure -> {
+                toastError(R.string.toast_services_failure)
                 updateRunningState(false)
             }
 
             MainServiceEvent.StateStopSuccess -> updateRunningState(false)
-            is MainServiceEvent.MeasureDelaySuccess -> {
-                _uiState.update { it.copy(statusText = event.content) }
+            is MainServiceEvent.MeasureDelayResult -> {
+                _uiState.update { it.copy(status = MainStatus.ConnectionTest(event.result)) }
             }
 
             MainServiceEvent.MeasureConfigSuccess -> {
@@ -129,20 +121,44 @@ class MainViewModel(
             }
 
             is MainServiceEvent.MeasureConfigNotify -> {
-                _uiState.update {
-                    it.copy(
-                        statusText = dataSource.getString(
-                            R.string.connection_running_task_left,
-                            event.progress
-                        )
-                    )
-                }
+                _uiState.update { it.copy(status = MainStatus.TestProgress(event.progress)) }
             }
 
             is MainServiceEvent.MeasureConfigFinish -> {
                 onTestsFinished()
             }
         }
+    }
+
+    internal fun formatStatus(status: MainStatus): String = when (status) {
+        MainStatus.Disconnected -> dataSource.getString(R.string.connection_not_connected)
+        MainStatus.Connected -> dataSource.getString(R.string.connection_connected)
+        MainStatus.Testing -> dataSource.getString(R.string.connection_test_testing)
+        is MainStatus.TestProgress -> dataSource.getString(
+            R.string.connection_running_task_left,
+            status.progress
+        )
+
+        is MainStatus.ConnectionTest -> formatConnectionTestResult(status.result)
+    }
+
+    private fun formatConnectionTestResult(result: ConnectionTestResult): String {
+        val status = if (result.delayMillis >= 0) {
+            val delay = dataSource.getString(R.string.server_test_delay_value, result.delayMillis)
+            dataSource.getString(R.string.connection_test_available, delay)
+        } else {
+            val detail = result.errorMessage.ifBlank {
+                dataSource.getString(R.string.connection_test_empty_message)
+            }
+            dataSource.getString(R.string.connection_test_error, detail)
+        }
+
+        if (result.delayMillis < 0 || (result.country == null && result.ipAddress == null)) {
+            return status
+        }
+
+        val unknown = dataSource.getString(R.string.value_unknown)
+        return "$status\n(${result.country ?: unknown}) ${result.ipAddress ?: unknown}"
     }
 
     // ---------- Public state accessors ----------
@@ -235,8 +251,7 @@ class MainViewModel(
             ServersCache(
                 guid = guid,
                 profile = profile.copy(),
-                testDelayMillis = affiliation?.testDelayMillis ?: 0L,
-                testDelayString = affiliation?.getTestDelayString().orEmpty()
+                testDelayMillis = affiliation?.testDelayMillis ?: 0L
             )
         }
 
@@ -665,7 +680,7 @@ class MainViewModel(
         _uiState.update {
             it.copy(
                 isTesting = false,
-                statusText = if (it.isRunning) connectedText else disconnectedText
+                status = if (it.isRunning) MainStatus.Connected else MainStatus.Disconnected
             )
         }
     }
@@ -683,7 +698,7 @@ class MainViewModel(
         _uiState.update {
             it.copy(
                 isTesting = true,
-                statusText = dataSource.getString(R.string.connection_test_testing)
+                status = MainStatus.Testing
             )
         }
         viewModelScope.launch(ioDispatcher) {
@@ -700,11 +715,7 @@ class MainViewModel(
     }
 
     fun testCurrentServerRealPing() {
-        _uiState.update {
-            it.copy(
-                statusText = dataSource.getString(R.string.connection_test_testing)
-            )
-        }
+        _uiState.update { it.copy(status = MainStatus.Testing) }
         dataSource.testCurrentServerRealPing()
     }
 
@@ -715,7 +726,7 @@ class MainViewModel(
             _uiState.update {
                 it.copy(
                     isTesting = false,
-                    statusText = if (it.isRunning) connectedText else disconnectedText
+                    status = if (it.isRunning) MainStatus.Connected else MainStatus.Disconnected
                 )
             }
             reloadAllGroups(_uiState.value.groups.map { it.id })
@@ -751,8 +762,8 @@ class MainViewModel(
         _uiState.update { state ->
             state.copy(
                 isRunning = running,
-                statusText = if (!clearTestingText && state.isTesting) state.statusText
-                else if (running) connectedText else disconnectedText
+                status = if (!clearTestingText && state.isTesting) state.status
+                else if (running) MainStatus.Connected else MainStatus.Disconnected
             )
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
@@ -119,6 +119,7 @@ fun RoutingEditScreen(
     onDelete: () -> Unit
 ) {
     val context = LocalContext.current
+    val processSelectTitle = stringResource(R.string.routing_settings_process_select)
     val scrollState = rememberScrollState()
 
     var remarks by rememberSaveable { mutableStateOf(initial?.remarks ?: "") }
@@ -258,7 +259,7 @@ fun RoutingEditScreen(
                             AppPickerActivity.createIntent(
                                 context = context,
                                 selectedPackages = current,
-                                title = context.getString(R.string.routing_settings_process_select)
+                                title = processSelectTitle
                             )
                         )
                     },
@@ -269,7 +270,7 @@ fun RoutingEditScreen(
                         contentDescription = null
                     )
                     Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(R.string.routing_settings_process_select))
+                    Text(processSelectTitle)
                 }
             }
             FormTextField(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
@@ -220,21 +221,27 @@ fun RoutingEditScreen(
                 checked = locked,
                 onCheckedChange = { locked = it }
             )
+            Text(
+                text = stringResource(R.string.routing_settings_tips),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
             FormTextField(
                 label = stringResource(R.string.routing_settings_domain),
-                placeholder = stringResource(R.string.routing_settings_tips),
+                placeholder = stringResource(R.string.routing_settings_comma_tip),
                 value = domain,
                 onValueChange = { domain = it }
             )
             FormTextField(
                 label = stringResource(R.string.routing_settings_ip),
-                placeholder = stringResource(R.string.routing_settings_tips),
+                placeholder = stringResource(R.string.routing_settings_comma_tip),
                 value = ip,
                 onValueChange = { ip = it }
             )
             FormTextField(
                 label = stringResource(R.string.routing_settings_process),
-                placeholder = stringResource(R.string.routing_settings_tips),
+                placeholder = stringResource(R.string.routing_settings_comma_tip),
                 value = processText,
                 onValueChange = { processText = it },
                 enabled = canUseProcess

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -227,7 +227,8 @@ fun SubEditScreen(
                 value = prevProfile,
                 options = profileSuggestions,
                 onValueChange = { prevProfile = it },
-                editable = true
+                editable = true,
+                supportingText = stringResource(R.string.sub_setting_entry_proxy_tip)
             )
             FormDropdownField(
                 label = stringResource(R.string.sub_setting_next_profile),
@@ -235,7 +236,8 @@ fun SubEditScreen(
                 value = nextProfile,
                 options = profileSuggestions,
                 onValueChange = { nextProfile = it },
-                editable = true
+                editable = true,
+                supportingText = stringResource(R.string.sub_setting_exit_proxy_tip)
             )
         }
     }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">تفعيل التحديث</string>
     <string name="sub_auto_update">تفعيل التحديث التلقائي</string>
     <string name="sub_allow_insecure_url">السماح بعنوان HTTP غير آمن</string>
-    <string name="sub_setting_pre_profile">ملاحظات تكوين الوكيل السابق</string>
-    <string name="sub_setting_next_profile">ملاحظات تكوين الوكيل التالي</string>
+    <string name="sub_setting_pre_profile">وكيل الدخول</string>
+    <string name="sub_setting_next_profile">وكيل الخروج</string>
     <string name="sub_setting_pre_profile_tip">يجب أن تكون ملاحظات التكوين موجودة وفريدة</string>
+    <string name="sub_setting_entry_proxy_tip">يُضاف الوكيل المحدد قبل كل ملف تعريف في هذا الاشتراك كحلقة الدخول في سلسلة الوكلاء لذلك الملف.</string>
+    <string name="sub_setting_exit_proxy_tip">يُضاف الوكيل المحدد بعد كل ملف تعريف في هذا الاشتراك كحلقة الخروج في سلسلة الوكلاء لذلك الملف.</string>
     <string name="toast_invalid_update_interval">فاصل التحديث غير صالح. الحد الأدنى هو 15 دقيقة.</string>
     <string name="title_sub_update">تحديث الاشتراك</string>
     <string name="title_ping_all_server">اختبار تأخير TCP (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">استراتيجية النطاق</string>
     <string name="routing_settings_title">إعدادات التوجيه</string>
-    <string name="routing_settings_tips">افصل بعلامة الفاصلة (,) واختر أحد: domain أو ip أو process</string>
+    <string name="routing_settings_tips">لا تُطبَّق القاعدة إلا إذا تحققت جميع شروط المطابقة المحددة معًا (AND). تُفحص القواعد من الأعلى إلى الأسفل، وتُطبَّق أول قاعدة متطابقة.</string>
+    <string name="routing_settings_comma_tip">افصل بين الإدخالات المتعددة بفواصل (,).</string>
     <string name="routing_settings_save">حفظ</string>
     <string name="routing_settings_delete">مسح</string>
     <string name="routing_settings_rule_title">إعدادات قاعدة التوجيه</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">التحقق من الاتصال</string>
     <string name="connection_test_testing">يجري الاختبار…</string>
     <string name="connection_test_testing_count">جارٍ اختبار %d من التكوينات…</string>
-    <string name="connection_test_available">نجاح: استغرق اتصال HTTP %dms</string>
+    <string name="connection_test_available">تم الاتصال بنجاح خلال %1$s</string>
+    <string name="server_test_delay_value">%1$d ملي ثانية</string>
     <string name="connection_test_error">فشل اختبار الاتصال: %s</string>
     <string name="connection_test_fail">الإنترنت غير متاح</string>
     <string name="connection_test_error_status_code">رمز الخطأ: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">نسخ السجل</string>
     <string name="acc_clear_log">مسح السجل</string>
     <string name="acc_add_rule">إضافة قاعدة توجيه</string>
-    <string name="core_error_no_server_selected">لم يتم تحديد تكوين</string>
-    <string name="core_error_decode_server_config">تعذرت قراءة التكوين المحدد</string>
-    <string name="core_error_build_config_context">تعذر إعداد التكوين المحدد</string>
-    <string name="core_error_get_config">تعذر إنشاء تكوين النواة</string>
-    <string name="core_error_get_config_detail">تعذر إنشاء تكوين النواة: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">تعذر إنشاء تكوين النواة لاختبار السرعة: %1$s</string>
-    <string name="core_error_custom_config_empty">التكوين المخصص فارغ</string>
-    <string name="core_error_start">تعذر تشغيل النواة</string>
     <string name="acc_start">بدء الخدمة</string>
     <string name="acc_stop">إيقاف الخدمة</string>
     <string name="acc_back">رجوع</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">আপডেট সক্রিয় করুন</string>
     <string name="sub_auto_update">স্বয়ংক্রিয় আপডেট সক্রিয় করুন</string>
     <string name="sub_allow_insecure_url">অনিরাপদ HTTP ঠিকানা অনুমোদন করুন</string>
-    <string name="sub_setting_pre_profile">আগের প্রক্সি কনফিগারেশনের মন্তব্য</string>
-    <string name="sub_setting_next_profile">পরবর্তী প্রক্সি কনফিগারেশনের মন্তব্য</string>
+    <string name="sub_setting_pre_profile">প্রবেশ প্রক্সি</string>
+    <string name="sub_setting_next_profile">প্রস্থান প্রক্সি</string>
     <string name="sub_setting_pre_profile_tip">কনফিগারেশনের মন্তব্যটি বিদ্যমান ও অনন্য হতে হবে</string>
+    <string name="sub_setting_entry_proxy_tip">নির্বাচিত প্রক্সিটি এই সাবস্ক্রিপশনের প্রতিটি প্রোফাইলের আগে সেই প্রোফাইলের প্রক্সি চেইনের প্রবেশ লিঙ্ক হিসেবে যোগ করা হবে।</string>
+    <string name="sub_setting_exit_proxy_tip">নির্বাচিত প্রক্সিটি এই সাবস্ক্রিপশনের প্রতিটি প্রোফাইলের পরে সেই প্রোফাইলের প্রক্সি চেইনের প্রস্থান লিঙ্ক হিসেবে যোগ করা হবে।</string>
     <string name="toast_invalid_update_interval">আপডেটের বিরতি সঠিক নয়। সর্বনিম্ন ১৫ মিনিট।</string>
     <string name="title_sub_update">সাবস্ক্রিপশন আপডেট</string>
     <string name="title_ping_all_server">TCP বিলম্ব পরীক্ষা করুন (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">ডোমেইন কৌশল</string>
     <string name="routing_settings_title">রাউটিং সেটিংস</string>
-    <string name="routing_settings_tips">কমা (,) দিয়ে আলাদা করুন। domain, ip বা process-এ একটি নির্বাচন করুন</string>
+    <string name="routing_settings_tips">সব নির্ধারিত মিলের শর্ত একসঙ্গে পূরণ হলেই কেবল নিয়মটি প্রয়োগ হবে (AND)। নিয়মগুলি ওপর থেকে নিচে পরীক্ষা করা হয়; প্রথম মিলে যাওয়া নিয়মটি প্রয়োগ করা হয়।</string>
+    <string name="routing_settings_comma_tip">একাধিক এন্ট্রি কমা (,) দিয়ে আলাদা করুন।</string>
     <string name="routing_settings_save">সেভ করুন</string>
     <string name="routing_settings_delete">মুছে ফেলুন</string>
     <string name="routing_settings_rule_title">রাউটিং নিয়মের সেটিংস</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">সংযোগ পরীক্ষা করুন</string>
     <string name="connection_test_testing">পরীক্ষা চলছে…</string>
     <string name="connection_test_testing_count">%dটি কনফিগারেশন পরীক্ষা করা হচ্ছে…</string>
-    <string name="connection_test_available">সফল: HTTP সংযোগ নিয়েছে %dms</string>
+    <string name="connection_test_available">সংযোগ সফল হয়েছে; সময় লেগেছে %1$s</string>
+    <string name="server_test_delay_value">%1$d মিলিসেকেন্ড</string>
     <string name="connection_test_error">সংযোগ পরীক্ষা ব্যর্থ: %s</string>
     <string name="connection_test_fail">ইন্টারনেট উপলব্ধ নয়</string>
     <string name="connection_test_error_status_code">ত্রুটি কোড: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">লগ কপি করুন</string>
     <string name="acc_clear_log">লগ মুছুন</string>
     <string name="acc_add_rule">রাউটিং নিয়ম যোগ করুন</string>
-    <string name="core_error_no_server_selected">কোনো কনফিগারেশন নির্বাচন করা হয়নি</string>
-    <string name="core_error_decode_server_config">নির্বাচিত কনফিগারেশন পড়তে ব্যর্থ</string>
-    <string name="core_error_build_config_context">নির্বাচিত কনফিগারেশন প্রস্তুত করতে ব্যর্থ</string>
-    <string name="core_error_get_config">কোর কনফিগারেশন তৈরি করতে ব্যর্থ</string>
-    <string name="core_error_get_config_detail">কোর কনফিগারেশন তৈরি করতে ব্যর্থ: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">স্পিড টেস্টের জন্য কোর কনফিগারেশন তৈরি করতে ব্যর্থ: %1$s</string>
-    <string name="core_error_custom_config_empty">কাস্টম কনফিগারেশন খালি</string>
-    <string name="core_error_start">কোর চালু করতে ব্যর্থ</string>
     <string name="acc_start">সার্ভিস শুরু করুন</string>
     <string name="acc_stop">সার্ভিস বন্ধ করুন</string>
     <string name="acc_back">ফিরে যান</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">ره وندن ورۊ کردن</string>
     <string name="sub_auto_update">ره وندن ورۊ کردن خوتکار</string>
     <string name="sub_allow_insecure_url">موجاز کردن نشۊوی HTTP نا ٱمن</string>
-    <string name="sub_setting_pre_profile">نیشتنا کانفیگ پروکسی دیندایی</string>
-    <string name="sub_setting_next_profile">نیشتنا کانفیگ پروکسی نیایی</string>
+    <string name="sub_setting_pre_profile">پروکسی وۊرۊی</string>
+    <string name="sub_setting_next_profile">پروکسی دری</string>
     <string name="sub_setting_pre_profile_tip">موطمئن بۊ ک نیشتنا هڌس وو جۊرس نی</string>
+    <string name="sub_setting_entry_proxy_tip">ای پروکسی پؽش ز هر کانفیگ من ای اشتراک، وری ٱول عوزو زنجیره پروکسی اضاف ابۊ.</string>
+    <string name="sub_setting_exit_proxy_tip">ای پروکسی بئڌ ز هر کانفیگ من ای اشتراک، وری آخر عوزو زنجیره پروکسی اضاف ابۊ.</string>
     <string name="toast_invalid_update_interval">فاصله ورۊ کردن نا موئتبر هڌ. حداقل مقدار 15 دؽقه هڌ.</string>
     <string name="title_sub_update">ورۊ کردن اشتراک بونکۊ سکویی</string>
     <string name="title_ping_all_server">آزمایش تئخیر TCP (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">نشقه دامنه</string>
     <string name="routing_settings_title">سامووا تور جوستن</string>
-    <string name="routing_settings_tips">وا کاما (,) ز یک جوڌا ابۊن؛ یکی ن بزنین: domain، ip یا process</string>
+    <string name="routing_settings_tips">پوی شرطا سئت بیڌه بایڌ هوم زمووی جور ابۊن (AND). قانووݩ یل ز سر و ته وارس ابۊن؛ ٱولی قانووݩ جور وابیڌه و کار ابسته ابۊ.</string>
+    <string name="routing_settings_comma_tip">چنتا مقدار ن وا کاما (,) ز یک جوڌا کۊنین.</string>
     <string name="routing_settings_save">زفت کردن</string>
     <string name="routing_settings_delete">روفتن</string>
     <string name="routing_settings_rule_title">سامووا قانووݩ تور جوستن</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">منپیزن واجۊری کوݩ</string>
     <string name="connection_test_testing">هونی آزمایش ابۊ…</string>
     <string name="connection_test_testing_count">%d کانفیگ هونی آزمایش ابۊ…</string>
-    <string name="connection_test_available">مووفق بی: منپیز %dms طۊل کشی</string>
+    <string name="connection_test_available">مووفق بی: منپیز %1$s طۊل کشی</string>
+    <string name="server_test_delay_value">%1$d میلی‌ثانیه</string>
     <string name="connection_test_error">منپیز و اینترنتن نجوست: %s</string>
     <string name="connection_test_fail">اینترنت من دسرس نؽ</string>
     <string name="connection_test_error_status_code">کود خطا: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">لف گیری گوزارش</string>
     <string name="acc_clear_log">روفتن گوزارش</string>
     <string name="acc_add_rule">ٱووردن قانووݩ</string>
-    <string name="core_error_no_server_selected">هیچ کانفیگ پسند وابیڌه نؽ</string>
-    <string name="core_error_decode_server_config">خوندن کانفیگ پسند وابیڌه مووفق نبی</string>
-    <string name="core_error_build_config_context">پردازشت کانفیگ پسند وابیڌه مووفق نبی</string>
-    <string name="core_error_get_config">ساڌن کانفیگ هسته مووفق نبی</string>
-    <string name="core_error_get_config_detail">ساڌن کانفیگ هسته مووفق نبی: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">ساڌن کانفیگ هسته سی آزمایش سورعت مووفق نبی: %1$s</string>
-    <string name="core_error_custom_config_empty">کانفیگ سفارشی نؽ</string>
-    <string name="core_error_start">ره وستن هسته مووفق نبی</string>
     <string name="acc_start">ره وستن سرویس</string>
     <string name="acc_stop">واڌاشتن سرویس</string>
     <string name="acc_back">برگشت</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">فعال کردن به‌روزرسانی</string>
     <string name="sub_auto_update">فعال سازی به‌روزرسانی خودکار</string>
     <string name="sub_allow_insecure_url">مجاز کردن آدرس HTTP ناامن</string>
-    <string name="sub_setting_pre_profile">نام مستعار پروکسی قبلی</string>
-    <string name="sub_setting_next_profile">نام مستعار پروکسی بعدی</string>
+    <string name="sub_setting_pre_profile">پروکسی ورودی</string>
+    <string name="sub_setting_next_profile">پروکسی خروجی</string>
     <string name="sub_setting_pre_profile_tip">لطفاً مطمئن شوید که نام مستعار وجود دارد و منحصر به فرد است</string>
+    <string name="sub_setting_entry_proxy_tip">پروکسی انتخاب‌شده پیش از هر پروفایل این اشتراک، به‌عنوان حلقهٔ ورودی زنجیرهٔ پروکسی آن پروفایل اضافه می‌شود.</string>
+    <string name="sub_setting_exit_proxy_tip">پروکسی انتخاب‌شده پس از هر پروفایل این اشتراک، به‌عنوان حلقهٔ خروجی زنجیرهٔ پروکسی آن پروفایل اضافه می‌شود.</string>
     <string name="toast_invalid_update_interval">بازه بروزرسانی نامعتبر است. حداقل مقدار 15 دقیقه است.</string>
     <string name="title_sub_update">به‌روزرسانی گروه فعلی اشتراک</string>
     <string name="title_ping_all_server">آزمایش تأخیر TCP (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">استراتژی دامنه</string>
     <string name="routing_settings_title">تنظیمات مسیریابی</string>
-    <string name="routing_settings_tips">با کاما (,) جدا کنید. یکی از موارد domain، ip یا process را وارد کنید</string>
+    <string name="routing_settings_tips">یک قانون فقط زمانی اعمال می‌شود که همهٔ شرط‌های تطبیق واردشده هم‌زمان برقرار باشند (AND). قوانین از بالا به پایین بررسی می‌شوند و نخستین قانون منطبق اعمال می‌شود.</string>
+    <string name="routing_settings_comma_tip">چند ورودی را با کاما (,) جدا کنید.</string>
     <string name="routing_settings_save">ذخیره</string>
     <string name="routing_settings_delete">حذف</string>
     <string name="routing_settings_rule_title">تنظیمات قانون مسیریابی</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">اتصال را بررسی کنید</string>
     <string name="connection_test_testing">در حال آزمایش…</string>
     <string name="connection_test_testing_count">تست کردن %d کانفیگ…</string>
-    <string name="connection_test_available">موفقیت: اتصال %dms طول کشید</string>
+    <string name="connection_test_available">اتصال در %1$s با موفقیت برقرار شد</string>
+    <string name="server_test_delay_value">%1$d میلی‌ثانیه</string>
     <string name="connection_test_error">آزمایش اتصال ناموفق بود: %s</string>
     <string name="connection_test_fail">اینترنت در دسترس نیست</string>
     <string name="connection_test_error_status_code">کد خطا: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">کپی گزارش</string>
     <string name="acc_clear_log">پاک کردن گزارش</string>
     <string name="acc_add_rule">افزودن قانون مسیریابی</string>
-    <string name="core_error_no_server_selected">هیچ پیکربندی‌ای انتخاب نشده است</string>
-    <string name="core_error_decode_server_config">خواندن پیکربندی انتخاب‌شده ناموفق بود</string>
-    <string name="core_error_build_config_context">آماده‌سازی پیکربندی انتخاب‌شده ناموفق بود</string>
-    <string name="core_error_get_config">ایجاد پیکربندی هسته ناموفق بود</string>
-    <string name="core_error_get_config_detail">ایجاد پیکربندی هسته ناموفق بود: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">ایجاد پیکربندی هسته برای آزمایش سرعت ناموفق بود: %1$s</string>
-    <string name="core_error_custom_config_empty">پیکربندی سفارشی خالی است</string>
-    <string name="core_error_start">راه‌اندازی هسته ناموفق بود</string>
     <string name="acc_start">شروع سرویس</string>
     <string name="acc_stop">توقف سرویس</string>
     <string name="acc_back">بازگشت</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">Включить обновление</string>
     <string name="sub_auto_update">Использовать автообновление</string>
     <string name="sub_allow_insecure_url">Разрешать незащищённые HTTP-адреса</string>
-    <string name="sub_setting_pre_profile">Предыдущий профиль прокси</string>
-    <string name="sub_setting_next_profile">Следующий профиль прокси</string>
+    <string name="sub_setting_pre_profile">Входной прокси</string>
+    <string name="sub_setting_next_profile">Выходной прокси</string>
     <string name="sub_setting_pre_profile_tip">Убедитесь, что профиль с таким названием существует и его название уникально</string>
+    <string name="sub_setting_entry_proxy_tip">Выбранный прокси добавляется перед каждым профилем подписки и становится входным звеном цепочки прокси для этого профиля.</string>
+    <string name="sub_setting_exit_proxy_tip">Выбранный прокси добавляется после каждого профиля подписки и становится выходным звеном цепочки прокси для этого профиля.</string>
     <string name="toast_invalid_update_interval">Неправильный интервал обновления. Минимум 15 минут.</string>
     <string name="title_sub_update">Обновить подписку</string>
     <string name="title_ping_all_server">Проверить TCP-задержку (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">Доменная стратегия</string>
     <string name="routing_settings_title">Маршрутизация</string>
-    <string name="routing_settings_tips">Через запятую (,)\nЧто-то одно: домен, IP или процесс</string>
+    <string name="routing_settings_tips">Правило применяется, только если одновременно выполняются все заданные условия сопоставления (AND). Правила проверяются сверху вниз; применяется первое совпавшее правило.</string>
+    <string name="routing_settings_comma_tip">Разделяйте несколько значений запятыми (,).</string>
     <string name="routing_settings_save">Сохранить</string>
     <string name="routing_settings_delete">Очистить</string>
     <string name="routing_settings_rule_title">Настройка правил маршрутизации</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">Проверить соединение</string>
     <string name="connection_test_testing">Проверка…</string>
     <string name="connection_test_testing_count">Проверка профилей (%d)…</string>
-    <string name="connection_test_available">Успешно: соединение заняло %d мс</string>
+    <string name="connection_test_available">Соединение установлено за %1$s</string>
+    <string name="server_test_delay_value">%1$d мс</string>
     <string name="connection_test_error">Ошибка проверки соединения: %s</string>
     <string name="connection_test_fail">Интернет недоступен</string>
     <string name="connection_test_error_status_code">Код ошибки: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">Копировать журнал</string>
     <string name="acc_clear_log">Очистить журнал</string>
     <string name="acc_add_rule">Добавить правило маршрутизации</string>
-    <string name="core_error_no_server_selected">Конфигурация не выбрана</string>
-    <string name="core_error_decode_server_config">Не удалось прочитать выбранную конфигурацию</string>
-    <string name="core_error_build_config_context">Не удалось подготовить выбранную конфигурацию</string>
-    <string name="core_error_get_config">Не удалось создать конфигурацию ядра</string>
-    <string name="core_error_get_config_detail">Не удалось создать конфигурацию ядра: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">Не удалось создать конфигурацию ядра для теста скорости: %1$s</string>
-    <string name="core_error_custom_config_empty">Пользовательская конфигурация пуста</string>
-    <string name="core_error_start">Не удалось запустить ядро</string>
     <string name="acc_start">Запустить службу</string>
     <string name="acc_stop">Остановить службу</string>
     <string name="acc_back">Назад</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">Bật cập nhật</string>
     <string name="sub_auto_update">Bật tự động cập nhật</string>
     <string name="sub_allow_insecure_url">Cho phép địa chỉ HTTP không an toàn</string>
-    <string name="sub_setting_pre_profile">Tên ghi chú của cấu hình proxy trước đó</string>
-    <string name="sub_setting_next_profile">Tên ghi chú của cấu hình proxy tiếp theo</string>
+    <string name="sub_setting_pre_profile">Proxy đầu vào</string>
+    <string name="sub_setting_next_profile">Proxy đầu ra</string>
     <string name="sub_setting_pre_profile_tip">Tên ghi chú của cấu hình phải tồn tại và là duy nhất</string>
+    <string name="sub_setting_entry_proxy_tip">Proxy đã chọn được thêm trước mỗi cấu hình trong gói đăng ký, làm mắt xích đầu vào của chuỗi proxy cho cấu hình đó.</string>
+    <string name="sub_setting_exit_proxy_tip">Proxy đã chọn được thêm sau mỗi cấu hình trong gói đăng ký, làm mắt xích đầu ra của chuỗi proxy cho cấu hình đó.</string>
     <string name="toast_invalid_update_interval">Khoảng thời gian cập nhật không hợp lệ. Giá trị tối thiểu là 15 phút.</string>
     <string name="title_sub_update">Cập nhật gói đăng ký</string>
     <string name="title_ping_all_server">Kiểm tra độ trễ TCP (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">Chiến lược tên miền (DomainStrategy)</string>
     <string name="routing_settings_title">Cài đặt định tuyến</string>
-    <string name="routing_settings_tips">Phân cách bằng dấu phẩy (,). Chọn một trong: domain, ip hoặc process</string>
+    <string name="routing_settings_tips">Quy tắc chỉ được áp dụng khi tất cả điều kiện đối sánh đã đặt đều được thỏa mãn cùng lúc (AND). Các quy tắc được kiểm tra từ trên xuống; quy tắc khớp đầu tiên sẽ được áp dụng.</string>
+    <string name="routing_settings_comma_tip">Phân cách nhiều mục bằng dấu phẩy (,).</string>
     <string name="routing_settings_save">Lưu lại</string>
     <string name="routing_settings_delete">Xoá</string>
     <string name="routing_settings_rule_title">Cài đặt quy tắc định tuyến</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">Kiểm tra kết nối</string>
     <string name="connection_test_testing">Đang kiểm tra kết nối mạng…</string>
     <string name="connection_test_testing_count">Đang kiểm tra %d cấu hình…</string>
-    <string name="connection_test_available">Kiểm tra thành công: thời gian truy cập Google là %d ms</string>
+    <string name="connection_test_available">Kết nối thành công sau %1$s</string>
+    <string name="server_test_delay_value">%1$d mili giây</string>
     <string name="connection_test_error">Kiểm tra kết nối thất bại: %s</string>
     <string name="connection_test_fail">Không thể truy cập Internet</string>
     <string name="connection_test_error_status_code">Mã lỗi: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">Sao chép nhật ký</string>
     <string name="acc_clear_log">Xóa nhật ký</string>
     <string name="acc_add_rule">Thêm quy tắc định tuyến</string>
-    <string name="core_error_no_server_selected">Chưa chọn cấu hình</string>
-    <string name="core_error_decode_server_config">Không thể đọc cấu hình đã chọn</string>
-    <string name="core_error_build_config_context">Không thể chuẩn bị cấu hình đã chọn</string>
-    <string name="core_error_get_config">Không thể tạo cấu hình lõi</string>
-    <string name="core_error_get_config_detail">Không thể tạo cấu hình lõi: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">Không thể tạo cấu hình lõi để kiểm tra tốc độ: %1$s</string>
-    <string name="core_error_custom_config_empty">Cấu hình tùy chỉnh đang trống</string>
-    <string name="core_error_start">Không thể khởi động lõi</string>
     <string name="acc_start">Khởi động dịch vụ</string>
     <string name="acc_stop">Dừng dịch vụ</string>
     <string name="acc_back">Quay lại</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">启用更新</string>
     <string name="sub_auto_update">启用自动更新</string>
     <string name="sub_allow_insecure_url">允许不安全的 HTTP 地址</string>
-    <string name="sub_setting_pre_profile">前置代理配置别名</string>
-    <string name="sub_setting_next_profile">落地代理配置別名</string>
+    <string name="sub_setting_pre_profile">入口代理</string>
+    <string name="sub_setting_next_profile">出口代理</string>
     <string name="sub_setting_pre_profile_tip">请确保配置别名存在并唯一</string>
+    <string name="sub_setting_entry_proxy_tip">所选代理会添加到该订阅中每个配置的前面，作为该配置代理链的入口节点。</string>
+    <string name="sub_setting_exit_proxy_tip">所选代理会添加到该订阅中每个配置的后面，作为该配置代理链的出口节点。</string>
     <string name="toast_invalid_update_interval">更新间隔无效，最小值为 15 分钟。</string>
     <string name="title_sub_update">更新订阅</string>
     <string name="title_ping_all_server">测试 TCP 延迟（TCPing）</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">域名策略</string>
     <string name="routing_settings_title">路由设置</string>
-    <string name="routing_settings_tips">用逗号（,）分隔，选择填写 domain、ip 或 process 中的一项</string>
+    <string name="routing_settings_tips">一条规则仅在所有已设置的匹配条件同时满足时生效（AND）。规则按从上到下的顺序检查，并应用首条匹配的规则。</string>
+    <string name="routing_settings_comma_tip">多个条目请用逗号（,）分隔。</string>
     <string name="routing_settings_save">保存</string>
     <string name="routing_settings_delete">清空</string>
     <string name="routing_settings_rule_title">路由规则设置</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">"检查网络连接"</string>
     <string name="connection_test_testing">"测试中…"</string>
     <string name="connection_test_testing_count">测试 %d 个配置中…</string>
-    <string name="connection_test_available">"连接成功：延时 %d 毫秒"</string>
+    <string name="connection_test_available">"连接成功：延时 %1$s"</string>
+    <string name="server_test_delay_value">%1$d 毫秒</string>
     <string name="connection_test_error">连接测试失败：%s</string>
     <string name="connection_test_fail">无法访问互联网</string>
     <string name="connection_test_error_status_code">错误码：#%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">复制日志</string>
     <string name="acc_clear_log">清除日志</string>
     <string name="acc_add_rule">添加路由规则</string>
-    <string name="core_error_no_server_selected">未选择配置</string>
-    <string name="core_error_decode_server_config">无法读取所选配置</string>
-    <string name="core_error_build_config_context">无法准备所选配置</string>
-    <string name="core_error_get_config">无法生成核心配置</string>
-    <string name="core_error_get_config_detail">无法生成核心配置：%1$s</string>
-    <string name="core_error_get_speedtest_config_detail">无法生成测速用核心配置：%1$s</string>
-    <string name="core_error_custom_config_empty">自定义配置为空</string>
-    <string name="core_error_start">无法启动核心</string>
     <string name="acc_start">启动服务</string>
     <string name="acc_stop">停止服务</string>
     <string name="acc_back">返回</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -318,7 +318,7 @@
     <string name="title_del_duplicate_config">删除重复配置</string>
     <string name="title_del_invalid_config">删除无效配置</string>
     <string name="title_export_all">将配置导出至剪贴板</string>
-    <string name="title_sub_setting">订阅</string>
+    <string name="title_sub_setting">订阅分组</string>
     <string name="sub_setting_remarks">备注</string>
     <string name="sub_setting_url">URL（可选）</string>
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
@@ -327,8 +327,8 @@
     <string name="sub_setting_enable">启用更新</string>
     <string name="sub_auto_update">启用自动更新</string>
     <string name="sub_allow_insecure_url">允许不安全的 HTTP 地址</string>
-    <string name="sub_setting_pre_profile">入口代理</string>
-    <string name="sub_setting_next_profile">出口代理</string>
+    <string name="sub_setting_pre_profile">前置代理配置别名</string>
+    <string name="sub_setting_next_profile">落地代理配置別名</string>
     <string name="sub_setting_pre_profile_tip">请确保配置别名存在并唯一</string>
     <string name="sub_setting_entry_proxy_tip">所选代理会添加到该订阅中每个配置的前面，作为该配置代理链的入口节点。</string>
     <string name="sub_setting_exit_proxy_tip">所选代理会添加到该订阅中每个配置的后面，作为该配置代理链的出口节点。</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">啟用更新</string>
     <string name="sub_auto_update">啟用自動更新</string>
     <string name="sub_allow_insecure_url">允許不安全的 HTTP 位址</string>
-    <string name="sub_setting_pre_profile">前置代理設定檔别名</string>
-    <string name="sub_setting_next_profile">落地代理設定檔別名</string>
+    <string name="sub_setting_pre_profile">入口代理</string>
+    <string name="sub_setting_next_profile">出口代理</string>
     <string name="sub_setting_pre_profile_tip">請確保設定檔別名存在且唯一</string>
+    <string name="sub_setting_entry_proxy_tip">所選代理會加在此訂閱中每個設定檔之前，作為該設定檔代理鏈的入口節點。</string>
+    <string name="sub_setting_exit_proxy_tip">所選代理會加在此訂閱中每個設定檔之後，作為該設定檔代理鏈的出口節點。</string>
     <string name="toast_invalid_update_interval">更新間隔無效，最小值為 15 分鐘。</string>
     <string name="title_sub_update">更新訂閱</string>
     <string name="title_ping_all_server">測試 TCP 延遲（TCPing）</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">網域策略</string>
     <string name="routing_settings_title">路由設定</string>
-    <string name="routing_settings_tips">用逗號（,）分隔，選擇填寫 domain、ip 或 process 中的一項</string>
+    <string name="routing_settings_tips">一條規則只有在所有已設定的比對條件同時符合時才會生效（AND）。規則會由上而下檢查，並套用第一條符合的規則。</string>
+    <string name="routing_settings_comma_tip">多個項目請用逗號（,）分隔。</string>
     <string name="routing_settings_save">儲存</string>
     <string name="routing_settings_delete">清除</string>
     <string name="routing_settings_rule_title">路由規則設定</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">"測試連線能力"</string>
     <string name="connection_test_testing">"測試中……"</string>
     <string name="connection_test_testing_count">正在測試 %d 個設定…</string>
-    <string name="connection_test_available">"成功：%d ms延遲"</string>
+    <string name="connection_test_available">"連線成功：延遲 %1$s"</string>
+    <string name="server_test_delay_value">%1$d 毫秒</string>
     <string name="connection_test_error">連線測試失敗：%s</string>
     <string name="connection_test_fail">"無法使用網際網路"</string>
     <string name="connection_test_error_status_code">錯誤碼：#%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">複製日誌</string>
     <string name="acc_clear_log">清除日誌</string>
     <string name="acc_add_rule">新增路由規則</string>
-    <string name="core_error_no_server_selected">未選取設定</string>
-    <string name="core_error_decode_server_config">無法讀取所選設定</string>
-    <string name="core_error_build_config_context">無法準備所選設定</string>
-    <string name="core_error_get_config">無法產生核心設定</string>
-    <string name="core_error_get_config_detail">無法產生核心設定：%1$s</string>
-    <string name="core_error_get_speedtest_config_detail">無法產生測速用核心設定：%1$s</string>
-    <string name="core_error_custom_config_empty">自訂設定為空</string>
-    <string name="core_error_start">無法啟動核心</string>
     <string name="acc_start">啟動服務</string>
     <string name="acc_stop">停止服務</string>
     <string name="acc_back">返回</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -318,7 +318,7 @@
     <string name="title_del_duplicate_config">刪除重複設定</string>
     <string name="title_del_invalid_config">刪除無效設定</string>
     <string name="title_export_all">將設定匯出至剪貼簿</string>
-    <string name="title_sub_setting">訂閱</string>
+    <string name="title_sub_setting">訂閱分組</string>
     <string name="sub_setting_remarks">備註</string>
     <string name="sub_setting_url">URL（可選）</string>
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
@@ -327,8 +327,8 @@
     <string name="sub_setting_enable">啟用更新</string>
     <string name="sub_auto_update">啟用自動更新</string>
     <string name="sub_allow_insecure_url">允許不安全的 HTTP 位址</string>
-    <string name="sub_setting_pre_profile">入口代理</string>
-    <string name="sub_setting_next_profile">出口代理</string>
+    <string name="sub_setting_pre_profile">前置代理設定檔别名</string>
+    <string name="sub_setting_next_profile">落地代理設定檔別名</string>
     <string name="sub_setting_pre_profile_tip">請確保設定檔別名存在且唯一</string>
     <string name="sub_setting_entry_proxy_tip">所選代理會加在此訂閱中每個設定檔之前，作為該設定檔代理鏈的入口節點。</string>
     <string name="sub_setting_exit_proxy_tip">所選代理會加在此訂閱中每個設定檔之後，作為該設定檔代理鏈的出口節點。</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -327,9 +327,11 @@
     <string name="sub_setting_enable">Enable update</string>
     <string name="sub_auto_update">Enable automatic update</string>
     <string name="sub_allow_insecure_url">Allow insecure HTTP address</string>
-    <string name="sub_setting_pre_profile">Previous proxy config remarks</string>
-    <string name="sub_setting_next_profile">Next proxy config remarks</string>
+    <string name="sub_setting_pre_profile">Entry proxy</string>
+    <string name="sub_setting_next_profile">Exit proxy</string>
     <string name="sub_setting_pre_profile_tip">Make sure the config remarks exist and are unique</string>
+    <string name="sub_setting_entry_proxy_tip">The selected proxy is added before every profile in this subscription as the entry link in the proxy chain for that profile.</string>
+    <string name="sub_setting_exit_proxy_tip">The selected proxy is added after every profile in this subscription as the exit link in the proxy chain for that profile.</string>
     <string name="toast_invalid_update_interval">Invalid update interval. Minimum is 15 minutes.</string>
     <string name="title_sub_update">Update subscription</string>
     <string name="title_ping_all_server">Test TCP delays (TCPing)</string>
@@ -355,7 +357,8 @@
     <!-- RoutingSettingActivity -->
     <string name="routing_settings_domain_strategy">Domain strategy</string>
     <string name="routing_settings_title">Routing Settings</string>
-    <string name="routing_settings_tips">Separated by commas(,), \nchoose domain or ip or process</string>
+    <string name="routing_settings_tips">A rule applies only when every configured matching condition is satisfied (AND). Rules are checked from top to bottom; the first matching rule is applied.</string>
+    <string name="routing_settings_comma_tip">Separate multiple entries with commas (,).</string>
     <string name="routing_settings_save">Save</string>
     <string name="routing_settings_delete">Clear</string>
     <string name="routing_settings_rule_title">Routing Rule Settings</string>
@@ -380,7 +383,8 @@
     <string name="connection_test_pending">Check connectivity</string>
     <string name="connection_test_testing">Testing…</string>
     <string name="connection_test_testing_count">Testing %d configs…</string>
-    <string name="connection_test_available">Success: Connection took %dms</string>
+    <string name="connection_test_available">Connection succeeded in %1$s</string>
+    <string name="server_test_delay_value">%1$d ms</string>
     <string name="connection_test_error">Connection test failed: %s</string>
     <string name="connection_test_fail">Internet unavailable</string>
     <string name="connection_test_error_status_code">Error code: #%d</string>
@@ -502,14 +506,6 @@
     <string name="acc_copy_log">Copy log</string>
     <string name="acc_clear_log">Clear log</string>
     <string name="acc_add_rule">Add routing rule</string>
-    <string name="core_error_no_server_selected">No configuration selected</string>
-    <string name="core_error_decode_server_config">Failed to read the selected configuration</string>
-    <string name="core_error_build_config_context">Failed to prepare the selected configuration</string>
-    <string name="core_error_get_config">Failed to generate the core configuration</string>
-    <string name="core_error_get_config_detail">Failed to generate the core configuration: %1$s</string>
-    <string name="core_error_get_speedtest_config_detail">Failed to generate the core configuration for the speed test: %1$s</string>
-    <string name="core_error_custom_config_empty">Custom configuration is empty</string>
-    <string name="core_error_start">Failed to start the core</string>
     <string name="acc_start">Start service</string>
     <string name="acc_stop">Stop service</string>
     <string name="acc_back">Back</string>


### PR DESCRIPTION
## Context and series

Follow-up to #6005.

This is the extracted **part 5 of 3** in the localization series. It contains the runtime-code changes that were still bundled into the previous combined Part 3 draft in #6044, which itself was extracted from the original localization audit in #6021.

- **Part 1 — #6024 (merged):** synchronized the locale catalogs, filled missing translations, corrected divergent meanings, and marked invariant technical values non-translatable.
- **Part 2 — #6025 (merged):** extracted hardcoded user-facing text, introduced dedicated accessibility descriptions, and localized the resulting resources.
- **Part 3 — #6047:** makes the selected app language authoritative in Android resource contexts.
- **Part 4 — #6048:** contains standalone XML-only translation and wording corrections.
- **Part 5 — this PR:** keeps runtime data locale-neutral until it reaches the UI and localizes the remaining code-dependent presentation.

This branch is intentionally based on `master`, with no commits copied from Parts 3 or 4. It is designed to follow those PRs in the series.

## Why runtime localization needs a separate boundary

Some text cannot be corrected by editing `strings.xml` alone. Connection tests, profile delays, exceptions, and retained main-screen status were being converted into display strings before the final UI knew which app locale to use.

Formatting those values in a service or daemon path has two problems:

1. that process or `Context` can resolve resources using the device language rather than the language selected in v2rayNG; and
2. localized sentences can leak into Logcat, where stable technical diagnostics are more useful.

This PR therefore transports structured or semantic data through runtime layers and applies localization only at a presentation boundary.

## 1. Keep the connection-test core path locale-neutral

### Producer: `CoreServiceManager`

- Removes Android string-resource formatting from the current-server delay test.
- Renames `MSG_MEASURE_DELAY_SUCCESS` to `MSG_MEASURE_DELAY_RESULT`, because the message now represents either success or failure.
- Sends a serializable `ConnectionTestResult` instead of a finished UI sentence.
- Preserves the raw delay value and technical error detail.
- Adds country code and IP address as separate nullable fields instead of building an English `"(unknown) unknown"` suffix in `SpeedtestManager`.

The DTO contains only locale-neutral values:

- `delayMillis`
- `errorMessage`
- `country`
- `ipAddress`

This keeps `CoreServiceManager` independent of presentation wording. The raw failure remains useful as a diagnostic, while the UI chooses the localized sentence and fallback text. ISO country codes and IP addresses are deliberately not translated.

### Transport: `MainRepository` and `MainServiceEvent`

- Deserializes `ConnectionTestResult` from the service broadcast.
- Carries it through a typed `MeasureDelayResult` event.
- Converts startup failure into semantic `StateStartFailure` state rather than displaying the service's raw exception text as a toast.

### Consumer: `MainViewModel`

- Formats success with `connection_test_available` and a separately localized delay value.
- Formats failure with `connection_test_error` and a localized empty-message fallback.
- Uses the localized unknown-value label only when the country or IP field is absent.
- Leaves actual country codes, IP addresses, and technical error details unchanged.

The complete producer → transport → consumer chain was updated together so no old string payload remains on the connection-test path.

## 2. Represent retained main-screen status semantically

`MainUiState` previously retained already-formatted strings such as **Connected**, **Testing**, and connection-test results. A `ViewModel` survives activity recreation, so such strings could remain in the old language after an app-locale change.

This PR introduces `MainStatus` variants for:

- disconnected;
- connected;
- testing;
- test progress; and
- connection-test results.

`MainScreen` asks `MainViewModel` to format the current semantic status when rendering. The selected app locale is therefore consulted at presentation time instead of being frozen into retained state.

## 3. Localize TCPing and real-delay units in profile rows

`ServerAffiliationInfo.getTestDelayString()` previously appended the literal English unit `ms` before the value reached Compose.

- `ServerAffiliationInfo` and `ServersCache` now retain only the numeric millisecond value.
- `ServerListItem` formats that value with `stringResource(R.string.server_test_delay_value, ...)`.
- The current-connection test uses the same resource, keeping the unit consistent between the main status and profile rows.

The unit resource is provided in all nine maintained locale catalogs.

## 4. Separate diagnostic exceptions from localized user failures

Two exception paths previously exposed platform or exception text directly to users:

- update checking; and
- sharing Logcat output.

Both paths now log the original exception, including its diagnostic detail and stack trace, while showing the stable localized `toast_failure` message in the UI. This avoids device-language/platform exception text in the interface without reducing Logcat usefulness.

Startup failures follow the same principle: the core/service logs the technical cause, while the main UI displays `toast_services_failure`.

## 5. Clarify code-dependent settings UI

### Routing rule matching

The old comma-separated hint was repeated inside the domain, IP, and process fields and incorrectly suggested choosing only one field.

- Displays the rule-combination explanation once above the matching fields.
- States that every populated matching condition must be satisfied together (**AND**).
- States that rules are checked from top to bottom and the first matching rule is applied.
- Keeps a short comma-separated-entry hint inside the applicable fields.

The placement and wording now match how a `RulesetItem` is converted into one Xray routing rule.

### Subscription proxy-chain endpoints

The labels **Previous proxy config remarks** and **Next proxy config remarks** described storage fields rather than their visible effect.

- Renames them to **Entry proxy** and **Exit proxy**.
- Adds reusable supporting text to `FormDropdownField`.
- Explains below each field that the selected proxy is inserted before or after every profile in the subscription as that profile's entry or exit chain link.

The labels remain mapped to the existing `prevProfile` and `nextProfile` fields; no subscription data format or chain-building behavior changes.

## Resource ownership and focus

The new or code-dependent resources are supplied in English, Arabic, Bangla, Bakhtiari, Persian, Russian, Vietnamese, Simplified Chinese, and Traditional Chinese.

This PR changes exactly 16 resource identifiers per locale:

- four new presentation resources;
- four existing code-dependent labels/messages; and
- eight obsolete `core_error_*` resources removed after the core configuration path became resource-neutral.

The catalogs retain identical identifiers, order, physical row alignment, and format placeholders. These resource identifiers do not overlap the identifiers changed by #6047 or #6048.

## Impact

- Connection-test results are formatted in the selected app language at the UI boundary.
- Main-screen status cannot retain a sentence from the previous locale.
- TCPing and real-delay units follow the active locale.
- Core/service paths carry stable data and diagnostics rather than UI prose.
- User-facing failure toasts stay localized while Logcat retains the original exception.
- Routing and subscription-chain settings describe their actual runtime behavior.