### PR TITLE
Fix clipped update notes dialog

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/checkupdate/CheckUpdateActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/checkupdate/CheckUpdateActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -28,6 +29,7 @@ import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.SettingsMenuItem
 import com.v2ray.ang.ui.compose.SettingsSwitchItem
 import com.v2ray.ang.ui.compose.VersionInfoBlock
+import com.v2ray.ang.ui.compose.verticalScrollbar
 import com.v2ray.ang.util.Utils
 
 class CheckUpdateActivity : BaseComponentActivity() {
@@ -98,7 +100,16 @@ fun CheckUpdateScreen(
         AlertDialog(
             onDismissRequest = { viewModel.dismissUpdateDialog() },
             title = { Text(stringResource(R.string.update_new_version_found, result.latestVersion ?: "")) },
-            text = { Text(result.releaseNotes ?: "") },
+            text = {
+                val scrollState = rememberScrollState()
+                Text(
+                    text = result.releaseNotes.orEmpty(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(scrollState)
+                        .verticalScrollbar(scrollState)
+                )
+            },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.dismissUpdateDialog()


### PR DESCRIPTION
Long release notes were cut off in the update dialog.

This makes the notes scrollable and adds the existing fading scrollbar, while keeping the action buttons visible.

Validation:

- `assembleFdroidDebug`
- `assemblePlaystoreDebug`
