### PR TITLE
Add an explicit stop-and-exit action

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -178,6 +178,7 @@ object AppConfig {
     const val MSG_STATE_START_FAILURE = 32
     const val MSG_STATE_STOP = 4
     const val MSG_STATE_STOP_SUCCESS = 41
+    const val MSG_STATE_STOP_COMPLETE = 42
     const val MSG_STATE_RESTART = 5
     const val MSG_MEASURE_DELAY = 6
     const val MSG_MEASURE_DELAY_RESULT = 61

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreProxyOnlyService.kt
@@ -9,6 +9,7 @@ import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.core.CoreServiceManager
 import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.NotificationManager
+import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.util.LogUtil
 import java.lang.ref.SoftReference
 
@@ -48,6 +49,7 @@ class CoreProxyOnlyService : Service(), ServiceControl {
     override fun onDestroy() {
         super.onDestroy()
         CoreServiceManager.stopCoreLoop()
+        MessageHelper.sendMsg2UI(this, AppConfig.MSG_STATE_STOP_COMPLETE, "")
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreRootService.kt
@@ -9,6 +9,7 @@ import com.v2ray.ang.contracts.ServiceControl
 import com.v2ray.ang.core.CoreServiceManager
 import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.NotificationManager
+import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.root.RootProxyManager
 import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CoroutineScope
@@ -77,6 +78,7 @@ class CoreRootService : Service(), ServiceControl {
         // to a dead listener. Synchronous on purpose — leaving rules behind breaks the net.
         RootProxyManager.stop(this)
         CoreServiceManager.stopCoreLoop()
+        MessageHelper.sendMsg2UI(this, AppConfig.MSG_STATE_STOP_COMPLETE, "")
     }
 
     override fun getService(): Service = this

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -21,6 +21,7 @@ import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.root.RootLanSharing
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
@@ -72,6 +73,7 @@ class CoreVpnService : VpnService(), ServiceControl {
 
         unlockStart()
         NotificationManager.cancelNotification()
+        MessageHelper.sendMsg2UI(this, AppConfig.MSG_STATE_STOP_COMPLETE, "")
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -49,14 +49,22 @@ import com.v2ray.ang.ui.userasset.UserAssetActivity
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 class MainActivity : HelperBaseComponentActivity() {
+
+    companion object {
+        private const val SERVICE_STOP_TIMEOUT_MILLIS = 5_000L
+    }
 
     private val mainViewModel: MainViewModel by viewModels {
         MainViewModel.Factory(application, MainRepository(application as AngApplication))
     }
+    private var serviceTransitionJob: Job? = null
 
     private val requestVpnPermission =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -111,6 +119,7 @@ class MainActivity : HelperBaseComponentActivity() {
                     MainAction.ImportConfigLocal -> importConfigLocal()
                     is MainAction.ImportManually -> importManually(action.type)
                     MainAction.RestartService -> restartV2Ray()
+                    MainAction.Exit -> exitApp()
                     MainAction.LocateSelectedServer -> mainViewModel.triggerLocateSelectedServer()
                     is MainAction.SelectServer -> setSelectServer(action.guid)
                     is MainAction.EditServer -> editServer(action.guid, action.profile)
@@ -276,6 +285,24 @@ class MainActivity : HelperBaseComponentActivity() {
         if (guid != selected) {
             mainViewModel.updateSelectedGuid(guid)
             if (mainViewModel.uiState.value.isRunning) restartV2Ray()
+        }
+    }
+
+    private fun exitApp() {
+        serviceTransitionJob?.cancel()
+        if (!mainViewModel.uiState.value.isRunning) {
+            LauncherManager.stopService(this)
+            finishAndRemoveTask()
+            return
+        }
+
+        val stopGeneration = mainViewModel.serviceStopGeneration.value
+        LauncherManager.stopService(this)
+        serviceTransitionJob = lifecycleScope.launch {
+            withTimeoutOrNull(SERVICE_STOP_TIMEOUT_MILLIS) {
+                mainViewModel.serviceStopGeneration.first { it > stopGeneration }
+            }
+            finishAndRemoveTask()
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -52,6 +52,7 @@ sealed interface MainAction {
     data object ImportConfigLocal : MainAction
     data class ImportManually(val type: Int) : MainAction
     data object RestartService : MainAction
+    data object Exit : MainAction
     data object LocateSelectedServer : MainAction
 
     data class SelectGroup(val groupId: String) : MainAction

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
@@ -36,7 +36,8 @@ enum class MainMoreMenuAction(@StringRes val labelRes: Int) {
     SortByTestResults(R.string.title_sort_by_test_results),
     TestAll(R.string.title_ping_all_server),
     TestAllRealPing(R.string.title_real_ping_all_server),
-    UpdateSubscriptions(R.string.title_sub_update)
+    UpdateSubscriptions(R.string.title_sub_update),
+    Exit(R.string.action_exit)
 }
 
 internal enum class ServerMenuAction(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -57,6 +57,7 @@ class MainRepository(
                 AppConfig.MSG_STATE_START_FAILURE -> MainServiceEvent.StateStartFailure
 
                 AppConfig.MSG_STATE_STOP_SUCCESS -> MainServiceEvent.StateStopSuccess
+                AppConfig.MSG_STATE_STOP_COMPLETE -> MainServiceEvent.StateStopComplete
                 AppConfig.MSG_MEASURE_DELAY_RESULT -> safeIntent
                     .serializable<ConnectionTestResult>("content")
                     ?.let { MainServiceEvent.MeasureDelayResult(it) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -228,6 +228,7 @@ fun MainScreen(
                             MainMoreMenuAction.TestAll -> onAction(MainAction.TestAllServers)
                             MainMoreMenuAction.TestAllRealPing -> onAction(MainAction.TestRealAllServers)
                             MainMoreMenuAction.UpdateSubscriptions -> onAction(MainAction.UpdateSubscriptions)
+                            MainMoreMenuAction.Exit -> onAction(MainAction.Exit)
                         }
                     }
                 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
@@ -8,6 +8,7 @@ sealed class MainServiceEvent {
     data object StateStartSuccess : MainServiceEvent()
     data object StateStartFailure : MainServiceEvent()
     data object StateStopSuccess : MainServiceEvent()
+    data object StateStopComplete : MainServiceEvent()
     data class MeasureDelayResult(val result: ConnectionTestResult) : MainServiceEvent()
     data object MeasureConfigSuccess : MainServiceEvent()
     data class MeasureConfigNotify(val progress: String) : MainServiceEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -57,6 +57,9 @@ class MainViewModel(
     )
     val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
 
+    private val _serviceStopGeneration = MutableStateFlow(0L)
+    val serviceStopGeneration: StateFlow<Long> = _serviceStopGeneration.asStateFlow()
+
     // ---------- Keyword filtering ----------
     @Volatile
     private var keywordFilter: String = ""
@@ -108,6 +111,7 @@ class MainViewModel(
             }
 
             MainServiceEvent.StateStopSuccess -> updateRunningState(false)
+            MainServiceEvent.StateStopComplete -> _serviceStopGeneration.update { it + 1L }
             is MainServiceEvent.MeasureDelayResult -> {
                 _uiState.update { it.copy(status = MainStatus.ConnectionTest(event.result)) }
             }
@@ -208,6 +212,7 @@ class MainViewModel(
             MainAction.ImportConfigLocal,
             is MainAction.ImportManually,
             MainAction.RestartService,
+            MainAction.Exit,
             MainAction.LocateSelectedServer,
             is MainAction.EditServer,
             is MainAction.ShareClipboard,

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">تعديل</string>
     <string name="action_delete">حذف</string>
     <string name="action_close">إغلاق</string>
+    <string name="action_exit">خروج</string>
 
     <string name="share_subscription_qrcode">رمز QR</string>
     <string name="share_subscription_clipboard">تصدير إلى الحافظة</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">সম্পাদনা</string>
     <string name="action_delete">মুছুন</string>
     <string name="action_close">বন্ধ করুন</string>
+    <string name="action_exit">প্রস্থান</string>
 
     <string name="share_subscription_qrcode">QR কোড</string>
     <string name="share_subscription_clipboard">ক্লিপবোর্ডে রপ্তানি করুন</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">آلشتکاری</string>
     <string name="action_delete">پاک کردن</string>
     <string name="action_close">بستن</string>
+    <string name="action_exit">خروج</string>
 
     <string name="share_subscription_qrcode">کود QR</string>
     <string name="share_subscription_clipboard">و در کشیڌن من کلیپ بورد</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">ویرایش</string>
     <string name="action_delete">حذف</string>
     <string name="action_close">بستن</string>
+    <string name="action_exit">خروج</string>
 
     <string name="share_subscription_qrcode">کد QR</string>
     <string name="share_subscription_clipboard">خروجی گرفتن در کلیپ‌ بورد</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">Изменить</string>
     <string name="action_delete">Удалить</string>
     <string name="action_close">Закрыть</string>
+    <string name="action_exit">Выход</string>
 
     <string name="share_subscription_qrcode">QR-код</string>
     <string name="share_subscription_clipboard">Экспорт в буфер обмена</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">Chỉnh sửa</string>
     <string name="action_delete">Xoá</string>
     <string name="action_close">Đóng</string>
+    <string name="action_exit">Thoát</string>
 
     <string name="share_subscription_qrcode">Xuất gói ra mã QR (Chụp màn hình để lưu)</string>
     <string name="share_subscription_clipboard">Xuất gói vào bảng tạm</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">编辑</string>
     <string name="action_delete">删除</string>
     <string name="action_close">关闭</string>
+    <string name="action_exit">退出</string>
 
     <string name="share_subscription_qrcode">二维码</string>
     <string name="share_subscription_clipboard">导出至剪贴板</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">編輯</string>
     <string name="action_delete">刪除</string>
     <string name="action_close">關閉</string>
+    <string name="action_exit">退出</string>
 
     <string name="share_subscription_qrcode">QR Code</string>
     <string name="share_subscription_clipboard">匯出至剪貼簿</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -449,6 +449,7 @@
     <string name="action_edit">Edit</string>
     <string name="action_delete">Delete</string>
     <string name="action_close">Close</string>
+    <string name="action_exit">Exit</string>
 
     <string name="share_subscription_qrcode">QR code</string>
     <string name="share_subscription_clipboard">Export to clipboard</string>


### PR DESCRIPTION
## Summary

- Add a localized Exit item at the bottom of the main More menu on phones and TVs.
- Request service shutdown before removing the application task.
- Have VPN, proxy-only, and root services report when teardown has completed.
- Wait for completion with a five-second fallback timeout.
- Send the stop request even when the UI currently believes the service is stopped, protecting against stale UI state.

## Why

The future Android TV interface needs an obvious way to leave the application using only a remote control.

The action is also useful on smartphones as a convenient way to stop v2rayNG's core service and close its task without navigating to Android's App Info screen.

This is not equivalent to Android's privileged Force stop operation: it does not place the package in the force-stopped state or terminate arbitrary processes. It performs an orderly service shutdown and removes the application task.

## Testing

- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86`
