### PR TITLE
Potential fix: recover MMKV data on storage errors

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 import androidx.work.Configuration
 import androidx.work.WorkManager
-import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig.ANG_PACKAGE
 import com.v2ray.ang.handler.AppLocaleManager
+import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.compose.ThemeManager
 
@@ -35,7 +35,7 @@ class AngApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        MMKV.initialize(this)
+        MmkvManager.initialize(this)
 
         AppLocaleManager.initialize(this)
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -1,5 +1,7 @@
 package com.v2ray.ang.handler
 
+import android.content.Context
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -7,9 +9,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import com.tencent.mmkv.MMKV
+import com.tencent.mmkv.MMKVHandler
+import com.tencent.mmkv.MMKVLogLevel
+import com.tencent.mmkv.MMKVRecoverStrategic
 import com.v2ray.ang.AppConfig.DEFAULT_SUBSCRIPTION_ID
 import com.v2ray.ang.AppConfig.PREF_IS_BOOTED
 import com.v2ray.ang.AppConfig.PREF_ROUTING_RULESET
+import com.v2ray.ang.AppConfig.TAG
+import com.v2ray.ang.BuildConfig
 import com.v2ray.ang.dto.entities.AssetUrlCache
 import com.v2ray.ang.dto.entities.AssetUrlItem
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -41,6 +48,24 @@ object MmkvManager {
     private const val KEY_SUB_IDS = "SUB_IDS"
     private const val KEY_WEBDAV_CONFIG = "WEBDAV_CONFIG"
 
+    private val recoveryHandler = object : MMKVHandler {
+        override fun onMMKVCRCCheckFail(mmapID: String) =
+            recoverFromStorageError(mmapID, "CRC check")
+
+        override fun onMMKVFileLengthError(mmapID: String) =
+            recoverFromStorageError(mmapID, "file length check")
+
+        override fun wantLogRedirecting(): Boolean = false
+
+        override fun mmkvLog(
+            level: MMKVLogLevel,
+            file: String,
+            line: Int,
+            function: String,
+            message: String
+        ) = Unit
+    }
+
     private val mainStorage by lazy { MMKV.mmkvWithID(ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
     private val profileFullStorage by lazy { MMKV.mmkvWithID(ID_PROFILE_FULL_CONFIG, MMKV.MULTI_PROCESS_MODE) }
     private val serverRawStorage by lazy { MMKV.mmkvWithID(ID_SERVER_RAW, MMKV.MULTI_PROCESS_MODE) }
@@ -50,6 +75,29 @@ object MmkvManager {
     private val settingsStorage by lazy { MMKV.mmkvWithID(ID_SETTING, MMKV.MULTI_PROCESS_MODE) }
 
     //endregion
+
+    /**
+     * Initializes MMKV with best-effort recovery so a damaged store is not silently discarded.
+     */
+    fun initialize(context: Context) {
+        val logLevel = if (BuildConfig.DEBUG) {
+            MMKVLogLevel.LevelDebug
+        } else {
+            MMKVLogLevel.LevelInfo
+        }
+        MMKV.initialize(
+            context,
+            context.filesDir.resolve("mmkv").absolutePath,
+            null,
+            logLevel,
+            recoveryHandler
+        )
+    }
+
+    private fun recoverFromStorageError(mmapID: String, error: String): MMKVRecoverStrategic {
+        Log.e(TAG, "MMKV $error failed for $mmapID; attempting data recovery")
+        return MMKVRecoverStrategic.OnErrorRecover
+    }
 
     //region Server
 


### PR DESCRIPTION
## Summary

- initialize MMKV through `MmkvManager` with an explicit recovery handler
- request best-effort recovery after CRC or file-length validation failures instead of accepting MMKV's destructive default
- log the affected mmap ID directly to Logcat without depending on MMKV-backed application logging

## Rationale

Related to #6084.

The report shows subscription metadata disappearing from `SUB` together with the `MAIN`/`SUB_IDS` index, while `PROFILE_FULL_CONFIG`, `SUB_SERVERS_*`, and the selected profile survive. The current startup repair can rebuild `SUB_IDS` only when `SUB` still contains metadata, and I found no application path that clears the entire `SUB` store.

MMKV documents that its default response to a CRC or file-length error is to discard all data in the affected store. This change opts into MMKV's best-effort recovery strategy and records which mmap failed, preserving more evidence and giving recoverable data a chance to survive.

This remains a potential fix: the failure has not been reproduced and the reporter's raw MMKV files and `.crc` metadata have not yet been inspected. MMKV also does not guarantee that every damaged record can be recovered.

## User impact

Healthy MMKV stores retain the existing behavior, root directory, process mode, and debug/release log levels. When a store fails integrity validation, v2rayNG now attempts recovery rather than silently accepting total data loss.

## Follow-up: orphan profiles

The large number of historical entries in `PROFILE_FULL_CONFIG` is a separate persistence and cleanup problem. I will prepare a separate PR for reference-safe orphan-profile cleanup so its reachability rules, subscription-update ordering, and migration behavior can be reviewed and validated independently. This PR intentionally contains no profile deletion or migration logic.

## Validation

- `:app:compilePlaystoreDebugKotlin`
- `git diff --check`
