### PR TITLE
Hide Restart service while stopped

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
@@ -66,8 +66,8 @@ fun ImportMenuContent(onAction: (MainAction) -> Unit) = AppDropdownMenuItems(
 )
 
 @Composable
-fun MoreMenuContent(onSelected: (MainMoreMenuAction) -> Unit) = AppDropdownMenuItems(
-    items = MainMoreMenuAction.entries,
+fun MoreMenuContent(isRunning: Boolean, onSelected: (MainMoreMenuAction) -> Unit) = AppDropdownMenuItems(
+    items = MainMoreMenuAction.entries.filter { it != MainMoreMenuAction.RestartService || isRunning },
     labelRes = { it.labelRes },
     onSelected = onSelected
 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -202,6 +202,7 @@ fun MainScreen(
             topBar = {
                 MainTopBar(
                     isLoading = isLoading,
+                    isRunning = isRunning,
                     showSearch = showSearch,
                     searchQuery = searchQuery,
                     onSearchQueryChange = { query: String ->

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
@@ -30,6 +30,7 @@ import com.v2ray.ang.ui.compose.verticalScrollbar
 @Composable
 fun MainTopBar(
     isLoading: Boolean,
+    isRunning: Boolean,
     showSearch: Boolean,
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
@@ -107,7 +108,7 @@ fun MainTopBar(
                         .heightIn(max = maxMenuHeight)
                         .verticalScrollbar(moreMenuScrollState)
                 ) {
-                    MoreMenuContent { action ->
+                    MoreMenuContent(isRunning) { action ->
                         showMenu = false
                         onMoreMenuAction(action)
                     }


### PR DESCRIPTION
Much simpler alternative to #6072 

## Summary

- hide **Restart service** from the main More menu while the service is stopped
- keep the existing Start control as the only way to start a stopped service

## Why

Restart is meaningful only for an active service. Making it unavailable while stopped keeps the action semantics explicit and avoids introducing cross-process "restart or start" acknowledgement and fallback logic for a state already represented by the UI.

This also prevents Restart from silently becoming a second Start action.