### PR TITLE
feat: replace app name with app icon in navigation drawer header

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
@@ -2,12 +2,14 @@ package com.v2ray.ang.ui.main
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DrawerState
@@ -21,15 +23,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.AppDivider
+import com.v2ray.ang.ui.compose.LocalDarkTheme
 import com.v2ray.ang.ui.compose.verticalScrollbar
 
 enum class MainDestination(@DrawableRes val iconRes: Int, @StringRes val labelRes: Int) {
@@ -76,7 +78,7 @@ fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) ->
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(160.dp)
+                    .height(180.dp)
             ) {
                 Column(
                     modifier = Modifier
@@ -85,13 +87,21 @@ fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) ->
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
+                    val isDarkTheme = LocalDarkTheme.current
+                    Image(
+                        painter = painterResource(R.mipmap.ic_launcher_foreground),
+                        contentDescription = null,
+                        modifier = Modifier.size(120.dp),
+                        colorFilter = if (isDarkTheme) {
+                            ColorFilter.tint(Color.White, BlendMode.SrcIn)
+                        } else {
+                            null
+                        }
+                    )
                     Text(
                         text = stringResource(R.string.app_name),
-                        style = MaterialTheme.typography.headlineLarge.copy(
-                            fontFamily = FontFamily(Font(R.font.montserrat_thin)),
-                            fontWeight = FontWeight.Thin
-                        ),
-                        textAlign = TextAlign.Center
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurface
                     )
                 }
             }


### PR DESCRIPTION
# 修改导航栏上方的文字为图标+应用名，让页面更具美观性

# 如图所示

# 修改前
<img width="600" alt="微信图片_20260813082641_405_6" src="https://github.com/user-attachments/assets/b0356245-cf58-46e8-852b-2fd11c49281c" />

# 修改后
<img width="600" alt="微信图片_20260813082639_403_6" src="https://github.com/user-attachments/assets/6151be04-c496-4013-8caf-33f3f490dbe4" />
<img width="600" alt="微信图片_20260813082640_404_6" src="https://github.com/user-attachments/assets/2e0f7ae6-0937-4393-87cf-f327016c2e15" />

- 自适应黑色白色以及动态取色的主题