### PR TITLE
fix: drawer navigation issues

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -187,12 +187,15 @@ fun MainScreen(
 
     ModalNavigationDrawer(
         drawerState = drawerState,
+        gesturesEnabled = drawerState.isOpen,
         drawerContent = {
             MainDrawerContent(
                 drawerState = drawerState,
                 onNavigate = { route ->
-                    scope.launch { drawerState.close() }
-                    onNavigate(route)
+                    scope.launch {
+                        drawerState.close()
+                        onNavigate(route)
+                    }
                 }
             )
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -193,7 +193,7 @@ fun MainScreen(
                 drawerState = drawerState,
                 onNavigate = { route ->
                     scope.launch {
-                        drawerState.close()
+                        drawerState.snapTo(DrawerValue.Closed)
                         onNavigate(route)
                     }
                 }


### PR DESCRIPTION
# 问题一：进入二级页面时卡顿

- 现象：点击侧边导航栏的tab后，画面会卡一下，抽屉收回，再进入二级页面

- 根因：原代码中抽屉关闭动画和 Activity 启动并行执行

- drawerState.close() 是挂起函数，被 scope.launch 包裹后异步执行关闭动画。onNavigate(route) 紧接着在主线程同步调用 settingsActivityLauncher.launch(intent) 启动新 Activity。Activity 创建（实例化、onCreate、setContent 组合首帧）是重操作，与抽屉关闭动画争抢主线程时间片，导致动画掉帧卡顿。

- 修复：将 onNavigate(route) 移入协程，在侧边导航栏关闭后再执行；并改用 snapTo() 瞬间关闭，消除等待时间

# 问题二：侧边导航栏打开后无法立刻点击tab

- 现象：点击左上角菜单按钮弹出侧边导航栏后，短时间内点击选项无响应，需要等动画执行完毕300ms后才能点

- 根因：ModalNavigationDrawer 未设置 gesturesEnabled，默认为 true，抽屉的水平拖拽手势检测始终活跃。在抽屉打开动画期间（约 250ms），拖拽手势检测器会拦截抽屉内容区域的触摸事件，阻止 NavigationDrawerItem 的 onClick 触发。用户必须等动画完全结束后点击才能生效，此外，ModalDrawerSheet(drawerState = drawerState, ...) 在新版 Material 3 中启用了内部拖拽关闭手势，进一步加剧了动画期间的手势冲突

- 修复：设置 gesturesEnabled = drawerState.isOpen。isOpen 基于 currentValue，在抽屉打开动画期间为 false，禁用手势检测，使触摸事件直接传递给抽屉选项。抽屉完全打开后 isOpen 变为 true，恢复滑动手势用于滑动关闭