### PR TITLE
Add subscription network type filtering

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/SubscriptionItem.kt
@@ -11,6 +11,7 @@ data class SubscriptionItem(
     var prevProfile: String? = null,
     var nextProfile: String? = null,
     var filter: String? = null,
+    var networkFilter: String? = null,
     var allowInsecureUrl: Boolean = false,
     var userAgent: String? = null,
     var requestHeaders: String? = null,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -492,6 +492,9 @@ object AngConfigManager {
                     .containsMatchIn(input = config.remarks)
                 if (!matched) return null
             }
+            if (!matchesNetworkFilter(config.network, subItem?.networkFilter)) {
+                return null
+            }
 
             config.subscriptionId = subid
             config.description = generateDescription(config)
@@ -507,6 +510,15 @@ object AngConfigManager {
             LogUtil.e(AppConfig.TAG, "Failed to parse config", e)
             return null
         }
+    }
+
+    internal fun matchesNetworkFilter(network: String?, filter: String?): Boolean {
+        val networkTypes = filter.orEmpty()
+            .split(',')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        return networkTypes.isEmpty() || networkTypes.any { it.equals(network, ignoreCase = true) }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -135,6 +135,7 @@ fun SubEditScreen(
     var userAgent by rememberSaveable { mutableStateOf(initial.userAgent.orEmpty()) }
     var requestHeaders by rememberSaveable { mutableStateOf(initial.requestHeaders.orEmpty()) }
     var filter by rememberSaveable { mutableStateOf(initial.filter ?: "") }
+    var networkFilter by rememberSaveable { mutableStateOf(initial.networkFilter ?: "") }
     var enabled by rememberSaveable { mutableStateOf(initial.enabled) }
     var autoUpdate by rememberSaveable { mutableStateOf(initial.autoUpdate) }
     var updateInterval by rememberSaveable { mutableStateOf(initial.updateInterval.toString()) }
@@ -153,6 +154,7 @@ fun SubEditScreen(
         subItem.userAgent = userAgent
         subItem.requestHeaders = requestHeaders
         subItem.filter = filter
+        subItem.networkFilter = networkFilter
         subItem.enabled = enabled
         subItem.autoUpdate = autoUpdate
         subItem.updateInterval = updateInterval.toLongEx()
@@ -199,6 +201,13 @@ fun SubEditScreen(
             FormTextField(stringResource(R.string.sub_setting_user_agent), userAgent, { userAgent = it })
             FormTextField(stringResource(R.string.sub_setting_request_headers), requestHeaders, { requestHeaders = it })
             FormTextField(stringResource(R.string.sub_setting_filter), filter, { filter = it })
+            FormTextField(
+                label = stringResource(R.string.sub_setting_network_filter),
+                value = networkFilter,
+                onValueChange = { networkFilter = it },
+                placeholder = stringResource(R.string.sub_setting_network_filter_tip),
+                maxLines = 1
+            )
             SettingsSwitchItem(
                 title = stringResource(R.string.sub_setting_enable),
                 checked = enabled,

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">رؤوس الطلب (بتنسيق JSON)</string>
     <string name="sub_setting_filter">مرشح تعبير نمطي للملاحظات</string>
+    <string name="sub_setting_network_filter">مرشح نوع الشبكة</string>
+    <string name="sub_setting_network_filter_tip">قيم مفصولة بفاصلة إنجليزية، مثل: ws, grpc, xhttp</string>
     <string name="sub_setting_enable">تفعيل التحديث</string>
     <string name="sub_auto_update">تفعيل التحديث التلقائي</string>
     <string name="sub_allow_insecure_url">السماح بعنوان HTTP غير آمن</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">রিকোয়েস্ট হেডার (JSON ফরম্যাট)</string>
     <string name="sub_setting_filter">মন্তব্যের রেগুলার এক্সপ্রেশন ফিল্টার</string>
+    <string name="sub_setting_network_filter">নেটওয়ার্কের ধরন অনুযায়ী ফিল্টার</string>
+    <string name="sub_setting_network_filter_tip">ইংরেজি কমা দিয়ে আলাদা করুন, যেমন: ws, grpc, xhttp</string>
     <string name="sub_setting_enable">আপডেট সক্রিয় করুন</string>
     <string name="sub_auto_update">স্বয়ংক্রিয় আপডেট সক্রিয় করুন</string>
     <string name="sub_allow_insecure_url">অনিরাপদ HTTP ঠিকানা অনুমোদন করুন</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">سرآیندا درخواست (قالوو JSON)</string>
     <string name="sub_setting_filter">فیلتر نیشتنا وا regex</string>
+    <string name="sub_setting_network_filter">فیلتر نوع شبکه</string>
+    <string name="sub_setting_network_filter_tip">وا کاما (,) ز یک جوڌا ابۊن: ws, grpc, xhttp</string>
     <string name="sub_setting_enable">ره وندن ورۊ کردن</string>
     <string name="sub_auto_update">ره وندن ورۊ کردن خوتکار</string>
     <string name="sub_allow_insecure_url">موجاز کردن نشۊوی HTTP نا ٱمن</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">سرآیندهای درخواست (قالب JSON)</string>
     <string name="sub_setting_filter">فیلتر عبارت منظم برای نام‌ها</string>
+    <string name="sub_setting_network_filter">فیلتر نوع شبکه</string>
+    <string name="sub_setting_network_filter_tip">با ویرگول انگلیسی جدا کنید، مانند: ws, grpc, xhttp</string>
     <string name="sub_setting_enable">فعال کردن به‌روزرسانی</string>
     <string name="sub_auto_update">فعال سازی به‌روزرسانی خودکار</string>
     <string name="sub_allow_insecure_url">مجاز کردن آدرس HTTP ناامن</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">Заголовки запроса (формат JSON)</string>
     <string name="sub_setting_filter">Фильтр названий (регулярное выражение)</string>
+    <string name="sub_setting_network_filter">Фильтр по типу сети</string>
+    <string name="sub_setting_network_filter_tip">Через запятую, например: ws, grpc, xhttp</string>
     <string name="sub_setting_enable">Включить обновление</string>
     <string name="sub_auto_update">Использовать автообновление</string>
     <string name="sub_allow_insecure_url">Разрешать незащищённые HTTP-адреса</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">Tiêu đề yêu cầu (định dạng JSON)</string>
     <string name="sub_setting_filter">Bộ lọc biểu thức chính quy cho tên ghi chú</string>
+    <string name="sub_setting_network_filter">Bộ lọc giao thức truyền tải</string>
+    <string name="sub_setting_network_filter_tip">Phân tách bằng dấu phẩy, ví dụ: ws, grpc, xhttp</string>
     <string name="sub_setting_enable">Bật cập nhật</string>
     <string name="sub_auto_update">Bật tự động cập nhật</string>
     <string name="sub_allow_insecure_url">Cho phép địa chỉ HTTP không an toàn</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">请求头（JSON 格式）</string>
     <string name="sub_setting_filter">别名正则过滤</string>
+    <string name="sub_setting_network_filter">传输协议筛选</string>
+    <string name="sub_setting_network_filter_tip">使用英文逗号分隔，例如：ws, grpc, xhttp</string>
     <string name="sub_setting_enable">启用更新</string>
     <string name="sub_auto_update">启用自动更新</string>
     <string name="sub_allow_insecure_url">允许不安全的 HTTP 地址</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">請求標頭（JSON 格式）</string>
     <string name="sub_setting_filter">備註篩選條件（正規表示式）</string>
+    <string name="sub_setting_network_filter">網路類型篩選</string>
+    <string name="sub_setting_network_filter_tip">以英文逗號分隔，例如：ws, grpc, xhttp</string>
     <string name="sub_setting_enable">啟用更新</string>
     <string name="sub_auto_update">啟用自動更新</string>
     <string name="sub_allow_insecure_url">允許不安全的 HTTP 位址</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -324,6 +324,8 @@
     <string name="sub_setting_user_agent" translatable="false">User Agent</string>
     <string name="sub_setting_request_headers">Request Headers (JSON format)</string>
     <string name="sub_setting_filter">Remarks filter (regular expression)</string>
+    <string name="sub_setting_network_filter">Network type filter</string>
+    <string name="sub_setting_network_filter_tip">Comma-separated, e.g. ws, grpc, xhttp</string>
     <string name="sub_setting_enable">Enable update</string>
     <string name="sub_auto_update">Enable automatic update</string>
     <string name="sub_allow_insecure_url">Allow insecure HTTP address</string>


### PR DESCRIPTION
## Summary

- add an optional network type filter directly after the subscription remarks filter
- accept case-insensitive, comma-separated transport values such as `ws`, `grpc`, and `xhttp`
- persist the filter with the subscription and apply it while parsing imported profiles
- localize the field label and placeholder across all nine maintained catalogs

## Why

Subscription groups can currently filter imported profiles by remarks, but not by transport type. Users therefore cannot retain only profiles using selected transports without encoding that information into profile remarks.

Closes #6040.

## User impact

Leaving the new field blank preserves the existing import behavior. When values are supplied, only profiles whose network type matches one of the comma-separated entries are imported. Matching ignores case and surrounding whitespace.

## Validation

- `:app:compilePlaystoreDebugKotlin`
- XML structural audit: all nine catalogs contain 452 ordered resource identifiers with no duplicates
- `git diff --check`

No test source files are included in this PR.
