### PR TITLE
Add translator credits page

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -209,6 +209,9 @@
         <activity
             android:name=".ui.AboutActivity"
             android:exported="false" />
+        <activity
+            android:name=".ui.TranslatorsActivity"
+            android:exported="false" />
 
         <service
             android:name=".service.CoreVpnService"

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AboutActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/AboutActivity.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.webkit.WebView
 import androidx.compose.foundation.layout.Column
@@ -46,12 +47,20 @@ class AboutActivity : BaseComponentActivity() {
 
     @Composable
     override fun ScreenContent() {
-        AboutScreen(onBackClick = { finish() })
+        AboutScreen(
+            onBackClick = { finish() },
+            onTranslatorsClick = {
+                startActivity(Intent(this, TranslatorsActivity::class.java))
+            }
+        )
     }
 }
 
 @Composable
-fun AboutScreen(onBackClick: () -> Unit) {
+fun AboutScreen(
+    onBackClick: () -> Unit,
+    onTranslatorsClick: () -> Unit
+) {
     val context = LocalContext.current
     var showOssDialog by remember { mutableStateOf(false) }
 
@@ -83,6 +92,11 @@ fun AboutScreen(onBackClick: () -> Unit) {
                 icon = painterResource(R.drawable.license_24px),
                 title = stringResource(R.string.title_oss_license),
                 onClick = { showOssDialog = true }
+            )
+            SettingsMenuItem(
+                icon = painterResource(R.drawable.ic_translate_24dp),
+                title = stringResource(R.string.title_translators),
+                onClick = onTranslatorsClick
             )
             SettingsMenuItem(
                 icon = painterResource(R.drawable.ic_feedback_24dp),

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
@@ -161,7 +161,7 @@ private val translationCredits = listOf(
     TranslationCredit(
         language = "لۊری بختیاری (Luri Bakhtiari)",
         contributors = listOf(
-            contributor("@hosseinabaspanah", "https://github.com/hosseinabaspanah"),
+            contributor("Hossein Abaspanah", "https://github.com/hosseinabaspanah"),
             contributor("@CodeWithTamim", "https://github.com/CodeWithTamim")
         )
     ),

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
@@ -1,0 +1,227 @@
+package com.v2ray.ang.ui
+
+import android.os.Bundle
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import com.v2ray.ang.R
+import com.v2ray.ang.ui.base.BaseComponentActivity
+import com.v2ray.ang.ui.compose.AppTopBar
+import com.v2ray.ang.ui.compose.NavigationBarsSpacer
+import com.v2ray.ang.util.Utils
+
+class TranslatorsActivity : BaseComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    @Composable
+    override fun ScreenContent() {
+        TranslatorsScreen(onBackClick = { finish() })
+    }
+}
+
+@Composable
+fun TranslatorsScreen(onBackClick: () -> Unit) {
+    Scaffold(
+        contentWindowInsets = WindowInsets(0),
+        topBar = {
+            AppTopBar(
+                title = stringResource(R.string.title_translators),
+                onBackClick = onBackClick
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item {
+                Text(
+                    text = stringResource(R.string.translators_intro),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            items(translationCredits, key = { it.language }) { credit ->
+                TranslationCreditCard(credit)
+            }
+            item {
+                AuditNoteCard()
+            }
+            item {
+                NavigationBarsSpacer()
+            }
+        }
+    }
+}
+
+@Composable
+private fun TranslationCreditCard(credit: TranslationCredit) {
+    val context = LocalContext.current
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = credit.language,
+                style = MaterialTheme.typography.titleMedium
+            )
+            credit.contributors.forEach { contributor ->
+                val githubLogin = contributor.githubLogin
+                Text(
+                    text = contributor.displayName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = if (githubLogin != null) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (githubLogin != null) {
+                                Modifier.clickable(role = Role.Button) {
+                                    Utils.openUri(context, "https://github.com/$githubLogin")
+                                }
+                            } else {
+                                Modifier
+                            }
+                        )
+                        .padding(vertical = 6.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AuditNoteCard() {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.translators_audit_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = stringResource(R.string.translators_audit_note),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+    }
+}
+
+private data class TranslationCredit(
+    val language: String,
+    val contributors: List<Contributor>
+)
+
+private data class Contributor(
+    val displayName: String,
+    val githubLogin: String? = null
+)
+
+private fun githubContributor(login: String) = Contributor(
+    displayName = "@$login",
+    githubLogin = login
+)
+
+private val translationCredits = listOf(
+    TranslationCredit(
+        language = "العربية (Arabic)",
+        contributors = listOf(githubContributor("MrIbrahem"))
+    ),
+    TranslationCredit(
+        language = "বাংলা (Bengali)",
+        contributors = listOf(githubContributor("CodeWithTamim"))
+    ),
+    TranslationCredit(
+        language = "لری بختیاری (Luri Bakhtiari)",
+        contributors = listOf(
+            githubContributor("hosseinabaspanah"),
+            githubContributor("CodeWithTamim")
+        )
+    ),
+    TranslationCredit(
+        language = "فارسی (Persian)",
+        contributors = listOf(
+            githubContributor("TheMRVX"),
+            githubContributor("Skh-web6982"),
+            githubContributor("Ptechgithub"),
+            Contributor("@Pk-web6936"),
+            Contributor("@alphax-hue3682"),
+            Contributor("@phoenix6936"),
+            Contributor("@DecorativeFamily"),
+            Contributor("@decorativeman"),
+            githubContributor("mh292929"),
+            githubContributor("Amir-yazdanmanesh"),
+            githubContributor("CUMOON"),
+            githubContributor("hadi-norouzi"),
+            Contributor("Vahid Farid")
+        )
+    ),
+    TranslationCredit(
+        language = "Русский (Russian)",
+        contributors = listOf(
+            githubContributor("solokot"),
+            githubContributor("Liniya"),
+            githubContributor("eliotcougar")
+        )
+    ),
+    TranslationCredit(
+        language = "Tiếng Việt (Vietnamese)",
+        contributors = listOf(
+            githubContributor("admarty"),
+            githubContributor("user09283"),
+            githubContributor("yuhan6665")
+        )
+    ),
+    TranslationCredit(
+        language = "简体中文 (Simplified Chinese)",
+        contributors = listOf(
+            githubContributor("2dust"),
+            githubContributor("Yau08")
+        )
+    ),
+    TranslationCredit(
+        language = "繁體中文 (Traditional Chinese)",
+        contributors = listOf(
+            githubContributor("2dust"),
+            githubContributor("Yau08"),
+            githubContributor("Fubuki0x10DE")
+        )
+    )
+)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
@@ -58,13 +58,6 @@ fun TranslatorsScreen(onBackClick: () -> Unit) {
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            item {
-                Text(
-                    text = stringResource(R.string.translators_intro),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
             items(translationCredits, key = { it.language }) { credit ->
                 TranslationCreditCard(credit)
             }
@@ -94,11 +87,11 @@ private fun TranslationCreditCard(credit: TranslationCredit) {
                 style = MaterialTheme.typography.titleMedium
             )
             credit.contributors.forEach { contributor ->
-                val githubLogin = contributor.githubLogin
+                val linkUrl = contributor.linkUrl
                 Text(
                     text = contributor.displayName,
                     style = MaterialTheme.typography.bodyLarge,
-                    color = if (githubLogin != null) {
+                    color = if (linkUrl != null) {
                         MaterialTheme.colorScheme.primary
                     } else {
                         MaterialTheme.colorScheme.onSurface
@@ -106,9 +99,9 @@ private fun TranslationCreditCard(credit: TranslationCredit) {
                     modifier = Modifier
                         .fillMaxWidth()
                         .then(
-                            if (githubLogin != null) {
+                            if (linkUrl != null) {
                                 Modifier.clickable(role = Role.Button) {
-                                    Utils.openUri(context, "https://github.com/$githubLogin")
+                                    Utils.openUri(context, linkUrl)
                                 }
                             } else {
                                 Modifier
@@ -151,77 +144,74 @@ private data class TranslationCredit(
 
 private data class Contributor(
     val displayName: String,
-    val githubLogin: String? = null
+    val linkUrl: String?
 )
 
-private fun githubContributor(login: String) = Contributor(
-    displayName = "@$login",
-    githubLogin = login
-)
+private fun contributor(displayName: String, linkUrl: String?) = Contributor(displayName, linkUrl)
 
 private val translationCredits = listOf(
     TranslationCredit(
         language = "العربية (Arabic)",
-        contributors = listOf(githubContributor("MrIbrahem"))
+        contributors = listOf(contributor("@MrIbrahem", "https://github.com/MrIbrahem"))
     ),
     TranslationCredit(
         language = "বাংলা (Bengali)",
-        contributors = listOf(githubContributor("CodeWithTamim"))
+        contributors = listOf(contributor("@CodeWithTamim", "https://github.com/CodeWithTamim"))
     ),
     TranslationCredit(
         language = "لری بختیاری (Luri Bakhtiari)",
         contributors = listOf(
-            githubContributor("hosseinabaspanah"),
-            githubContributor("CodeWithTamim")
+            contributor("@hosseinabaspanah", "https://github.com/hosseinabaspanah"),
+            contributor("@CodeWithTamim", "https://github.com/CodeWithTamim")
         )
     ),
     TranslationCredit(
         language = "فارسی (Persian)",
         contributors = listOf(
-            githubContributor("TheMRVX"),
-            githubContributor("Skh-web6982"),
-            githubContributor("Ptechgithub"),
-            Contributor("@Pk-web6936"),
-            Contributor("@alphax-hue3682"),
-            Contributor("@phoenix6936"),
-            Contributor("@DecorativeFamily"),
-            Contributor("@decorativeman"),
-            githubContributor("mh292929"),
-            githubContributor("Amir-yazdanmanesh"),
-            githubContributor("CUMOON"),
-            githubContributor("hadi-norouzi"),
-            Contributor("Vahid Farid")
+            contributor("@TheMRVX", "https://github.com/TheMRVX"),
+            contributor("@Skh-web6982", "https://github.com/Skh-web6982"),
+            contributor("@Ptechgithub", "https://github.com/Ptechgithub"),
+            contributor("@Pk-web6936", null),
+            contributor("@alphax-hue3682", null),
+            contributor("@phoenix6936", null),
+            contributor("@DecorativeFamily", null),
+            contributor("@decorativeman", null),
+            contributor("@mh292929", "https://github.com/mh292929"),
+            contributor("@Amir-yazdanmanesh", "https://github.com/Amir-yazdanmanesh"),
+            contributor("@CUMOON", "https://github.com/CUMOON"),
+            contributor("@hadi-norouzi", "https://github.com/hadi-norouzi"),
+            contributor("Vahid Farid", null)
         )
     ),
     TranslationCredit(
         language = "Русский (Russian)",
         contributors = listOf(
-            githubContributor("solokot"),
-            githubContributor("Liniya"),
-            githubContributor("eliotcougar")
+            contributor("@solokot", "https://github.com/solokot"),
+            contributor("@Liniya", "https://github.com/Liniya"),
+            contributor("@eliotcougar", "https://github.com/eliotcougar")
         )
     ),
     TranslationCredit(
         language = "Tiếng Việt (Vietnamese)",
         contributors = listOf(
-            githubContributor("admarty"),
-            githubContributor("user09283"),
-            githubContributor("yuhan6665")
+            contributor("@admarty", "https://github.com/admarty"),
+            contributor("@user09283", "https://github.com/user09283"),
+            contributor("@yuhan6665", "https://github.com/yuhan6665")
         )
     ),
     TranslationCredit(
         language = "简体中文 (Simplified Chinese)",
         contributors = listOf(
-            githubContributor("2dust"),
-            githubContributor("Yau08")
+            contributor("@2dust", "https://github.com/2dust"),
+            contributor("@Yau08", "https://github.com/Yau08")
         )
     ),
     TranslationCredit(
         language = "繁體中文 (Traditional Chinese)",
         contributors = listOf(
-            githubContributor("2dust"),
-            githubContributor("Yau08"),
-            githubContributor("Fubuki0x10DE")
+            contributor("@2dust", "https://github.com/2dust"),
+            contributor("@Yau08", "https://github.com/Yau08"),
+            contributor("@Fubuki0x10DE", "https://github.com/Fubuki0x10DE")
         )
     )
 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/TranslatorsActivity.kt
@@ -159,7 +159,7 @@ private val translationCredits = listOf(
         contributors = listOf(contributor("@CodeWithTamim", "https://github.com/CodeWithTamim"))
     ),
     TranslationCredit(
-        language = "لری بختیاری (Luri Bakhtiari)",
+        language = "لۊری بختیاری (Luri Bakhtiari)",
         contributors = listOf(
             contributor("@hosseinabaspanah", "https://github.com/hosseinabaspanah"),
             contributor("@CodeWithTamim", "https://github.com/CodeWithTamim")
@@ -201,15 +201,11 @@ private val translationCredits = listOf(
     ),
     TranslationCredit(
         language = "简体中文 (Simplified Chinese)",
-        contributors = listOf(
-            contributor("@2dust", "https://github.com/2dust"),
-            contributor("@Yau08", "https://github.com/Yau08")
-        )
+        contributors = listOf(contributor("@Yau08", "https://github.com/Yau08"))
     ),
     TranslationCredit(
         language = "繁體中文 (Traditional Chinese)",
         contributors = listOf(
-            contributor("@2dust", "https://github.com/2dust"),
             contributor("@Yau08", "https://github.com/Yau08"),
             contributor("@Fubuki0x10DE", "https://github.com/Fubuki0x10DE")
         )

--- a/V2rayNG/app/src/main/res/drawable/ic_translate_24dp.xml
+++ b/V2rayNG/app/src/main/res/drawable/ic_translate_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.87,15.07L10.33,12.56L10.36,12.53C12.1,10.59 13.34,8.36 14.07,6H17V4H10V2H8V4H1V6H12.17C11.5,7.92 10.45,9.75 9,11.35C8.06,10.32 7.28,9.19 6.69,8H4.69C5.42,9.63 6.42,11.17 7.7,12.56L2.61,17.58L4,19L9,14L12.11,17.11L12.87,15.07ZM18.5,10H16.5L12,22H14L15.12,19H19.87L21,22H23L18.5,10ZM15.88,17L17.5,12.67L19.12,17H15.88Z" />
+</vector>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">حول التطبيق</string>
     <string name="title_source_code">الكود المصدري</string>
     <string name="title_oss_license">تراخيص المصادر المفتوحة</string>
+    <string name="title_translators">المترجمون</string>
+    <string name="translators_intro">المساهمون الرئيسيون في كل ترجمة تتم صيانتها.</string>
+    <string name="translators_audit_title">تدقيق الترجمة الأخير</string>
+    <string name="translators_audit_note">أُجري التدقيق الأخير لجميع اللغات باستخدام GPT-5.6-Sol وراجعه eliotcougar.</string>
     <string name="title_tg_channel">قناة Telegram</string>
 
     <string name="title_pref_promotion">ترويج</string>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">الكود المصدري</string>
     <string name="title_oss_license">تراخيص المصادر المفتوحة</string>
     <string name="title_translators">المترجمون</string>
-    <string name="translators_intro">المساهمون الرئيسيون في كل ترجمة تتم صيانتها.</string>
     <string name="translators_audit_title">تدقيق الترجمة الأخير</string>
     <string name="translators_audit_note">أُجري التدقيق الأخير لجميع اللغات باستخدام GPT-5.6-Sol وراجعه eliotcougar.</string>
     <string name="title_tg_channel">قناة Telegram</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">সম্পর্কিত</string>
     <string name="title_source_code">সোর্স কোড</string>
     <string name="title_oss_license">ওপেন সোর্স লাইসেন্স</string>
+    <string name="title_translators">অনুবাদকগণ</string>
+    <string name="translators_intro">রক্ষণাবেক্ষণ করা প্রতিটি অনুবাদের প্রধান অবদানকারীরা।</string>
+    <string name="translators_audit_title">সাম্প্রতিক স্থানীয়করণ নিরীক্ষা</string>
+    <string name="translators_audit_note">সাম্প্রতিক সব ভাষার স্থানীয়করণ নিরীক্ষা GPT-5.6-Sol ব্যবহার করে করা হয়েছে এবং eliotcougar তা পর্যালোচনা করেছেন।</string>
     <string name="title_tg_channel">টেলিগ্রাম চ্যানেল</string>
 
     <string name="title_pref_promotion">প্রচার</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">সোর্স কোড</string>
     <string name="title_oss_license">ওপেন সোর্স লাইসেন্স</string>
     <string name="title_translators">অনুবাদকগণ</string>
-    <string name="translators_intro">রক্ষণাবেক্ষণ করা প্রতিটি অনুবাদের প্রধান অবদানকারীরা।</string>
     <string name="translators_audit_title">সাম্প্রতিক স্থানীয়করণ নিরীক্ষা</string>
     <string name="translators_audit_note">সাম্প্রতিক সব ভাষার স্থানীয়করণ নিরীক্ষা GPT-5.6-Sol ব্যবহার করে করা হয়েছে এবং eliotcougar তা পর্যালোচনা করেছেন।</string>
     <string name="title_tg_channel">টেলিগ্রাম চ্যানেল</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">کود بونچک</string>
     <string name="title_oss_license">موجوزا کود بونچک</string>
     <string name="title_translators">ترجومه‌گرا</string>
-    <string name="translators_intro">همکاریارا گرنگ هر ترجومه‌ای که نگهداری ایبو.</string>
     <string name="translators_audit_title">وا رسی تازه ترجومه</string>
     <string name="translators_audit_note">وا رسی تازه همه زوونا وا GPT-5.6-Sol انجوم وابید و eliotcougar وا رسیس کرد.</string>
     <string name="title_tg_channel">تورگه تلگرام</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">زبار</string>
     <string name="title_source_code">کود بونچک</string>
     <string name="title_oss_license">موجوزا کود بونچک</string>
+    <string name="title_translators">ترجومه‌گرا</string>
+    <string name="translators_intro">همکاریارا گرنگ هر ترجومه‌ای که نگهداری ایبو.</string>
+    <string name="translators_audit_title">وا رسی تازه ترجومه</string>
+    <string name="translators_audit_note">وا رسی تازه همه زوونا وا GPT-5.6-Sol انجوم وابید و eliotcougar وا رسیس کرد.</string>
     <string name="title_tg_channel">تورگه تلگرام</string>
 
     <string name="title_pref_promotion">تبلیغات</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">درباره</string>
     <string name="title_source_code">کد منبع</string>
     <string name="title_oss_license">مجوز های منبع باز</string>
+    <string name="title_translators">مترجمان</string>
+    <string name="translators_intro">مشارکت‌کنندگان اصلی هر ترجمهٔ نگهداری‌شده.</string>
+    <string name="translators_audit_title">بازبینی اخیر بومی‌سازی</string>
+    <string name="translators_audit_note">بازبینی اخیر بومی‌سازی همهٔ زبان‌ها با GPT-5.6-Sol انجام و توسط eliotcougar بازبینی شد.</string>
     <string name="title_tg_channel">کانال تلگرام</string>
 
     <string name="title_pref_promotion">تبلیغات</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">کد منبع</string>
     <string name="title_oss_license">مجوز های منبع باز</string>
     <string name="title_translators">مترجمان</string>
-    <string name="translators_intro">مشارکت‌کنندگان اصلی هر ترجمهٔ نگهداری‌شده.</string>
     <string name="translators_audit_title">بازبینی اخیر بومی‌سازی</string>
     <string name="translators_audit_note">بازبینی اخیر بومی‌سازی همهٔ زبان‌ها با GPT-5.6-Sol انجام و توسط eliotcougar بازبینی شد.</string>
     <string name="title_tg_channel">کانال تلگرام</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">Исходный код</string>
     <string name="title_oss_license">Лицензии открытого исходного кода</string>
     <string name="title_translators">Переводчики</string>
-    <string name="translators_intro">Основные участники перевода для каждого поддерживаемого языка.</string>
     <string name="translators_audit_title">Недавняя проверка локализации</string>
     <string name="translators_audit_note">Недавняя проверка локализации всех языков выполнена с помощью GPT-5.6-Sol и проверена eliotcougar.</string>
     <string name="title_tg_channel">Telegram-канал</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">О приложении</string>
     <string name="title_source_code">Исходный код</string>
     <string name="title_oss_license">Лицензии открытого исходного кода</string>
+    <string name="title_translators">Переводчики</string>
+    <string name="translators_intro">Основные участники перевода для каждого поддерживаемого языка.</string>
+    <string name="translators_audit_title">Недавняя проверка локализации</string>
+    <string name="translators_audit_note">Недавняя проверка локализации всех языков выполнена с помощью GPT-5.6-Sol и проверена eliotcougar.</string>
     <string name="title_tg_channel">Telegram-канал</string>
 
     <string name="title_pref_promotion">Предложения</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">Mã nguồn</string>
     <string name="title_oss_license">Giấy phép mã nguồn mở</string>
     <string name="title_translators">Người dịch</string>
-    <string name="translators_intro">Những người đóng góp chính cho từng bản dịch đang được duy trì.</string>
     <string name="translators_audit_title">Đợt rà soát bản địa hóa gần đây</string>
     <string name="translators_audit_note">Đợt rà soát bản địa hóa gần đây cho tất cả ngôn ngữ được thực hiện với GPT-5.6-Sol và được eliotcougar xem xét.</string>
     <string name="title_tg_channel">Kênh Telegram</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">Giới thiệu</string>
     <string name="title_source_code">Mã nguồn</string>
     <string name="title_oss_license">Giấy phép mã nguồn mở</string>
+    <string name="title_translators">Người dịch</string>
+    <string name="translators_intro">Những người đóng góp chính cho từng bản dịch đang được duy trì.</string>
+    <string name="translators_audit_title">Đợt rà soát bản địa hóa gần đây</string>
+    <string name="translators_audit_note">Đợt rà soát bản địa hóa gần đây cho tất cả ngôn ngữ được thực hiện với GPT-5.6-Sol và được eliotcougar xem xét.</string>
     <string name="title_tg_channel">Kênh Telegram</string>
 
     <string name="title_pref_promotion">Ưu đãi</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">关于</string>
     <string name="title_source_code">源代码</string>
     <string name="title_oss_license">开源许可证</string>
+    <string name="title_translators">翻译贡献者</string>
+    <string name="translators_intro">各维护语言翻译的主要贡献者。</string>
+    <string name="translators_audit_title">近期本地化审查</string>
+    <string name="translators_audit_note">近期的全语言本地化审查由 GPT-5.6-Sol 协助完成，并由 eliotcougar 审核。</string>
     <string name="title_tg_channel">Telegram 频道</string>
 
     <string name="title_pref_promotion">推广</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">源代码</string>
     <string name="title_oss_license">开源许可证</string>
     <string name="title_translators">翻译贡献者</string>
-    <string name="translators_intro">各维护语言翻译的主要贡献者。</string>
     <string name="translators_audit_title">近期本地化审查</string>
     <string name="translators_audit_note">近期的全语言本地化审查由 GPT-5.6-Sol 协助完成，并由 eliotcougar 审核。</string>
     <string name="title_tg_channel">Telegram 频道</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">原始碼</string>
     <string name="title_oss_license">開放原始碼授權</string>
     <string name="title_translators">翻譯貢獻者</string>
-    <string name="translators_intro">各維護語言翻譯的主要貢獻者。</string>
     <string name="translators_audit_title">近期本地化審查</string>
     <string name="translators_audit_note">近期的全語言本地化審查由 GPT-5.6-Sol 協助完成，並由 eliotcougar 審核。</string>
     <string name="title_tg_channel">Telegram 頻道</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">關於</string>
     <string name="title_source_code">原始碼</string>
     <string name="title_oss_license">開放原始碼授權</string>
+    <string name="title_translators">翻譯貢獻者</string>
+    <string name="translators_intro">各維護語言翻譯的主要貢獻者。</string>
+    <string name="translators_audit_title">近期本地化審查</string>
+    <string name="translators_audit_note">近期的全語言本地化審查由 GPT-5.6-Sol 協助完成，並由 eliotcougar 審核。</string>
     <string name="title_tg_channel">Telegram 頻道</string>
 
     <string name="title_pref_promotion">推廣</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -284,7 +284,6 @@
     <string name="title_source_code">Source code</string>
     <string name="title_oss_license">Open-source licenses</string>
     <string name="title_translators">Translators</string>
-    <string name="translators_intro">Major contributors to each maintained translation.</string>
     <string name="translators_audit_title">Recent localization audit</string>
     <string name="translators_audit_note">The recent all-locale localization audit was carried out with GPT-5.6-Sol and reviewed by eliotcougar.</string>
     <string name="title_tg_channel">Telegram channel</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -283,6 +283,10 @@
     <string name="title_about">About</string>
     <string name="title_source_code">Source code</string>
     <string name="title_oss_license">Open-source licenses</string>
+    <string name="title_translators">Translators</string>
+    <string name="translators_intro">Major contributors to each maintained translation.</string>
+    <string name="translators_audit_title">Recent localization audit</string>
+    <string name="translators_audit_note">The recent all-locale localization audit was carried out with GPT-5.6-Sol and reviewed by eliotcougar.</string>
     <string name="title_tg_channel">Telegram channel</string>
 
     <string name="title_pref_promotion">Promotion</string>


### PR DESCRIPTION
## Summary

- add an About > Translators page for #6070
- credit major contributors for each of the eight maintained non-English locales
- show each language's localized name together with its English name
- link GitHub profiles that still resolve while retaining historical names whose accounts no longer resolve
- include the requested note that the recent all-locale localization audit was carried out with GPT-5.6-Sol and reviewed by `eliotcougar`
- localize the page copy across all nine maintained string catalogs

English is intentionally excluded from the translator list.

Closes #6070

## How the lists were compiled

The audit started from `upstream/master` at `e4e3a36e` and examined the history of every maintained `values*/strings.xml` catalog. For each non-English locale, I used no-merge Git history and per-path shortlogs to identify authors who changed that catalog, then inspected the relevant commits to distinguish translation-focused work from feature additions, mechanical synchronization, accessibility work, and other resource-file changes.

Contributor aliases were normalized using GitHub account identity and commit email where possible. Two historical names were confirmed as renamed accounts: `@MH140000` is now `@mh292929`, and `@NagisaEfi` is now `@Fubuki0x10DE`. Every profile linked from the app was checked directly. Historical handles that no longer resolve are kept as visible, non-clickable credits rather than silently discarded.

The compact lists shown in the app are the locale-focused major contributors. The broader audit below intentionally contains identifiable Git authors who touched each locale catalog, except contributors who opted out; it is included for review and provenance, but those names should not all be interpreted as translators. The GPT-5.6-Sol audit note is based on the recent issue/PR localization work and is non-Git attribution.

## Credits shown in the app

- Arabic: `@MrIbrahem`
- Bengali: `@CodeWithTamim`
- Luri Bakhtiari: `@hosseinabaspanah`, `@CodeWithTamim`
- Persian: `@TheMRVX`, `@Skh-web6982`, `@Ptechgithub`, `@Pk-web6936`, `@alphax-hue3682`, `@phoenix6936`, `@DecorativeFamily`, `@decorativeman`, `@mh292929`, `@Amir-yazdanmanesh`, `@CUMOON`, `@hadi-norouzi`, Vahid Farid
- Russian: `@solokot`, `@Liniya`, `@eliotcougar`
- Vietnamese: `@admarty`, `@user09283`, `@yuhan6665`
- Simplified Chinese: `@Yau08`
- Traditional Chinese: `@Yau08`, `@Fubuki0x10DE`

## Expanded catalog-history audit

<details>
<summary>Cross-locale union</summary>

`@admarty`, `@AlirezaParsi`, `@alphax-hue3682`, `@Amir-yazdanmanesh`, `@chlink2025`, `@Chocolate4U`, `@CodeWithTamim`, `@Copilot`, `@CUMOON`, `@DecorativeFamily`, `@decorativeman`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hadi-norouzi`, `@hamidrezahy`, `@hippo2025`, `@hosseinabaspanah`, `@Kapkap5454`, `@Liniya`, `@MH140000` (now `@mh292929`), `@mmrabbani`, `@MrArrowww`, `@MrIbrahem`, `@NagisaEfi` (now `@Fubuki0x10DE`), `@name321467`, `@patterniha`, `@phoenix6936`, `@Pk-web6936`, `@Ptechgithub`, `@Q7DF1`, `@Skh-web6982`, `@solokot`, `@star-studio975`, `@TheMRVX`, `@Umor1st`, `@user09283`, Vahid Farid, `@XiaochangXu`, `@Yau08`, `@yuhan6665`

</details>

<details>
<summary>العربية (Arabic)</summary>

`@chlink2025`, `@Chocolate4U`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hamidrezahy`, `@hippo2025`, `@MrIbrahem`, `@name321467`, `@star-studio975`, `@XiaochangXu`, `@yuhan6665`

</details>

<details>
<summary>বাংলা (Bengali)</summary>

`@chlink2025`, `@Chocolate4U`, `@CodeWithTamim`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@fuilloi`, `@hippo2025`, `@name321467`, `@star-studio975`, `@Umor1st`, `@XiaochangXu`, `@yuhan6665`

</details>

<details>
<summary>لۊری بختیاری (Luri Bakhtiari)</summary>

`@chlink2025`, `@Chocolate4U`, `@CodeWithTamim`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@fuilloi`, `@hippo2025`, `@hosseinabaspanah`, `@name321467`, `@star-studio975`, `@Umor1st`, `@XiaochangXu`, `@yuhan6665`

</details>

<details>
<summary>فارسی (Persian)</summary>

`@alphax-hue3682`, `@Amir-yazdanmanesh`, `@chlink2025`, `@Chocolate4U`, `@Copilot`, `@CUMOON`, `@DecorativeFamily`, `@decorativeman`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hadi-norouzi`, `@hamidrezahy`, `@hippo2025`, `@MH140000` (now `@mh292929`), `@mmrabbani`, `@name321467`, `@phoenix6936`, `@Pk-web6936`, `@Ptechgithub`, `@Skh-web6982`, `@star-studio975`, `@TheMRVX`, `@Umor1st`, Vahid Farid, `@XiaochangXu`, `@yuhan6665`

</details>

<details>
<summary>Русский (Russian)</summary>

`@chlink2025`, `@Chocolate4U`, `@CodeWithTamim`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hadi-norouzi`, `@hamidrezahy`, `@hippo2025`, `@Liniya`, `@name321467`, `@solokot`, `@star-studio975`, `@Umor1st`, `@XiaochangXu`, `@yuhan6665`

</details>

<details>
<summary>Tiếng Việt (Vietnamese)</summary>

`@admarty`, `@chlink2025`, `@Chocolate4U`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hadi-norouzi`, `@hamidrezahy`, `@hippo2025`, `@name321467`, `@star-studio975`, `@user09283`, `@XiaochangXu`, `@yuhan6665`

</details>

<details>
<summary>简体中文 (Simplified Chinese)</summary>

`@AlirezaParsi`, `@chlink2025`, `@Chocolate4U`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hadi-norouzi`, `@hamidrezahy`, `@hippo2025`, `@mmrabbani`, `@name321467`, `@Q7DF1`, `@star-studio975`, `@Umor1st`, `@XiaochangXu`, `@Yau08`, `@yuhan6665`

</details>

<details>
<summary>繁體中文 (Traditional Chinese)</summary>

`@AlirezaParsi`, `@chlink2025`, `@Chocolate4U`, `@Copilot`, `@DHR60`, `@eliotcougar`, `@Enqvy`, `@FranzKafkaYu`, `@fuilloi`, `@hadi-norouzi`, `@hamidrezahy`, `@hippo2025`, `@mmrabbani`, `@NagisaEfi` (now `@Fubuki0x10DE`), `@name321467`, `@star-studio975`, `@Umor1st`, `@XiaochangXu`, `@Yau08`, `@yuhan6665`

</details>

## Validation

- `:app:processPlaystoreDebugResources`
- `:app:compilePlaystoreDebugKotlin`
- `:app:installPlaystoreDebug`
- verified all nine catalogs remain aligned at 452 resource entries
- verified all 18 unique live GitHub profile links used by the page
- exercised About > Translators, scrolling, back navigation, and light/dark themes on a Pixel 5 Android 11 emulator; no crashes were logged
