### PR TITLE
Make explicit service restart daemon-authoritative

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.core
 
+import android.app.Activity
 import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -474,6 +475,9 @@ object CoreServiceManager {
 
                 AppConfig.MSG_STATE_RESTART -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart service")
+                    // The UI and daemon run in separate processes, so acknowledge the active
+                    // daemon before stopping it instead of relying on possibly stale UI state.
+                    if (isOrderedBroadcast) resultCode = Activity.RESULT_OK
                     serviceControl.stopService()
                     Thread.sleep(500L)
                     LauncherManager.startService(serviceControl.getService())

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -31,6 +31,7 @@ import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
@@ -478,9 +479,17 @@ object CoreServiceManager {
                     // The UI and daemon run in separate processes, so acknowledge the active
                     // daemon before stopping it instead of relying on possibly stale UI state.
                     if (isOrderedBroadcast) resultCode = Activity.RESULT_OK
-                    serviceControl.stopService()
-                    Thread.sleep(500L)
-                    LauncherManager.startService(serviceControl.getService())
+
+                    val pendingResult = goAsync()
+                    CoroutineScope(Dispatchers.Default).launch {
+                        try {
+                            serviceControl.stopService()
+                            delay(500L)
+                            LauncherManager.startService(serviceControl.getService())
+                        } finally {
+                            pendingResult.finish()
+                        }
+                    }
                 }
 
                 AppConfig.MSG_MEASURE_DELAY -> {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/LauncherManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/LauncherManager.kt
@@ -56,6 +56,18 @@ object LauncherManager {
         MessageHelper.sendMsg2Service(context, AppConfig.MSG_STATE_STOP, "")
     }
 
+    /** Restarts the active daemon without starting a stopped service. */
+    fun restartService(context: Context) {
+        MessageHelper.sendMsg2Service(context, AppConfig.MSG_STATE_RESTART, "")
+    }
+
+    /** Restarts the active daemon, or delegates to the caller's permission-aware start flow. */
+    fun restartServiceOrStart(context: Context, startIfStopped: () -> Unit) {
+        MessageHelper.sendMsg2ServiceForResult(context, AppConfig.MSG_STATE_RESTART, "") { handled ->
+            if (!handled) startIfStopped()
+        }
+    }
+
     @Throws(Exception::class)
     private fun startContextService(context: Context) {
         // Note: isRunning check is removed here to avoid loading Native libraries in the UI process.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/MessageHelper.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/MessageHelper.kt
@@ -1,5 +1,7 @@
 package com.v2ray.ang.helper
 
+import android.app.Activity
+import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -25,6 +27,37 @@ object MessageHelper {
      */
     fun sendMsg2Service(ctx: Context, what: Int, content: Serializable) {
         sendMsg(ctx, AppConfig.BROADCAST_ACTION_SERVICE, what, content)
+    }
+
+    /**
+     * Sends an ordered service message and reports whether a daemon receiver handled it.
+     * With no running daemon, the initial canceled result reaches [onResult] unchanged.
+     */
+    internal fun sendMsg2ServiceForResult(
+        ctx: Context,
+        what: Int,
+        content: Serializable,
+        onResult: (handled: Boolean) -> Unit,
+    ) {
+        val resultReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                onResult(resultCode == Activity.RESULT_OK)
+            }
+        }
+        try {
+            ctx.sendOrderedBroadcast(
+                messageIntent(AppConfig.BROADCAST_ACTION_SERVICE, what, content),
+                null,
+                resultReceiver,
+                null,
+                Activity.RESULT_CANCELED,
+                null,
+                null,
+            )
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to send ordered message to service", e)
+            onResult(false)
+        }
     }
 
     /**
@@ -115,14 +148,16 @@ object MessageHelper {
      */
     private fun sendMsg(ctx: Context, action: String, what: Int, content: Serializable) {
         try {
-            val intent = Intent()
-            intent.action = action
-            intent.`package` = AppConfig.ANG_PACKAGE
-            intent.putExtra("key", what)
-            intent.putExtra("content", content)
-            ctx.sendBroadcast(intent)
+            ctx.sendBroadcast(messageIntent(action, what, content))
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to send message with action: $action", e)
         }
     }
+
+    private fun messageIntent(action: String, what: Int, content: Serializable): Intent =
+        Intent(action).apply {
+            `package` = AppConfig.ANG_PACKAGE
+            putExtra("key", what)
+            putExtra("content", content)
+        }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -75,10 +75,10 @@ class MainActivity : HelperBaseComponentActivity() {
             val restartService = data.getBooleanExtra(
                 ProfileEditorResult.EXTRA_RESTART_SERVICE, false
             )
+            val selectedProfileSaved = action == ProfileEditorResult.ACTION_SAVED &&
+                data.getStringExtra(ProfileEditorResult.EXTRA_GUID) == mainViewModel.uiState.value.selectedGuid
             mainViewModel.onAction(MainAction.RefreshGroups)
-            if (restartService && mainViewModel.uiState.value.isRunning) {
-                restartV2Ray()
-            }
+            if (restartService || selectedProfileSaved) LauncherManager.restartService(this)
         }
 
     private val settingsActivityLauncher =
@@ -87,7 +87,7 @@ class MainActivity : HelperBaseComponentActivity() {
             val refreshGroups = SettingsChangeManager.consumeSetupGroupTab()
             mainViewModel.refreshUiSettings()
             if (refreshGroups) mainViewModel.onAction(MainAction.RefreshGroups)
-            if (restartService && mainViewModel.uiState.value.isRunning) restartV2Ray()
+            if (restartService) LauncherManager.restartService(this)
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -110,7 +110,7 @@ class MainActivity : HelperBaseComponentActivity() {
                     MainAction.ImportClipboard -> importClipboard()
                     MainAction.ImportConfigLocal -> importConfigLocal()
                     is MainAction.ImportManually -> importManually(action.type)
-                    MainAction.RestartService -> restartV2Ray()
+                    MainAction.RestartService -> LauncherManager.restartServiceOrStart(this, ::requestServiceStart)
                     MainAction.LocateSelectedServer -> mainViewModel.triggerLocateSelectedServer()
                     is MainAction.SelectServer -> setSelectServer(action.guid)
                     is MainAction.EditServer -> editServer(action.guid, action.profile)
@@ -161,12 +161,18 @@ class MainActivity : HelperBaseComponentActivity() {
     private fun handleFabAction() {
         if (mainViewModel.uiState.value.isRunning) {
             LauncherManager.stopService(this)
-        } else if (SettingsManager.isVpnMode()) {
-            val intent = VpnService.prepare(this)
-            if (intent == null) startV2Ray() else requestVpnPermission.launch(intent)
         } else {
-            startV2Ray()
+            requestServiceStart()
         }
+    }
+
+    private fun requestServiceStart() {
+        if (!SettingsManager.isVpnMode()) {
+            startV2Ray()
+            return
+        }
+        val intent = VpnService.prepare(this)
+        if (intent == null) startV2Ray() else requestVpnPermission.launch(intent)
     }
 
     private fun handleLayoutTestClick() {
@@ -186,14 +192,6 @@ class MainActivity : HelperBaseComponentActivity() {
             checkAndRequestPermission(PermissionType.ACCESS_LOCAL_NETWORK) {}
         }
         LauncherManager.startService(this)
-    }
-
-    private fun restartV2Ray() {
-        if (mainViewModel.uiState.value.isRunning) LauncherManager.stopService(this)
-        lifecycleScope.launch {
-            kotlinx.coroutines.delay(500)
-            startV2Ray()
-        }
     }
 
     private fun importManually(createConfigType: Int) {
@@ -275,7 +273,7 @@ class MainActivity : HelperBaseComponentActivity() {
         val selected = mainViewModel.uiState.value.selectedGuid
         if (guid != selected) {
             mainViewModel.updateSelectedGuid(guid)
-            if (mainViewModel.uiState.value.isRunning) restartV2Ray()
+            LauncherManager.restartService(this)
         }
     }
 


### PR DESCRIPTION
If I recall correctly, this fixes a bug I found several weeks ago - when you disconnect Ethernet cable, the core crashes, but the main process still thinks it's active. From that point on, pressing start service or restart service only led to "already running" message with no new service being started.

I may be wrong, though. I found so many bugs lately it is turning into a blur.

## Summary

- send the explicit **Restart service** action as a package-scoped ordered broadcast
- let a running daemon acknowledge that it handled the restart
- use the existing permission-aware start flow when no daemon handled the request
- keep profile, settings, and server-selection reactions restart-only so they never start a stopped service

## Why

The explicit Restart action intentionally means “restart if running, start if stopped.” The main UI and core service run in separate processes, however, so the UI process's in-memory running state cannot reliably distinguish those cases.

The daemon is authoritative instead: it acknowledges an ordered restart request before performing the existing restart sequence. If no daemon receiver is registered, the ordered broadcast retains its initial canceled result and the UI runs the normal start path, including VPN permission handling when necessary.

Automatic reactions to configuration changes use an ordinary restart-only broadcast. This removes stale UI-state checks without turning those background reactions into implicit service starts.

## Testing

- Android 11 x86 TV emulator:
  - Restart with a running VPN daemon recreated the service/core and remained connected
  - Restart with no service record started `CoreVpnService` and Xray, including when the old daemon process was only cached
  - changing the selected profile while stopped did not start the service
