### PR TITLE
Use action labels for service launcher shortcuts

### DIFF
--- a/V2rayNG/app/src/fdroid/res/xml/shortcuts.xml
+++ b/V2rayNG/app/src/fdroid/res/xml/shortcuts.xml
@@ -33,10 +33,10 @@
     <shortcut
         android:enabled="true"
         android:icon="@drawable/ic_qu_start_24dp"
-        android:shortcutDisabledMessage="@string/toast_services_start"
+        android:shortcutDisabledMessage="@string/acc_start"
         android:shortcutId="shortcuts_start"
-        android:shortcutLongLabel="@string/toast_services_start"
-        android:shortcutShortLabel="@string/toast_services_start">
+        android:shortcutLongLabel="@string/acc_start"
+        android:shortcutShortLabel="@string/acc_start">
 
         <!--suppress AndroidDomInspection -->
         <intent
@@ -48,10 +48,10 @@
     <shortcut
         android:enabled="true"
         android:icon="@drawable/ic_qu_stop_24dp"
-        android:shortcutDisabledMessage="@string/toast_services_stop"
+        android:shortcutDisabledMessage="@string/acc_stop"
         android:shortcutId="shortcuts_stop"
-        android:shortcutLongLabel="@string/toast_services_stop"
-        android:shortcutShortLabel="@string/toast_services_stop">
+        android:shortcutLongLabel="@string/acc_stop"
+        android:shortcutShortLabel="@string/acc_stop">
 
         <!--suppress AndroidDomInspection -->
         <intent

--- a/V2rayNG/app/src/main/res/xml/shortcuts.xml
+++ b/V2rayNG/app/src/main/res/xml/shortcuts.xml
@@ -31,10 +31,10 @@
     <shortcut
         android:enabled="true"
         android:icon="@drawable/ic_qu_start_24dp"
-        android:shortcutDisabledMessage="@string/toast_services_start"
+        android:shortcutDisabledMessage="@string/acc_start"
         android:shortcutId="shortcuts_start"
-        android:shortcutLongLabel="@string/toast_services_start"
-        android:shortcutShortLabel="@string/toast_services_start">
+        android:shortcutLongLabel="@string/acc_start"
+        android:shortcutShortLabel="@string/acc_start">
 
         <intent
             android:action="android.intent.action.VIEW"
@@ -45,10 +45,10 @@
     <shortcut
         android:enabled="true"
         android:icon="@drawable/ic_qu_stop_24dp"
-        android:shortcutDisabledMessage="@string/toast_services_stop"
+        android:shortcutDisabledMessage="@string/acc_stop"
         android:shortcutId="shortcuts_stop"
-        android:shortcutLongLabel="@string/toast_services_stop"
-        android:shortcutShortLabel="@string/toast_services_stop">
+        android:shortcutLongLabel="@string/acc_stop"
+        android:shortcutShortLabel="@string/acc_stop">
 
         <intent
             android:action="android.intent.action.VIEW"


### PR DESCRIPTION
## Summary

- Use the existing localized Start service and Stop service action strings for launcher shortcuts.
- Apply the change to both Play Store and F-Droid shortcut resources.
- Add no new localization strings.

## Why

The shortcuts currently use transient status messages such as “Starting service” and “Stopping service” as their permanent labels. Launcher shortcuts describe actions, so the existing imperative action labels are more accurate.

## Testing

- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86`
- `:app:processFdroidDebugResources`
