### PR TITLE
Fix crash during custom real-delay tests

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -18,8 +18,25 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+
+internal object RealPingExecutionLimiter {
+    private val customConfigMutex = Mutex()
+
+    suspend fun <T> run(configType: EConfigType, block: () -> T): T {
+        // Custom profiles bypass speed-test trimming and start complete Xray configs.
+        // Parallel teardown can abort the native probe process, so serialize their
+        // JNI measurements globally across batches.
+        return if (configType == EConfigType.CUSTOM) {
+            customConfigMutex.withLock { block() }
+        } else {
+            block()
+        }
+    }
+}
 
 /**
  * Worker that runs a batch of real-ping tests independently.
@@ -87,7 +104,7 @@ class RealPingWorkerService(
         }
     }
 
-    private fun startRealPing(guid: String): Long {
+    private suspend fun startRealPing(guid: String): Long {
         val retFailure = -1L
 
         val config = MmkvManager.decodeServerConfig(guid) ?: return retFailure
@@ -110,7 +127,9 @@ class RealPingWorkerService(
         if (!configResult.status) {
             return retFailure
         }
-        return CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+        return RealPingExecutionLimiter.run(config.configType) {
+            CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+        }
     }
 
     private fun startTcping(guid: String): Long {

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/service/RealPingExecutionLimiterTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/service/RealPingExecutionLimiterTest.kt
@@ -1,0 +1,61 @@
+package com.v2ray.ang.service
+
+import com.v2ray.ang.enums.EConfigType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class RealPingExecutionLimiterTest {
+
+    @Test
+    fun customConfigMeasurementsAreSerializedAcrossWorkers() {
+        runBlocking {
+            val active = AtomicInteger(0)
+            val maxActive = AtomicInteger(0)
+
+            List(8) {
+                async(Dispatchers.Default) {
+                    RealPingExecutionLimiter.run(EConfigType.CUSTOM) {
+                        val current = active.incrementAndGet()
+                        maxActive.accumulateAndGet(current, ::maxOf)
+                        Thread.sleep(20)
+                        active.decrementAndGet()
+                    }
+                }
+            }.awaitAll()
+
+            assertEquals(1, maxActive.get())
+        }
+    }
+
+    @Test
+    fun generatedConfigMeasurementsRemainConcurrent() {
+        runBlocking {
+            val entered = CountDownLatch(2)
+            val release = CountDownLatch(1)
+
+            val jobs = List(2) {
+                async(Dispatchers.Default) {
+                    RealPingExecutionLimiter.run(EConfigType.VMESS) {
+                        entered.countDown()
+                        release.await(5, TimeUnit.SECONDS)
+                    }
+                }
+            }
+
+            try {
+                assertTrue(entered.await(5, TimeUnit.SECONDS))
+            } finally {
+                release.countDown()
+            }
+            jobs.awaitAll()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- serialize custom-config real-delay measurements globally across concurrent workers and batches
- keep generated profile measurements concurrent
- add regression tests for both behaviors

## Root cause

Custom JSON profiles bypass the speed-test trimming applied to generated profiles, so each measurement starts a complete Xray config. With the public WireGuard subscription from #6077 (142 custom profiles), overlapping native core lifecycles reproduced a `panic: close of closed channel` followed by SIGABRT. That process-level native abort cannot be recovered by Kotlin exception handling.

The fix limits only this custom-config path; normal generated profiles retain the configured real-delay concurrency.

## Validation

- `:app:testPlaystoreDebugUnitTest --tests com.v2ray.ang.service.RealPingExecutionLimiterTest`
- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86_64`
- Android API 37 x86_64 emulator: reproduced the native abort on upstream after the first concurrent wave, then crossed the same boundary repeatedly with serialized custom core starts and no panic or SIGABRT

Fixes #6077