### PR TITLE
Optimize probing startup for large subscription groups

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -689,10 +689,16 @@ class MainViewModel(
         dataSource.cancelAllPing()
         val groupId = uiState.value.selectedGroupId
         val servers = currentServers()
-        dataSource.clearAllTestDelayResults(servers.map { it.guid })
         if (servers.isEmpty()) {
             _uiState.update { it.copy(isTesting = false) }
             return
+        }
+        val serverGuids = servers.map { it.guid }
+        mutableServersForGroup(groupId).update { current ->
+            current.map { server ->
+                if (server.testDelayMillis == 0L) server
+                else server.copy(testDelayMillis = 0L)
+            }
         }
         testingGroupId = groupId
         _uiState.update {
@@ -702,12 +708,13 @@ class MainViewModel(
             )
         }
         viewModelScope.launch(ioDispatcher) {
+            dataSource.clearAllTestDelayResults(serverGuids)
             cacheMutex.withLock { groupDataCache.remove(groupId) }
             dataSource.sendMsg2TestService(
                 TestServiceMessage(
                     key = AppConfig.MSG_MEASURE_CONFIG_START,
                     subscriptionId = groupId,
-                    serverGuids = if (keywordFilter.isNotEmpty()) servers.map { it.guid } else emptyList(),
+                    serverGuids = if (keywordFilter.isNotEmpty()) serverGuids else emptyList(),
                     onlyTcp = onlyTcp
                 )
             )


### PR DESCRIPTION
## Summary

- clear the currently displayed delay values immediately when a group probe starts
- move the per-profile MMKV delay reset from the caller path to the existing I/O coroutine
- complete the reset before starting the test service and reuse the captured GUID list

## Motivation

This is a small optimization extracted from the broader Observatory-based probing proposal in #6050.

Starting a group probe currently calls `clearAllTestDelayResults()` synchronously. That operation decodes, updates, serializes, and writes one MMKV affiliation record per profile, so its caller-path cost grows with the subscription group and is particularly noticeable for groups containing hundreds of profiles.

The change is independent of Observatory probing and benefits both TCPing and RealDelay on the current implementation. It does not change probe selection, concurrency, or result handling.

## Correctness

- Empty groups still return without starting a test.
- Visible results are reset immediately, so old delays are not presented as current while new results arrive.
- Persisted results are reset on `Dispatchers.IO` before `MSG_MEASURE_CONFIG_START` is sent, preventing a late reset from erasing newly reported results.
- The group cache is invalidated after the reset and before the test starts.

## Validation

- `:app:compilePlaystoreDebugKotlin` passes.
- `:app:testPlaystoreDebugUnitTest` runs 46 tests: 44 pass; the existing upstream `UtilsTest.test_isIpAddress` and `UtilsTest.test_IsIpInCidr` failures remain unchanged.
