### PR TITLE
Compose: Locate selected server by stable identifiers

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/LocateTarget.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/LocateTarget.kt
@@ -2,6 +2,5 @@ package com.v2ray.ang.dto
 
 data class LocateTarget(
     val groupId: String,
-    val groupIndex: Int,
-    val itemPosition: Int
+    val serverGuid: String,
 )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -66,5 +66,5 @@ sealed interface MainAction {
 
     data class ImportBatchConfig(val configText: String) : MainAction
 
-    data class LocateHandled(val target: LocateTarget) : MainAction
+    data object LocateHandled : MainAction
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -30,7 +30,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.ui.compose.LocalDarkTheme
 import com.v2ray.ang.ui.compose.QRCodeDialog
-import com.v2ray.ang.extension.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
@@ -73,15 +72,11 @@ fun MainScreen(
     val lazyListStates = remember { mutableStateMapOf<String, LazyListState>() }
     val lazyGridStates = remember { mutableStateMapOf<String, LazyGridState>() }
 
-    var locateInProgress by remember { mutableStateOf(false) }
-
     LaunchedEffect(groups) {
         val validGroupIds = groups.map { it.id }.toSet()
         lazyListStates.keys.retainAll(validGroupIds)
         lazyGridStates.keys.retainAll(validGroupIds)
     }
-
-    val latestDoubleColumnDisplay by rememberUpdatedState(doubleColumnDisplay)
 
     LaunchedEffect(groups, uiState.selectedGroupId) {
         if (groups.isEmpty()) return@LaunchedEffect
@@ -93,66 +88,16 @@ fun MainScreen(
     }
 
     val latestGroups by rememberUpdatedState(groups)
-    val latestLocateInProgress by rememberUpdatedState(locateInProgress)
 
     LaunchedEffect(pagerState) {
         snapshotFlow { pagerState.settledPage }
             .distinctUntilChanged()
             .collect { page ->
                 val currentGroups = latestGroups
-                if (!latestLocateInProgress && page in currentGroups.indices) {
+                if (page in currentGroups.indices) {
                     onAction(MainAction.SelectGroup(currentGroups[page].id))
                 }
             }
-    }
-
-    LaunchedEffect(uiState.locateTarget) {
-        val target = uiState.locateTarget ?: return@LaunchedEffect
-        if (target.groupIndex !in 0 until pagerState.pageCount) {
-            mainViewModel.onAction(MainAction.LocateHandled(target))
-            return@LaunchedEffect
-        }
-
-        locateInProgress = true
-        try {
-            if (pagerState.settledPage != target.groupIndex) {
-                pagerState.navigateToPageOptimized(
-                    targetPage = target.groupIndex,
-                    animateAdjacentPage = false
-                )
-            }
-            onAction(MainAction.SelectGroup(target.groupId))
-
-            repeat(10) {
-                val ready = if (latestDoubleColumnDisplay) {
-                    lazyGridStates[target.groupId] != null
-                } else {
-                    lazyListStates[target.groupId] != null
-                }
-                if (ready) return@repeat
-                delay(16)
-            }
-
-            if (latestDoubleColumnDisplay) {
-                lazyGridStates[target.groupId]?.let { gridState ->
-                    gridState.scrollToItem(
-                        index = target.itemPosition,
-                        scrollOffset = -gridState.layoutInfo.viewportSize.height / 3
-                    )
-                }
-            } else {
-                lazyListStates[target.groupId]?.let { listState ->
-                    listState.scrollToItem(
-                        index = target.itemPosition,
-                        scrollOffset = -listState.layoutInfo.viewportSize.height / 3
-                    )
-                }
-            }
-        } finally {
-            delay(32)
-            locateInProgress = false
-            mainViewModel.onAction(MainAction.LocateHandled(target))
-        }
     }
 
     MainDialogs(
@@ -279,6 +224,7 @@ fun MainScreen(
                             groupId = group.id,
                             mainViewModel = mainViewModel,
                             selectedGuid = selectedGuid,
+                            locateTarget = uiState.locateTarget,
                             doubleColumnDisplay = doubleColumnDisplay,
                             confirmRemove = confirmRemove,
                             searchQuery = searchQuery,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -46,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.v2ray.ang.R
+import com.v2ray.ang.dto.LocateTarget
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.ServersCache
 import com.v2ray.ang.extension.isComplexType
@@ -69,6 +71,7 @@ fun GroupPagerPage(
     groupId: String,
     mainViewModel: MainViewModel,
     selectedGuid: String?,
+    locateTarget: LocateTarget?,
     doubleColumnDisplay: Boolean,
     confirmRemove: Boolean,
     searchQuery: String,
@@ -89,6 +92,7 @@ fun GroupPagerPage(
     ServerListPage(
         servers = servers,
         selectedGuid = selectedGuid,
+        locateTarget = locateTarget?.takeIf { it.groupId == groupId },
         canReorder = canReorder,
         doubleColumnDisplay = doubleColumnDisplay,
         subscriptionId = groupId,
@@ -101,6 +105,7 @@ fun GroupPagerPage(
         onShareServer = onShareServer,
         onMoreServer = onMoreServer,
         onRemoveServer = onRemoveServer,
+        onLocateHandled = { mainViewModel.onAction(MainAction.LocateHandled) },
         onMoveServer = { fromIndex, toIndex -> mainViewModel.moveServer(groupId, fromIndex, toIndex) },
         contentPadding = contentPadding
     )
@@ -110,6 +115,7 @@ fun GroupPagerPage(
 private fun ServerListPage(
     servers: List<ServersCache>,
     selectedGuid: String?,
+    locateTarget: LocateTarget?,
     canReorder: Boolean,
     doubleColumnDisplay: Boolean,
     subscriptionId: String,
@@ -122,6 +128,7 @@ private fun ServerListPage(
     onShareServer: (String, ProfileItem) -> Unit,
     onMoreServer: (String, ProfileItem) -> Unit,
     onRemoveServer: (String) -> Unit,
+    onLocateHandled: () -> Unit,
     onMoveServer: (Int, Int) -> Unit,
     contentPadding: PaddingValues
 ) {
@@ -134,6 +141,8 @@ private fun ServerListPage(
                 onMoveServer(from.index, to.index)
             }
         } else null
+
+        LocateTargetEffect(locateTarget, servers, gridState, onLocateHandled)
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),
@@ -182,6 +191,8 @@ private fun ServerListPage(
             }
         } else null
 
+        LocateTargetEffect(locateTarget, servers, listState, onLocateHandled)
+
         LazyColumn(
             state = listState,
             modifier = Modifier
@@ -227,6 +238,38 @@ private fun ServerListPage(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun LocateTargetEffect(
+    target: LocateTarget?,
+    servers: List<ServersCache>,
+    state: LazyListState,
+    onHandled: () -> Unit,
+) {
+    if (target == null) return
+    LaunchedEffect(target, servers) {
+        val index = servers.indexOfFirst { it.guid == target.serverGuid }
+        if (index < 0) return@LaunchedEffect
+        state.scrollToItem(index, -state.layoutInfo.viewportSize.height / 3)
+        onHandled()
+    }
+}
+
+@Composable
+private fun LocateTargetEffect(
+    target: LocateTarget?,
+    servers: List<ServersCache>,
+    state: LazyGridState,
+    onHandled: () -> Unit,
+) {
+    if (target == null) return
+    LaunchedEffect(target, servers) {
+        val index = servers.indexOfFirst { it.guid == target.serverGuid }
+        if (index < 0) return@LaunchedEffect
+        state.scrollToItem(index, -state.layoutInfo.viewportSize.height / 3)
+        onHandled()
     }
 }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -191,7 +191,7 @@ class MainViewModel(
             is MainAction.RemoveServer -> removeServerAndRefresh(action.guid)
             is MainAction.Search -> filterConfig(action.query)
             is MainAction.ImportBatchConfig -> importBatchConfig(action.configText)
-            is MainAction.LocateHandled -> consumeLocateTarget(action.target)
+            MainAction.LocateHandled -> consumeLocateTarget()
             is MainAction.ShareQRCode -> {
                 val bitmap = dataSource.share2QRCode(action.guid)
                 _uiState.update { it.copy(shareQRCodeBitmap = bitmap) }
@@ -744,24 +744,21 @@ class MainViewModel(
         val selected = dataSource.getSelectServer() ?: return
         val profile = dataSource.decodeServerConfig(selected) ?: return
         val groupId = profile.subscriptionId
-        val groupIndex =
-            _uiState.value.groups.indexOfFirst { it.id == groupId }.takeIf { it >= 0 } ?: return
+        if (_uiState.value.groups.none { it.id == groupId }) return
         viewModelScope.launch(ioDispatcher) {
-            val position =
-                loadGroup(groupId).indexOfFirst { it.guid == selected }.takeIf { it >= 0 }
-                    ?: return@launch
+            updateGroupUi(groupId, loadGroup(groupId))
+            if (_uiState.value.selectedGroupId != groupId) {
+                dataSource.setSelectedSubscriptionId(groupId)
+            }
+            val target = LocateTarget(groupId, selected)
             _uiState.update {
-                it.copy(locateTarget = LocateTarget(groupId, groupIndex, position))
+                it.copy(selectedGroupId = groupId, locateTarget = target)
             }
         }
     }
 
-    fun getPosition(guid: String): Int = currentServers().indexOfFirst { it.guid == guid }
-
-    private fun consumeLocateTarget(target: LocateTarget) {
-        _uiState.update { state ->
-            if (state.locateTarget == target) state.copy(locateTarget = null) else state
-        }
+    private fun consumeLocateTarget() {
+        _uiState.update { it.copy(locateTarget = null) }
     }
 
     // ---------- Running state ----------


### PR DESCRIPTION
## Summary

- represent a pending Locate request with the subscription group ID and server GUID rather than snapshot-dependent group and row indices
- let the existing selected-group state move the pager
- resolve the GUID in the destination page's current list and perform one suspending `scrollToItem`
- remove timing delays, pager-idle coordination, visibility polling, cached index hints, and stale-request bookkeeping

## Why

The previous implementation computed both indices before Compose handled the navigation. Those positions described one snapshot of the UI rather than the server being located.

Servers already have stable GUIDs, and the lazy list and grid already use those GUIDs as item keys. Carrying the same identity through the Locate request avoids positional coupling and lets the destination page resolve its own current index immediately before scrolling.

Locate is a single uninterrupted menu action: the user selects **Find selected configuration** and waits for it to finish. The implementation therefore does not coordinate with concurrent gestures or mutations that are outside this interaction.

## Compose implementation

The ViewModel publishes the target group and GUID as state. The existing selected-group effect moves the pager, while a page-local `LaunchedEffect`, keyed by the target and server list, resolves the GUID and calls the suspending lazy-list or lazy-grid `scrollToItem` API.

This keeps UI work in lifecycle-aware Compose effects and requires no frame delays, polling loops, or imperative registry lookup.

## Performance

Measured on a Pixel 9 Pro API 37 x86_64 emulator with Play Store release builds compiled using `cmd package compile -m speed -f`.

Each run:

1. force-stopped and relaunched the app
2. started from the 15-item `lab` group
3. invoked **More > Find selected configuration**
4. verified that the exact target profile was visible
5. discarded warm-ups and recorded 12 measured trials per build and target

Median results:

| Target | Metric | Upstream | This PR | Change |
| --- | ---: | ---: | ---: | ---: |
| 1,000-item synthetic group, profile 850 | Locate latency | 54.804 ms | 28.368 ms | **-48.2%** |
| | Process CPU | 46.5 ms | 21.0 ms | **-54.8%** |
| 485-item Sub1 group, near-bottom profile | Locate latency | 65.619 ms | 25.345 ms | **-61.4%** |
| | Process CPU | 57.0 ms | 18.0 ms | **-68.4%** |

Median frame and janky-frame counts were effectively unchanged. Upstream produced one background-load outlier for each target; both remain included in the raw samples, while medians are reported so those outliers do not distort the comparison.

## Validation

- `:app:compilePlaystoreDebugKotlin`
- `:app:assemblePlaystoreRelease`
- 24 measured emulator Locate runs, all verifying the exact requested target
- full unit suite: 46 tests run; only the two existing unrelated `UtilsTest` environment-dependent failures remained
