### PR TITLE
Render scrollable release notes in update dialog

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/CheckUpdateResult.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/CheckUpdateResult.kt
@@ -4,6 +4,7 @@ data class CheckUpdateResult(
     val hasUpdate: Boolean,
     val latestVersion: String? = null,
     val releaseNotes: String? = null,
+    val releaseNotesHtml: String? = null,
     val downloadUrl: String? = null,
     val error: String? = null,
     val isPreRelease: Boolean = false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/GitHubRelease.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/GitHubRelease.kt
@@ -7,6 +7,8 @@ data class GitHubRelease(
     val tagName: String,
     @SerializedName("body")
     val body: String,
+    @SerializedName("body_html")
+    val bodyHtml: String? = null,
     @SerializedName("assets")
     val assets: List<Asset>,
     @SerializedName("prerelease")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/UpdateCheckerManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/UpdateCheckerManager.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 object UpdateCheckerManager {
+    private const val GITHUB_RELEASE_HEADERS = """{"Accept":"application/vnd.github.full+json"}"""
+
     suspend fun checkForUpdate(includePreRelease: Boolean = false): CheckUpdateResult = withContext(Dispatchers.IO) {
         val url = if (includePreRelease) {
             AppConfig.APP_API_URL
@@ -27,7 +29,8 @@ object UpdateCheckerManager {
         var response = HttpUtil.getUrlContent(
             UrlContentRequest(
                 url = url,
-                timeout = 5000
+                timeout = 5000,
+                requestHeaders = GITHUB_RELEASE_HEADERS
             )
         )
         if (response.isNullOrEmpty()) {
@@ -38,7 +41,8 @@ object UpdateCheckerManager {
                     timeout = 5000,
                     httpPort = httpPort,
                     proxyUsername = proxyUsername,
-                    proxyPassword = proxyPassword
+                    proxyPassword = proxyPassword,
+                    requestHeaders = GITHUB_RELEASE_HEADERS
                 )
             )
                 ?: throw IllegalStateException("Failed to get response")
@@ -67,6 +71,7 @@ object UpdateCheckerManager {
                 hasUpdate = true,
                 latestVersion = latestVersion,
                 releaseNotes = latestRelease.body,
+                releaseNotesHtml = latestRelease.bodyHtml,
                 downloadUrl = downloadUrl,
                 isPreRelease = latestRelease.prerelease
             )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/checkupdate/CheckUpdateActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/checkupdate/CheckUpdateActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -15,10 +16,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.v2ray.ang.BuildConfig
 import com.v2ray.ang.R
@@ -98,7 +105,12 @@ fun CheckUpdateScreen(
         AlertDialog(
             onDismissRequest = { viewModel.dismissUpdateDialog() },
             title = { Text(stringResource(R.string.update_new_version_found, result.latestVersion ?: "")) },
-            text = { Text(result.releaseNotes ?: "") },
+            text = {
+                ReleaseNotesText(
+                    releaseNotes = result.releaseNotes.orEmpty(),
+                    releaseNotesHtml = result.releaseNotesHtml
+                )
+            },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.dismissUpdateDialog()
@@ -115,4 +127,39 @@ fun CheckUpdateScreen(
             containerColor = MaterialTheme.colorScheme.surface
         )
     }
+}
+
+@Composable
+private fun ReleaseNotesText(
+    releaseNotes: String,
+    releaseNotesHtml: String?
+) {
+    val scrollState = rememberScrollState()
+    val linkColor = MaterialTheme.colorScheme.primary
+    val annotatedNotes = remember(releaseNotes, releaseNotesHtml, linkColor) {
+        releaseNotesHtml
+            ?.takeIf { it.isNotBlank() }
+            ?.let { html ->
+                runCatching {
+                    AnnotatedString.fromHtml(
+                        htmlString = html,
+                        linkStyles = TextLinkStyles(
+                            style = SpanStyle(
+                                color = linkColor,
+                                textDecoration = TextDecoration.Underline
+                            )
+                        )
+                    )
+                }.getOrNull()
+            }
+            ?: AnnotatedString(releaseNotes)
+    }
+
+    Text(
+        text = annotatedNotes,
+        modifier = Modifier
+            .fillMaxWidth()
+            .verticalScroll(scrollState),
+        style = MaterialTheme.typography.bodyMedium
+    )
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -116,6 +116,7 @@ object HttpUtil {
             .url(url)
             .get()
             .header("Connection", "close")
+        applyCustomHeaders(request, requestBuilder)
         if (request.httpPort != 0 && !request.proxyUsername.isNullOrBlank() && !request.proxyPassword.isNullOrBlank()) {
             requestBuilder.header("Proxy-Authorization", Credentials.basic(request.proxyUsername, request.proxyPassword))
         }
@@ -165,14 +166,7 @@ object HttpUtil {
             applyEmbeddedBasicAuthHeader(currentUrl, requestBuilder)
 
 
-            val headersMap = JsonUtil.parseHeadersToMap(request.requestHeaders)
-            for ((key, value) in headersMap) {
-                LogUtil.d(AppConfig.TAG, "Adding custom header: $key = $value")
-                try {
-                    requestBuilder.header(key, value)
-                } catch (_: IllegalArgumentException) {
-                }
-            }
+            applyCustomHeaders(request, requestBuilder)
 
             if (request.httpPort != 0 && !request.proxyUsername.isNullOrBlank() && !request.proxyPassword.isNullOrBlank()) {
                 requestBuilder.header("Proxy-Authorization", Credentials.basic(request.proxyUsername, request.proxyPassword))
@@ -203,6 +197,17 @@ object HttpUtil {
             }
         }
         throw IOException("Too many redirects")
+    }
+
+    private fun applyCustomHeaders(request: UrlContentRequest, requestBuilder: Request.Builder) {
+        val headersMap = JsonUtil.parseHeadersToMap(request.requestHeaders)
+        for ((key, value) in headersMap) {
+            LogUtil.d(AppConfig.TAG, "Adding custom header: $key = $value")
+            try {
+                requestBuilder.header(key, value)
+            } catch (_: IllegalArgumentException) {
+            }
+        }
     }
 
     private fun applyEmbeddedBasicAuthHeader(rawUrl: String, requestBuilder: Request.Builder) {

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/dto/GitHubReleaseTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/dto/GitHubReleaseTest.kt
@@ -1,0 +1,29 @@
+package com.v2ray.ang.dto
+
+import com.v2ray.ang.util.JsonUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class GitHubReleaseTest {
+
+    @Test
+    fun parsesRawAndHtmlReleaseNotes() {
+        val release = JsonUtil.fromJson(
+            """
+            {
+              "tag_name": "2.3.3",
+              "body": "### Changes",
+              "body_html": "<h3>Changes</h3>",
+              "assets": [],
+              "prerelease": true
+            }
+            """.trimIndent(),
+            GitHubRelease::class.java
+        )
+
+        assertNotNull(release)
+        assertEquals("### Changes", release?.body)
+        assertEquals("<h3>Changes</h3>", release?.bodyHtml)
+    }
+}


### PR DESCRIPTION
## Summary

- request GitHub's full release representation so update checks receive both raw and rendered release notes
- render GitHub-provided HTML with Compose `AnnotatedString`, with the raw Markdown kept as a fallback
- make the dialog body vertically scrollable so long release notes remain accessible above the action buttons
- apply custom request headers consistently in `HttpUtil` and test the full release response fields

## Root cause

The Compose migration replaced `AlertDialog.setMessage` with a plain `Text` inside a Material 3 `AlertDialog`. The dialog gives its text slot a bounded height, but the text itself was not scrollable, so longer release notes were clipped. The GitHub Releases API `body` field contains Markdown, which was also displayed verbatim.

## User impact

Long update notes can now be read to the end without covering or losing the dialog actions. Headings, lists, code blocks, emphasis, and links use GitHub's rendered release content, and links remain interactive.
