### PR TITLE
Allow TCPing mixed H3/H2 profiles

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -139,7 +139,7 @@ class RealPingWorkerService(
         if (!config.configType.isComplexType()
             && config.configType != EConfigType.HYSTERIA2
             && config.configType != EConfigType.WIREGUARD
-            && config.alpn?.startsWith("h3") != true
+            && config.alpn?.split(',')?.all { it.trim().startsWith("h3") } != true
             && config.server.isNotNullEmpty()
             && config.serverPort?.toIntOrNull() != null
         ) {


### PR DESCRIPTION
## What changed

- Treat an ALPN list as H3-only only when every advertised protocol is an H3 variant.
- Allow mixed `h3,h2` profiles to use the existing TCPing path.
- Keep pure H3 profiles excluded because TCPing is not meaningful for a UDP-only transport.

## Root cause

TCPing previously rejected any profile whose ALPN string started with `h3`. This also matched `h3,h2`, even though that list advertises an H2 fallback and therefore has a TCP-capable endpoint. The profile was assigned `-1 ms` before any socket connection was attempted.

## User impact

Mixed H3/H2 XHTTP profiles now receive a TCP delay result. Pure H3 and non-H3 behavior remains unchanged.

## Validation

- `:app:compilePlaystoreDebugKotlin`
- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86_64`
- Pixel 5 emulator with paired Lab profiles targeting the same servers:
  - mixed `h3,h2`: returned TCP delay results
  - pure `h3`: remained `-1 ms`
  - pure `h2`: returned a TCP delay result
  - ordinary TCP/Reality profiles: continued returning TCP delay results
