### PR TITLE
Improve accessibility announcement for server test status

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -56,7 +58,13 @@ fun MainBottomBar(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text(text = displayText, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = displayText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.semantics {
+                        contentDescription = displayText
+                    }
+                )
             }
         }
         FloatingActionButton(


### PR DESCRIPTION
## Description

Improve accessibility of the server test status for screen reader users.

Previously, when the server test status changed, the updated status was not automatically announced by screen readers while the status element had focus. Users had to move TalkBack focus away and back to the status to hear the updated result.

This change updates the accessibility content description whenever the server test status changes.

## Testing

Tested with:
- TalkBack
- Commentary Screen Reader

The updated status is announced automatically when the status element has accessibility focus, without requiring the user to move focus away and back.

When accessibility focus is elsewhere, the status change does not interrupt the user's current screen reader reading.