### PR TITLE
Make proxy-only service starts idempotent

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
@@ -33,6 +33,11 @@ class CoreProxyOnlyService : Service(), ServiceControl {
         NotificationManager.ensureForeground()
         LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Service command received")
 
+        if (CoreServiceManager.isRunning()) {
+            LogUtil.i(AppConfig.TAG, "StartCore-Proxy: Core is already running")
+            return START_STICKY
+        }
+
         if (!CoreServiceManager.startCoreLoop(null)) {
             LogUtil.e(AppConfig.TAG, "StartCore-Proxy: Failed to start core loop")
             stopSelf()


### PR DESCRIPTION
## Summary

- Treat a duplicate `CoreProxyOnlyService.onStartCommand()` invocation as a successful no-op when the core is already running.
- Keep the service foreground and return `START_STICKY` instead of treating the duplicate start as a failure.

## Why

`CoreServiceManager.startCoreLoop()` returns `false` when the core is already running. The proxy-only service currently interprets that as a startup failure, calls `stopSelf()`, and returns `START_NOT_STICKY`.

Android or vendor firmware can deliver duplicate foreground-service start commands. Such a command should not stop an already healthy proxy-only service.

## Testing

- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86`
