### PR TITLE
fix: make root service starts idempotent

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
@@ -43,6 +43,11 @@ class CoreRootService : Service(), ServiceControl {
         NotificationManager.ensureForeground()
         LogUtil.i(AppConfig.TAG, "StartCore-Root: command received")
 
+        if (CoreServiceManager.isRunning()) {
+            LogUtil.i(AppConfig.TAG, "StartCore-Root: Core is already running")
+            return START_STICKY
+        }
+
         // Start the in-process core first (this also posts the foreground notification),
         // then install the root routing off the main thread.
         if (!CoreServiceManager.startCoreLoop(null)) {


### PR DESCRIPTION
I guess, I forgot to include the root-mode part of the duplicate start fixes after #5967 in the subsequent "fix duplicate start" PR.

## Summary

- Treat duplicate `CoreRootService` start commands as idempotent when the daemon core is already running.
- Keep the foreground service active and return `START_STICKY` instead of interpreting the duplicate as a startup failure and stopping the service.

## Potential root cause

Issue #6051 reports that root mode disconnects around a second attempt to grant `su` access, but it does not include logs or environment details.

One plausible path is a duplicate root-service start after the first command has already started the daemon core. Previously, the second command called `startCoreLoop()`, which returned `false` because the core was already running. `CoreRootService` then treated that result as a startup failure and called `stopSelf()`, disconnecting the active root-mode session.

This change performs the duplicate check in the daemon-hosted service and treats it as a successful idempotent start. Root-shell or device-specific setup failures remain possible explanations for #6051, so this PR is intentionally presented as a potential fix rather than a confirmed diagnosis.

## User impact

A repeated root-service start no longer tears down an otherwise running root-mode connection.

## Validation

- `:app:compilePlaystoreDebugKotlin`
- `git diff --check upstream/master...HEAD`

Runtime reproduction on the reporter's rooted device was not possible because the issue contains no device, root implementation, or diagnostic log details.

Potentially addresses #6051.
