### PR TITLE
feat: show subscription traffic and expiration

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionUserInfo.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/SubscriptionUserInfo.kt
@@ -1,0 +1,14 @@
+package com.v2ray.ang.dto
+
+data class SubscriptionUserInfo(
+    val upload: Long = 0,
+    val download: Long = 0,
+    val total: Long = 0,
+    val expire: Long = -1
+) {
+    val hasTraffic: Boolean
+        get() = total > 0
+
+    val hasExpiration: Boolean
+        get() = expire > 0
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/UrlContentResponse.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/UrlContentResponse.kt
@@ -1,0 +1,6 @@
+package com.v2ray.ang.dto
+
+data class UrlContentResponse(
+    val content: String,
+    val headers: Map<String, String>
+)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/SubscriptionItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/entities/SubscriptionItem.kt
@@ -14,5 +14,9 @@ data class SubscriptionItem(
     var allowInsecureUrl: Boolean = false,
     var userAgent: String? = null,
     var requestHeaders: String? = null,
+    var upload: Long = 0,
+    var download: Long = 0,
+    var total: Long = 0,
+    var expire: Long = -1,
 )
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -8,6 +8,7 @@ import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreConfigManager
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.UrlContentRequest
+import com.v2ray.ang.dto.UrlContentResponse
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.SubscriptionCache
 import com.v2ray.ang.dto.entities.SubscriptionItem
@@ -26,6 +27,7 @@ import com.v2ray.ang.util.HttpUtil
 import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.QRCodeDecoder
+import com.v2ray.ang.util.SubscriptionUserInfoParser
 import com.v2ray.ang.util.Utils
 import java.net.URI
 
@@ -562,9 +564,9 @@ object AngConfigManager {
             val proxyUsername = SettingsManager.getSocksUsername()
             val proxyPassword = SettingsManager.getSocksPassword()
 
-            var configText = try {
+            var response: UrlContentResponse? = try {
                 val httpPort = SettingsManager.getHttpPort()
-                HttpUtil.getUrlContentWithUserAgent(
+                HttpUtil.getUrlContentWithUserAgentResponse(
                     UrlContentRequest(
                         url = url,
                         userAgent = userAgent,
@@ -577,11 +579,11 @@ object AngConfigManager {
                 )
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.ANG_PACKAGE, "Update subscription: proxy not ready or other error", e)
-                ""
+                null
             }
-            if (configText.isEmpty()) {
-                configText = try {
-                    HttpUtil.getUrlContentWithUserAgent(
+            if (response?.content.isNullOrEmpty()) {
+                response = try {
+                    HttpUtil.getUrlContentWithUserAgentResponse(
                         UrlContentRequest(
                             url = url,
                             userAgent = userAgent,
@@ -590,15 +592,23 @@ object AngConfigManager {
                     )
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "Update subscription: Failed to get URL content with user agent", e)
-                    ""
+                    null
                 }
             }
+            val configText = response?.content.orEmpty()
             if (configText.isEmpty()) {
                 return SubscriptionUpdateResult(failureCount = 1)
             }
 
             val count = parseConfigViaSub(configText, it.guid, false)
             if (count > 0) {
+                val userInfo = response?.headers?.entries?.firstOrNull { (name, _) ->
+                    name.equals("subscription-userinfo", ignoreCase = true)
+                }?.value?.let(SubscriptionUserInfoParser::parse)
+                it.subscription.upload = userInfo?.upload ?: 0
+                it.subscription.download = userInfo?.download ?: 0
+                it.subscription.total = userInfo?.total ?: 0
+                it.subscription.expire = userInfo?.expire ?: -1
                 it.subscription.lastUpdated = System.currentTimeMillis()
                 MmkvManager.encodeSubscription(it.guid, it.subscription)
                 LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
@@ -41,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.extension.toast
+import com.v2ray.ang.extension.toTrafficString
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.MmkvManager.rememberMmkvBool
 import com.v2ray.ang.ui.base.BaseComponentActivity
@@ -182,6 +184,37 @@ fun SubSettingScreen(
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis
                                     )
+                                }
+                                val used = subCache.subscription.upload + subCache.subscription.download
+                                if (subCache.subscription.total > 0 || subCache.subscription.expire > 0) {
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                    if (subCache.subscription.total > 0) {
+                                        Text(
+                                            text = stringResource(
+                                                R.string.subscription_traffic_info,
+                                                used.toTrafficString(),
+                                                subCache.subscription.total.toTrafficString()
+                                            ),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        LinearProgressIndicator(
+                                            progress = {
+                                                (used.toFloat() / subCache.subscription.total.toFloat()).coerceIn(0f, 1f)
+                                            },
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                    }
+                                    if (subCache.subscription.expire > 0) {
+                                        Text(
+                                            text = stringResource(
+                                                R.string.subscription_expiration,
+                                                Utils.formatTimestamp(subCache.subscription.expire)
+                                            ),
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
                                 }
                                 Spacer(modifier = Modifier.height(2.dp))
                                 Text(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/HttpUtil.kt
@@ -4,6 +4,7 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.AppConfig.LOOPBACK
 import com.v2ray.ang.BuildConfig
 import com.v2ray.ang.dto.UrlContentRequest
+import com.v2ray.ang.dto.UrlContentResponse
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -144,6 +145,11 @@ object HttpUtil {
      */
     @Throws(IOException::class)
     fun getUrlContentWithUserAgent(request: UrlContentRequest): String {
+        return getUrlContentWithUserAgentResponse(request).content
+    }
+
+    @Throws(IOException::class)
+    fun getUrlContentWithUserAgentResponse(request: UrlContentRequest): UrlContentResponse {
         var currentUrl = request.url
         var redirects = 0
         val maxRedirects = 3
@@ -193,7 +199,10 @@ object HttpUtil {
                     }
 
                     response.isSuccessful -> {
-                        return response.body?.string() ?: ""
+                        val headers = response.headers.names().associateWith { name ->
+                            response.header(name).orEmpty()
+                        }
+                        return UrlContentResponse(response.body?.string().orEmpty(), headers)
                     }
 
                     else -> {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/SubscriptionUserInfoParser.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/SubscriptionUserInfoParser.kt
@@ -1,0 +1,33 @@
+package com.v2ray.ang.util
+
+import com.v2ray.ang.dto.SubscriptionUserInfo
+
+object SubscriptionUserInfoParser {
+    fun parse(value: String?): SubscriptionUserInfo? {
+        if (value.isNullOrBlank()) return null
+
+        var upload = 0L
+        var download = 0L
+        var total = 0L
+        var expire = -1L
+        var found = false
+
+        value.split(';').forEach { item ->
+            val separator = item.indexOf('=')
+            if (separator <= 0) return@forEach
+
+            val key = item.substring(0, separator).trim().lowercase()
+            val number = item.substring(separator + 1).trim().toLongOrNull() ?: return@forEach
+            if (number < 0) return@forEach
+
+            when (key) {
+                "upload" -> upload = number.also { found = true }
+                "download" -> download = number.also { found = true }
+                "total" -> total = number.also { found = true }
+                "expire" -> expire = number.times(1000).also { found = true }
+            }
+        }
+
+        return if (found) SubscriptionUserInfo(upload, download, total, expire) else null
+    }
+}

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -114,6 +114,8 @@
     <string name="server_lab_content">Content</string>
     <string name="toast_none_data_clipboard">There is no data in the clipboard</string>
     <string name="toast_invalid_url">Invalid URL</string>
+    <string name="subscription_traffic_info">Traffic: %1$s / %2$s</string>
+    <string name="subscription_expiration">Expires: %1$s</string>
     <string name="toast_insecure_url_protocol">Do not use an insecure HTTP subscription URL</string>
     <string name="server_lab_need_inbound">Make sure the inbound port matches the settings</string>
     <string name="toast_malformed_json">Invalid configuration.</string>

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/SubscriptionUserInfoParserTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/SubscriptionUserInfoParserTest.kt
@@ -1,0 +1,35 @@
+package com.v2ray.ang
+
+import com.v2ray.ang.util.SubscriptionUserInfoParser
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SubscriptionUserInfoParserTest {
+    @Test
+    fun parsesTrafficAndExpirationHeader() {
+        val result = SubscriptionUserInfoParser.parse("upload=1024; download=2048; total=4096; expire=1700000000")
+
+        requireNotNull(result)
+        assertEquals(1024, result.upload)
+        assertEquals(2048, result.download)
+        assertEquals(4096, result.total)
+        assertEquals(1700000000000, result.expire)
+    }
+
+    @Test
+    fun ignoresMalformedAndNegativeValues() {
+        val result = SubscriptionUserInfoParser.parse("upload=-1; download=nope; total=8192; ignored=4")
+
+        requireNotNull(result)
+        assertEquals(0, result.upload)
+        assertEquals(0, result.download)
+        assertEquals(8192, result.total)
+        assertEquals(-1, result.expire)
+    }
+
+    @Test
+    fun returnsNullWhenHeaderHasNoKnownFields() {
+        assertNull(SubscriptionUserInfoParser.parse("foo=123;bar=456"))
+    }
+}


### PR DESCRIPTION
Closes #6045

Expose subscription usage and expiration metadata from the standard `subscription-userinfo` response header. The update path now keeps response headers through redirects, persists upload/download/total/expiration values with the subscription, and renders a traffic progress bar plus expiration timestamp in the subscription list when the provider supplies the metadata. Providers that do not send the header retain the existing behavior and hide the optional fields.

Validation:
- `git diff --check`
- Added focused parser coverage for valid, malformed, negative, and unknown header fields.
- The targeted Gradle unit-test command was attempted locally but could not resolve the repository's current Android Gradle Plugin from the offline cache; no build result is claimed.