### PR TITLE
Safely clean up orphaned server profiles

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AngApplication.kt
@@ -10,6 +10,10 @@ import com.v2ray.ang.AppConfig.ANG_PACKAGE
 import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.compose.ThemeManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 class AngApplication : Application() {
     companion object {
@@ -29,6 +33,8 @@ class AngApplication : Application() {
         .setDefaultProcessName("${ANG_PACKAGE}:bg")
         .build()
 
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     /**
      * Initializes the application.
      */
@@ -44,6 +50,9 @@ class AngApplication : Application() {
 
         // Ensure critical preference defaults are present in MMKV early
         SettingsManager.initApp(this)
+        applicationScope.launch {
+            SettingsManager.cleanupOrphanedServerProfilesOnce()
+        }
 
         // Initialize theme state from MMKV
         ThemeManager.refresh()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -31,6 +31,11 @@ import java.net.URI
 
 object AngConfigManager {
 
+    private data class ParsedProfile(
+        val profile: ProfileItem,
+        val rawConfig: String? = null,
+    )
+
     // Parser mapping for different config types (lazy initialized)
     private val configFmtParsers: Map<String, (String) -> ProfileItem?> by lazy {
         mapOf(
@@ -192,6 +197,9 @@ object AngConfigManager {
         if (countSub > 0) {
             updateConfigViaSubAll()
         }
+        if (count > 0 && !append) {
+            cleanupOrphanedProfiles()
+        }
 
         return count to countSub
     }
@@ -236,9 +244,6 @@ object AngConfigManager {
             if (servers == null) {
                 return 0
             }
-            // Find the currently selected server that belongs to the same subscription before replacement.
-            val removedSelected = getRemovedSelectedProfile(subid, append)
-
             val subItem = MmkvManager.decodeSubscription(subid)
 
             // Parse all configs first (no I/O during parsing)
@@ -255,12 +260,11 @@ object AngConfigManager {
 
             // Batch save all parsed configs (only one serverList read/write)
             if (configs.isNotEmpty()) {
-                if (!append) {
-                    MmkvManager.removeServerViaSubid(subid)
-                }
-                val keyToProfile = batchSaveConfigs(configs, subid)
-                val matchKey = findMatchedProfileKey(keyToProfile, removedSelected)
-                matchKey?.let { MmkvManager.setSelectServer(it) }
+                commitProfiles(
+                    configs = configs.map(::ParsedProfile),
+                    subid = subid,
+                    append = append,
+                )
             }
 
             return configs.size
@@ -271,33 +275,59 @@ object AngConfigManager {
     }
 
     /**
-     * Batch save configurations to reduce serverList read/write operations.
-     * Reads serverList once, saves all configs, then writes serverList once.
+     * Saves configurations and their group index as one lock-protected operation.
      *
-     * @param configs The list of ProfileItem to save.
+     * @param configs The parsed profiles to save.
      * @param subid The subscription ID.
+     * @param append Whether to append to the existing server list.
      * @return Map of generated keys to their corresponding ProfileItem.
      */
-    private fun batchSaveConfigs(configs: List<ProfileItem>, subid: String): Map<String, ProfileItem> {
-        val keyToProfile = mutableMapOf<String, ProfileItem>()
+    private fun saveProfiles(
+        configs: List<ParsedProfile>,
+        subid: String,
+        append: Boolean,
+    ): Map<String, ProfileItem> {
+        val keyToProfile = linkedMapOf<String, ProfileItem>()
+        val rawConfigs = mutableMapOf<String, String>()
 
-        // Read serverList once
-        val serverList = MmkvManager.decodeServerList(subid)
-
-        configs.forEach { config ->
+        configs.forEach { parsed ->
             val key = Utils.getUuid()
-            // Save profile directly without updating serverList
-            MmkvManager.encodeProfileDirect(key, JsonUtil.toJson(config))
-
-            if (!serverList.contains(key)) {
-                serverList.add(0, key)
-            }
-            keyToProfile[key] = config
+            keyToProfile[key] = parsed.profile
+            parsed.rawConfig?.let { raw -> rawConfigs[key] = raw }
         }
 
-        // Write serverList once
-        MmkvManager.encodeServerList(serverList, subid)
+        MmkvManager.saveServerProfiles(
+            profiles = keyToProfile,
+            rawConfigs = rawConfigs,
+            subscriptionId = subid,
+            append = append,
+        )
         return keyToProfile
+    }
+
+    /**
+     * Commits parsed profiles, reassigns a replaced selection, then collects old payloads.
+     */
+    private fun commitProfiles(
+        configs: List<ParsedProfile>,
+        subid: String,
+        append: Boolean,
+    ) {
+        val removedSelected = getRemovedSelectedProfile(subid, append)
+        val keyToProfile = saveProfiles(configs, subid, append)
+        val matchKey = findMatchedProfileKey(keyToProfile, removedSelected)
+        matchKey?.let { MmkvManager.setSelectServer(it) }
+    }
+
+    private fun cleanupOrphanedProfiles() {
+        try {
+            val removed = MmkvManager.removeOrphanedServerProfiles()
+            if (removed > 0) {
+                LogUtil.i(AppConfig.TAG, "Removed $removed orphaned server profiles")
+            }
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to clean orphaned server profiles", e)
+        }
     }
 
     /**
@@ -400,26 +430,17 @@ object AngConfigManager {
                     JsonUtil.fromJson(server, Array<Any>::class.java) ?: arrayOf()
 
                 if (serverList.isNotEmpty()) {
-                    val removedSelected = getRemovedSelectedProfile(subid, append)
-                    if (!append) {
-                        MmkvManager.removeServerViaSubid(subid)
-                    }
-                    var count = 0
-                    val keyToProfile = mutableMapOf<String, ProfileItem>()
-                    for (srv in serverList.reversed()) {
-                        val config = CustomFmt.parse(JsonUtil.toJson(srv)) ?: continue
+                    val configs = serverList.reversed().map { srv ->
+                        val config = CustomFmt.parse(JsonUtil.toJson(srv))
                         config.subscriptionId = subid
                         config.description = generateDescription(config)
-                        val key = MmkvManager.encodeServerConfig("", config)
-                        MmkvManager.encodeServerRaw(key, JsonUtil.toJsonPretty(srv) ?: "")
-                        keyToProfile[key] = config
-                        count += 1
+                        ParsedProfile(
+                            profile = config,
+                            rawConfig = JsonUtil.toJsonPretty(srv) ?: "",
+                        )
                     }
-                    if (count > 0) {
-                        val matchKey = findMatchedProfileKey(keyToProfile, removedSelected)
-                        matchKey?.let { MmkvManager.setSelectServer(it) }
-                    }
-                    return count
+                    commitProfiles(configs, subid, append)
+                    return configs.size
                 }
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.TAG, "Failed to parse custom config server JSON array", e)
@@ -427,14 +448,14 @@ object AngConfigManager {
 
             try {
                 // For compatibility
-                val config = CustomFmt.parse(server) ?: return 0
+                val config = CustomFmt.parse(server)
                 config.subscriptionId = subid
                 config.description = generateDescription(config)
-                if (!append) {
-                    MmkvManager.removeServerViaSubid(subid)
-                }
-                val key = MmkvManager.encodeServerConfig("", config)
-                MmkvManager.encodeServerRaw(key, server)
+                commitProfiles(
+                    configs = listOf(ParsedProfile(config, server)),
+                    subid = subid,
+                    append = append,
+                )
                 return 1
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.TAG, "Failed to parse custom config server as single config", e)
@@ -442,13 +463,14 @@ object AngConfigManager {
             return 0
         } else if (server.startsWith("[Interface]") && server.contains("[Peer]")) {
             try {
-                val config = WireguardFmt.parseWireguardConfFile(server) ?: return R.string.toast_incorrect_protocol
+                val config = WireguardFmt.parseWireguardConfFile(server)
+                config.subscriptionId = subid
                 config.description = generateDescription(config)
-                if (!append) {
-                    MmkvManager.removeServerViaSubid(subid)
-                }
-                val key = MmkvManager.encodeServerConfig("", config)
-                MmkvManager.encodeServerRaw(key, server)
+                commitProfiles(
+                    configs = listOf(ParsedProfile(config, server)),
+                    subid = subid,
+                    append = append,
+                )
                 return 1
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.TAG, "Failed to parse WireGuard config file", e)
@@ -517,9 +539,13 @@ object AngConfigManager {
     fun updateConfigViaSubAll(): SubscriptionUpdateResult {
         return try {
             val subscriptions = MmkvManager.decodeSubscriptions()
-            subscriptions.fold(SubscriptionUpdateResult()) { acc, subscription ->
-                acc + updateConfigViaSub(subscription)
+            val result = subscriptions.fold(SubscriptionUpdateResult()) { acc, subscription ->
+                acc + updateConfigViaSub(subscription, cleanupOrphans = false)
             }
+            if (result.successCount > 0) {
+                cleanupOrphanedProfiles()
+            }
+            result
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to update config via all subscriptions", e)
             SubscriptionUpdateResult()
@@ -533,6 +559,13 @@ object AngConfigManager {
      * @return Subscription update result.
      */
     fun updateConfigViaSub(it: SubscriptionCache): SubscriptionUpdateResult {
+        return updateConfigViaSub(it, cleanupOrphans = true)
+    }
+
+    private fun updateConfigViaSub(
+        it: SubscriptionCache,
+        cleanupOrphans: Boolean,
+    ): SubscriptionUpdateResult {
         try {
             // Check if disabled
             if (!it.subscription.enabled) {
@@ -601,6 +634,9 @@ object AngConfigManager {
             if (count > 0) {
                 it.subscription.lastUpdated = System.currentTimeMillis()
                 MmkvManager.encodeSubscription(it.guid, it.subscription)
+                if (cleanupOrphans) {
+                    cleanupOrphanedProfiles()
+                }
                 LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")
                 return SubscriptionUpdateResult(
                     configCount = count,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -40,6 +40,7 @@ object MmkvManager {
     private const val KEY_SUB_SERVER_PREFIX = "SUB_SERVERS_"
     private const val KEY_SUB_IDS = "SUB_IDS"
     private const val KEY_WEBDAV_CONFIG = "WEBDAV_CONFIG"
+    private const val KEY_ORPHAN_PROFILE_CLEANUP = "orphaned_server_profiles_cleaned_v1"
 
     private val mainStorage by lazy { MMKV.mmkvWithID(ID_MAIN, MMKV.MULTI_PROCESS_MODE) }
     private val profileFullStorage by lazy { MMKV.mmkvWithID(ID_PROFILE_FULL_CONFIG, MMKV.MULTI_PROCESS_MODE) }
@@ -48,6 +49,29 @@ object MmkvManager {
     private val subStorage by lazy { MMKV.mmkvWithID(ID_SUB, MMKV.MULTI_PROCESS_MODE) }
     private val assetStorage by lazy { MMKV.mmkvWithID(ID_ASSET, MMKV.MULTI_PROCESS_MODE) }
     private val settingsStorage by lazy { MMKV.mmkvWithID(ID_SETTING, MMKV.MULTI_PROCESS_MODE) }
+
+    private inline fun <T> withProfileIndexLock(block: () -> T): T {
+        mainStorage.lock()
+        return try {
+            block()
+        } finally {
+            mainStorage.unlock()
+        }
+    }
+
+    private fun removeProfilePayload(guid: String) {
+        profileFullStorage.remove(guid)
+        serverAffStorage.remove(guid)
+        serverRawStorage.remove(guid)
+    }
+
+    private fun removeProfilePayloads(guids: Collection<String>) {
+        if (guids.isEmpty()) return
+        val keys = guids.toTypedArray()
+        profileFullStorage.removeValuesForKeys(keys)
+        serverAffStorage.removeValuesForKeys(keys)
+        serverRawStorage.removeValuesForKeys(keys)
+    }
 
     //endregion
 
@@ -166,17 +190,19 @@ object MmkvManager {
      */
     fun encodeServerConfig(guid: String, config: ProfileItem): String {
         val key = guid.ifBlank { Utils.getUuid() }
-        profileFullStorage.encode(key, JsonUtil.toJson(config))
+        withProfileIndexLock {
+            profileFullStorage.encode(key, JsonUtil.toJson(config))
 
-        // Use default subscription for servers without subscription
-        val subId = getSubscriptionId(config.subscriptionId)
-        val serverList = decodeServerList(subId)
+            // Use default subscription for servers without subscription
+            val subId = getSubscriptionId(config.subscriptionId)
+            val serverList = decodeServerList(subId)
 
-        if (!serverList.contains(key)) {
-            serverList.add(0, key)
-            encodeServerList(serverList, subId)
-            if (getSelectServer().isNullOrBlank()) {
-                mainStorage.encode(KEY_SELECTED_SERVER, key)
+            if (!serverList.contains(key)) {
+                serverList.add(0, key)
+                encodeServerList(serverList, subId)
+                if (getSelectServer().isNullOrBlank()) {
+                    mainStorage.encode(KEY_SELECTED_SERVER, key)
+                }
             }
         }
 
@@ -184,13 +210,42 @@ object MmkvManager {
     }
 
     /**
-     * Encodes the server configuration directly without updating serverList.
+     * Saves parsed profiles and commits their group index while holding the MAIN storage lock.
+     * Existing profile payloads remain available until orphan cleanup runs after selection is
+     * reassigned, so an interrupted replacement never leaves the group empty.
      *
-     * @param key The server GUID.
-     * @param configJson The server configuration JSON string.
+     * @param profiles Generated GUIDs and parsed profiles, in insertion order.
+     * @param rawConfigs Optional raw configuration payloads keyed by profile GUID.
+     * @param subscriptionId The destination subscription ID.
+     * @param append Whether to append to the existing group index.
      */
-    fun encodeProfileDirect(key: String, configJson: String) {
-        profileFullStorage.encode(key, configJson)
+    internal fun saveServerProfiles(
+        profiles: Map<String, ProfileItem>,
+        rawConfigs: Map<String, String>,
+        subscriptionId: String,
+        append: Boolean,
+    ) {
+        if (profiles.isEmpty()) return
+
+        withProfileIndexLock {
+            profiles.forEach { (guid, profile) ->
+                profileFullStorage.encode(guid, JsonUtil.toJson(profile))
+                rawConfigs[guid]?.let { raw -> serverRawStorage.encode(guid, raw) }
+            }
+
+            val serverList = if (append) {
+                decodeServerList(subscriptionId)
+            } else {
+                mutableListOf()
+            }
+            val indexedServers = serverList.toHashSet()
+            profiles.keys.forEach { guid ->
+                if (indexedServers.add(guid)) {
+                    serverList.add(0, guid)
+                }
+            }
+            encodeServerList(serverList, subscriptionId)
+        }
     }
 
     /**
@@ -216,8 +271,7 @@ object MmkvManager {
         if (getSelectServer() == guid) {
             mainStorage.remove(KEY_SELECTED_SERVER)
         }
-        profileFullStorage.remove(guid)
-        serverAffStorage.remove(guid)
+        removeProfilePayload(guid)
     }
 
     /**
@@ -229,14 +283,10 @@ object MmkvManager {
         val subId = getSubscriptionId(subscriptionId)
         val serverList = decodeServerList(subId)
 
-        // Remove all servers in the list
-        serverList.forEach { guid ->
-            if (getSelectServer() == guid) {
-                mainStorage.remove(KEY_SELECTED_SERVER)
-            }
-            profileFullStorage.remove(guid)
-            serverAffStorage.remove(guid)
+        if (getSelectServer() in serverList) {
+            mainStorage.remove(KEY_SELECTED_SERVER)
         }
+        removeProfilePayloads(serverList)
 
         serverList.clear()
         encodeServerList(serverList, subId)
@@ -256,15 +306,10 @@ object MmkvManager {
             encodeServerList(serverList, subId)
         }
 
-        val selectedServer = getSelectServer()
-        guids.forEach { guid ->
-            if (selectedServer == guid) {
-                mainStorage.remove(KEY_SELECTED_SERVER)
-            }
-            profileFullStorage.remove(guid)
-            serverAffStorage.remove(guid)
-            serverRawStorage.remove(guid)
+        if (getSelectServer() in guids) {
+            mainStorage.remove(KEY_SELECTED_SERVER)
         }
+        removeProfilePayloads(guids)
     }
 
     /**
@@ -376,6 +421,65 @@ object MmkvManager {
      */
     fun decodeServerRaw(guid: String): String? {
         return serverRawStorage.decodeString(guid)
+    }
+
+    /**
+     * Removes profile payloads that are provably absent from their raw SUB_SERVERS_* index.
+     *
+     * SUB_IDS and SUB are intentionally ignored: either store can be missing after MMKV
+     * recovery while the group indexes still identify live profiles. If any group index or
+     * profile payload needed for a decision is unreadable, that data is preserved.
+     *
+     * @return The number of profile payloads removed.
+     */
+    internal fun removeOrphanedServerProfiles(): Int = withProfileIndexLock {
+        removeOrphanedServerProfilesLocked()
+    }
+
+    /**
+     * Runs the initial cleanup at most once across all application processes.
+     *
+     * @return The removed profile count, or null if another process already completed it.
+     */
+    internal fun removeOrphanedServerProfilesOnce(): Int? = withProfileIndexLock {
+        if (settingsStorage.decodeBool(KEY_ORPHAN_PROFILE_CLEANUP, false)) {
+            return@withProfileIndexLock null
+        }
+
+        removeOrphanedServerProfilesLocked().also {
+            settingsStorage.encode(KEY_ORPHAN_PROFILE_CLEANUP, true)
+        }
+    }
+
+    private fun removeOrphanedServerProfilesLocked(): Int {
+        val indexedServersBySubscription = mainStorage.allKeys().orEmpty()
+            .asSequence()
+            .filter { key -> key.startsWith(KEY_SUB_SERVER_PREFIX) }
+            .associate { key ->
+                val subscriptionId = key.removePrefix(KEY_SUB_SERVER_PREFIX)
+                val json = mainStorage.decodeString(key)
+                val serverIds = if (json.isNullOrBlank()) {
+                    null
+                } else {
+                    JsonUtil.fromJsonSafe(json, Array<String>::class.java)?.toSet()
+                }
+                subscriptionId to serverIds
+            }
+
+        val profiles = profileFullStorage.allKeys().orEmpty().map { guid ->
+            StoredProfileReference(
+                guid = guid,
+                subscriptionId = decodeServerConfig(guid)?.subscriptionId,
+            )
+        }
+        val orphans = OrphanProfileCleaner.findOrphans(
+            profiles = profiles,
+            indexedServersBySubscription = indexedServersBySubscription,
+            selectedServer = getSelectServer(),
+        )
+
+        removeProfilePayloads(orphans)
+        return orphans.size
     }
 
     //endregion

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/OrphanProfileCleaner.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/OrphanProfileCleaner.kt
@@ -1,0 +1,50 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.AppConfig.DEFAULT_SUBSCRIPTION_ID
+
+internal data class StoredProfileReference(
+    val guid: String,
+    val subscriptionId: String?,
+)
+
+internal object OrphanProfileCleaner {
+
+    /**
+     * Finds profile payloads that are provably unreachable from the raw group indexes.
+     *
+     * A null subscription ID means that the profile payload could not be decoded. A null
+     * server set means that a group index could not be decoded. Both cases fail closed.
+     * Subscription metadata is deliberately not an input because SUB and SUB_IDS can be
+     * missing while the raw SUB_SERVERS_* indexes remain intact.
+     */
+    fun findOrphans(
+        profiles: Collection<StoredProfileReference>,
+        indexedServersBySubscription: Map<String, Set<String>?>,
+        selectedServer: String?,
+    ): Set<String> {
+        if (indexedServersBySubscription.isEmpty() ||
+            indexedServersBySubscription.values.any { it == null }
+        ) {
+            return emptySet()
+        }
+
+        val indexedServers = indexedServersBySubscription.values
+            .filterNotNull()
+            .flatten()
+            .toSet()
+
+        return profiles.mapNotNullTo(linkedSetOf()) { profile ->
+            if (profile.guid == selectedServer || profile.guid in indexedServers) {
+                return@mapNotNullTo null
+            }
+
+            val subscriptionId = profile.subscriptionId ?: return@mapNotNullTo null
+            val groupId = subscriptionId.ifEmpty { DEFAULT_SUBSCRIPTION_ID }
+            if (!indexedServersBySubscription.containsKey(groupId)) {
+                return@mapNotNullTo null
+            }
+
+            profile.guid
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -560,6 +560,21 @@ object SettingsManager {
     }
 
     /**
+     * Runs the initial orphan cleanup after legacy server lists have been migrated.
+     * Later subscription replacements run the same idempotent cleanup directly.
+     */
+    internal fun cleanupOrphanedServerProfilesOnce() {
+        try {
+            val removed = MmkvManager.removeOrphanedServerProfilesOnce() ?: return
+            if (removed > 0) {
+                LogUtil.i(AppConfig.TAG, "Removed $removed orphaned server profiles")
+            }
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to clean orphaned server profiles", e)
+        }
+    }
+
+    /**
      * Ensures the default subscription exists for ungrouped servers.
      * This subscription is used internally to store servers without a subscription.
      * Made public for migration in SettingsManager.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupActivity.kt
@@ -44,8 +44,10 @@ import com.v2ray.ang.ui.compose.InputField
 import com.v2ray.ang.ui.compose.SelectListDialog
 import com.v2ray.ang.ui.compose.SettingsMenuItem
 import com.v2ray.ang.util.LogUtil
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -79,6 +81,9 @@ class BackupActivity : HelperBaseComponentActivity() {
 
                         is BackupViewModel.BackupViewModelEvent.RestoreSuccess -> {
                             SettingsManager.initApp(this@BackupActivity)
+                            withContext(Dispatchers.IO) {
+                                SettingsManager.cleanupOrphanedServerProfilesOnce()
+                            }
                         }
 
                         else -> {}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/OrphanProfileCleanerTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/OrphanProfileCleanerTest.kt
@@ -1,0 +1,110 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.AppConfig.DEFAULT_SUBSCRIPTION_ID
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OrphanProfileCleanerTest {
+
+    @Test
+    fun `uses raw group indexes when subscription metadata is missing`() {
+        val profiles = listOf(
+            StoredProfileReference("live", "group-a"),
+            StoredProfileReference("orphan", "group-a"),
+        )
+
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = profiles,
+            indexedServersBySubscription = mapOf("group-a" to setOf("live")),
+            selectedServer = null,
+        )
+
+        assertEquals(setOf("orphan"), result)
+    }
+
+    @Test
+    fun `keeps profiles whose group index is missing`() {
+        val profiles = listOf(
+            StoredProfileReference("known-orphan", "group-a"),
+            StoredProfileReference("unknown", "missing-group"),
+        )
+
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = profiles,
+            indexedServersBySubscription = mapOf("group-a" to emptySet()),
+            selectedServer = null,
+        )
+
+        assertEquals(setOf("known-orphan"), result)
+    }
+
+    @Test
+    fun `aborts cleanup when any raw group index is unreadable`() {
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = listOf(StoredProfileReference("candidate", "group-a")),
+            indexedServersBySubscription = mapOf(
+                "group-a" to emptySet(),
+                "corrupt-group" to null,
+            ),
+            selectedServer = null,
+        )
+
+        assertEquals(emptySet<String>(), result)
+    }
+
+    @Test
+    fun `aborts cleanup when no raw group indexes survive`() {
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = listOf(StoredProfileReference("candidate", "group-a")),
+            indexedServersBySubscription = emptyMap(),
+            selectedServer = null,
+        )
+
+        assertEquals(emptySet<String>(), result)
+    }
+
+    @Test
+    fun `keeps selected and undecodable profiles`() {
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = listOf(
+                StoredProfileReference("selected", "group-a"),
+                StoredProfileReference("undecodable", null),
+                StoredProfileReference("orphan", "group-a"),
+            ),
+            indexedServersBySubscription = mapOf("group-a" to emptySet()),
+            selectedServer = "selected",
+        )
+
+        assertEquals(setOf("orphan"), result)
+    }
+
+    @Test
+    fun `normalizes ungrouped profiles to the default group`() {
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = listOf(
+                StoredProfileReference("live", ""),
+                StoredProfileReference("orphan", ""),
+            ),
+            indexedServersBySubscription = mapOf(
+                DEFAULT_SUBSCRIPTION_ID to setOf("live"),
+            ),
+            selectedServer = null,
+        )
+
+        assertEquals(setOf("orphan"), result)
+    }
+
+    @Test
+    fun `keeps a profile indexed by a different group`() {
+        val result = OrphanProfileCleaner.findOrphans(
+            profiles = listOf(StoredProfileReference("mismatched", "group-a")),
+            indexedServersBySubscription = mapOf(
+                "group-a" to emptySet(),
+                "group-b" to setOf("mismatched"),
+            ),
+            selectedServer = null,
+        )
+
+        assertEquals(emptySet<String>(), result)
+    }
+}


### PR DESCRIPTION
## Summary

- commit replacement profiles and their `SUB_SERVERS_*` group index together under the MMKV multi-process lock
- collect only profile payloads that are provably unreachable from every readable raw group index
- run cleanup once in the background for existing installations and after successful replacement imports or subscription updates
- remove matching full-profile, raw-config, and affinity entries in bulk

## Context

Follow-up to #6085. Related to #6084.

#6084 contained more than 21,000 entries in `PROFILE_FULL_CONFIG`, while only about 4,900 profiles remained referenced by current subscription group indexes. This PR addresses that separate persistence and cleanup problem.

It does not assume that orphan-profile growth caused the reported loss of `SUB_IDS` and `SUB`, and it does not attempt to reconstruct missing subscription metadata. The exact corruption point has not been reproduced, so that remains a separate investigation.

## Cleanup safety

The collector deliberately derives reachability from the raw `SUB_SERVERS_*` indexes instead of `SUB_IDS` or `SUB`, because #6084 shows that those metadata stores may be missing while the group indexes and profiles remain intact.

Cleanup fails closed:

- the selected profile is always preserved
- undecodable profiles are preserved
- profiles whose group index is missing are preserved
- profiles referenced by any group are preserved, even if their embedded group ID disagrees
- the entire pass is skipped if no raw group indexes survive or any group index is unreadable

Replacement ordering is also changed so new payloads and their group index are committed before the previous payloads become cleanup candidates. Selection reassignment completes before collection runs, avoiding an empty or broken intermediate group if a refresh is interrupted.

The one-time migration marker and profile/index updates use the same cross-process lock. The initial scan runs on `Dispatchers.IO`, and cleanup failures are logged without turning an otherwise successful import or subscription refresh into a failure.

## User impact

Existing installations can discard historical profile payloads that are no longer reachable, reducing persistent MMKV and backup growth while preserving ambiguous or potentially recoverable data. Future replacement updates clean their old payloads after the new group is committed.

There are no UI changes, and healthy active profiles keep their current behavior.

## Validation

- `:app:testPlaystoreDebugUnitTest --tests com.v2ray.ang.handler.OrphanProfileCleanerTest` — 7 tests passed
- `:app:compilePlaystoreDebugKotlin`
- `git diff --check`

The unit tests cover missing subscription metadata, missing and unreadable group indexes, selected and undecodable profiles, default-group normalization, and cross-group references.
