### PR TITLE
TalkBack: app accessibility combined implementation (temporary)

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/extension/_Ext.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/extension/_Ext.kt
@@ -12,6 +12,9 @@ import kotlin.time.Duration.Companion.milliseconds
 const val THRESHOLD = 1000L
 const val DIVISOR = 1024.0
 
+internal fun Long.toPluralQuantity(): Int =
+    coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong()).toInt()
+
 /**
  * Converts a Long value to a speed string.
  *

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/apppicker/AppPickerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/apppicker/AppPickerActivity.kt
@@ -159,7 +159,7 @@ fun AppPickerScreen(
                         IconButton(onClick = { showMenu = true }) {
                             Icon(
                                 painterResource(R.drawable.ic_more_vert_24dp),
-                                contentDescription = null
+                                contentDescription = stringResource(R.string.acc_more)
                             )
                         }
                         DropdownMenu(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Components.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Components.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -19,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material3.Checkbox
@@ -50,6 +50,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
@@ -77,6 +83,7 @@ fun AppTopBar(
 ) {
     Column {
         TopAppBar(
+            modifier = Modifier.semantics { isTraversalGroup = true },
             title = {
                 if (isSearchActive) {
                     SearchInputField(
@@ -85,7 +92,10 @@ fun AppTopBar(
                         placeholder = searchPlaceholder
                     )
                 } else {
-                    Text(text = title)
+                    Text(
+                        text = title,
+                        modifier = Modifier.semantics { traversalIndex = -1f },
+                    )
                 }
             },
             navigationIcon = {
@@ -151,7 +161,10 @@ private fun SearchInputField(
         )
         if (query.isNotEmpty()) {
             IconButton(onClick = { onQueryChange("") }) {
-                Icon(painterResource(android.R.drawable.ic_menu_close_clear_cancel), "Clear")
+                Icon(
+                    painter = painterResource(android.R.drawable.ic_menu_close_clear_cancel),
+                    contentDescription = stringResource(R.string.logcat_clear)
+                )
             }
         }
     }
@@ -164,13 +177,30 @@ fun AppListItem(
     icon: Any?,
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    routingDescription: String? = null
 ) {
     val context = LocalContext.current
+    val appAnnouncement = if (routingDescription == null) {
+        appName
+    } else {
+        stringResource(
+            R.string.acc_app_routing_announcement,
+            appName,
+            routingDescription
+        )
+    }
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { onCheckedChange(!checked) }
+            .toggleable(
+                value = checked,
+                role = Role.Checkbox,
+                onValueChange = onCheckedChange,
+            )
+            .semantics(mergeDescendants = true) {
+                contentDescription = appAnnouncement
+            }
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -198,6 +228,7 @@ fun AppListItem(
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = appName,
+                modifier = Modifier.semantics { hideFromAccessibility() },
                 style = MaterialTheme.typography.bodyLarge,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -205,6 +236,7 @@ fun AppListItem(
             Spacer(modifier = Modifier.height(2.dp))
             Text(
                 text = packageName,
+                modifier = Modifier.semantics { hideFromAccessibility() },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -213,7 +245,7 @@ fun AppListItem(
         }
         Checkbox(
             checked = checked,
-            onCheckedChange = onCheckedChange,
+            onCheckedChange = null,
             colors = CheckboxDefaults.colors(checkedColor = MaterialTheme.colorScheme.secondary)
         )
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Dialog.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/Dialog.kt
@@ -210,6 +210,7 @@ fun <T> SelectListDialog(
             LazyColumn {
                 items(options) { option ->
                     val isSelected = option == selectedOption
+                    val optionLabel = optionText(option)
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -231,7 +232,7 @@ fun <T> SelectListDialog(
                             Spacer(modifier = Modifier.width(8.dp))
                         }
                         Text(
-                            text = optionText(option),
+                            text = optionLabel,
                             style = MaterialTheme.typography.bodyMedium,
                             modifier = Modifier.weight(1f)
                         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/SettingsItem.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/SettingsItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
@@ -26,6 +27,9 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
@@ -49,10 +53,14 @@ fun CollapsiblePreferenceGroupHeader(
     onExpandedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val groupState = stringResource(
+        if (expanded) R.string.acc_group_expanded else R.string.acc_group_collapsed
+    )
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable { onExpandedChange(!expanded) }
+            .semantics { stateDescription = groupState }
+            .clickable(role = Role.Button) { onExpandedChange(!expanded) }
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -79,7 +87,7 @@ private fun SettingsItemRow(
     title: String,
     description: String?,
     enabled: Boolean,
-    onClick: (() -> Unit)?,
+    interactionModifier: Modifier,
     modifier: Modifier = Modifier,
     trailing: @Composable (() -> Unit)? = null
 ) {
@@ -91,7 +99,7 @@ private fun SettingsItemRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .then(if (onClick != null) Modifier.clickable(enabled = enabled, onClick = onClick) else Modifier)
+            .then(interactionModifier)
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -146,9 +154,7 @@ fun SettingsEditItem(
         title = title,
         description = description,
         enabled = enabled,
-        onClick = if (enabled) {
-            { showDialog = true }
-        } else null,
+        interactionModifier = Modifier.clickable(enabled = enabled) { showDialog = true },
         modifier = modifier
     )
 
@@ -193,9 +199,7 @@ fun SettingsListItem(
         title = title,
         description = summary.ifEmpty { null },
         enabled = enabled,
-        onClick = if (enabled) {
-            { showDialog = true }
-        } else null,
+        interactionModifier = Modifier.clickable(enabled = enabled) { showDialog = true },
         modifier = modifier
     )
 
@@ -228,8 +232,8 @@ fun SettingsMenuItem(
         title = title,
         description = subtitle,
         enabled = true,
-        onClick = onClick,
-        modifier = modifier
+        interactionModifier = Modifier.clickable(onClick = onClick),
+        modifier = modifier,
     )
 }
 
@@ -248,14 +252,17 @@ fun SettingsSwitchItem(
         title = title,
         description = summary,
         enabled = enabled,
-        onClick = if (enabled) {
-            { onCheckedChange(!checked) }
-        } else null,
+        interactionModifier = Modifier.toggleable(
+            value = checked,
+            enabled = enabled,
+            role = Role.Switch,
+            onValueChange = onCheckedChange,
+        ),
         modifier = modifier,
         trailing = {
             Switch(
                 checked = checked,
-                onCheckedChange = if (enabled) onCheckedChange else null,
+                onCheckedChange = null,
                 modifier = Modifier.scale(0.8f),
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.onSecondary,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
@@ -37,6 +38,7 @@ import com.v2ray.ang.ui.compose.colorFabInactiveLight
 @Composable
 fun MainBottomBar(
     displayText: String,
+    accessibilityText: String,
     isRunning: Boolean,
     isDarkTheme: Boolean,
     onAction: (MainAction) -> Unit
@@ -47,6 +49,9 @@ fun MainBottomBar(
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
                 .clickable(onClick = { onAction(MainAction.TestCurrentServer) })
+                .semantics {
+                    contentDescription = accessibilityText
+                }
                 .windowInsetsPadding(WindowInsets.navigationBars)
         ) {
             AppDivider()
@@ -60,10 +65,8 @@ fun MainBottomBar(
             ) {
                 Text(
                     text = displayText,
+                    modifier = Modifier.semantics { hideFromAccessibility() },
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.semantics {
-                        contentDescription = displayText
-                    }
                 )
             }
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
@@ -24,6 +24,7 @@ interface MainDataSource : Closeable {
 
     fun getString(resId: Int): String
     fun getString(resId: Int, vararg formatArgs: Any): String
+    fun getQuantityString(resId: Int, quantity: Int, vararg formatArgs: Any): String
 
     fun getSubscriptions(): List<SubscriptionCache>
     fun getSubscriptionItem(id: String): SubscriptionItem?

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -5,6 +5,11 @@ import androidx.compose.ui.res.stringResource
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 
+data class ServerDeleteTarget(
+    val guid: String,
+    val profileName: String
+)
+
 @Composable
 fun MainDialogs(
     showDelAllConfirm: Boolean,
@@ -16,7 +21,7 @@ fun MainDialogs(
     showDelInvalidConfirm: Boolean,
     onDismissDelInvalid: () -> Unit,
     onConfirmDelInvalid: () -> Unit,
-    showRemoveConfirm: String?,
+    showRemoveConfirm: ServerDeleteTarget?,
     onDismissRemove: () -> Unit,
     onConfirmRemove: (String) -> Unit,
 ) {
@@ -42,10 +47,10 @@ fun MainDialogs(
         )
     }
     if (showRemoveConfirm != null) {
-        val guid = showRemoveConfirm
+        val target = showRemoveConfirm
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
-            onConfirm = { onConfirmRemove(guid) },
+            message = stringResource(R.string.confirm_delete_profile_named, target.profileName),
+            onConfirm = { onConfirmRemove(target.guid) },
             onDismiss = onDismissRemove
         )
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.AppDivider
@@ -102,6 +104,7 @@ fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) ->
                     )
                     Text(
                         text = stringResource(R.string.app_name),
+                        modifier = Modifier.semantics { hideFromAccessibility() },
                         style = MaterialTheme.typography.titleLarge,
                         color = MaterialTheme.colorScheme.onSurface
                     )
@@ -109,8 +112,9 @@ fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) ->
             }
             drawerItems.forEachIndexed { index, item ->
                 if (index == primaryDrawerItems.size) AppDivider()
+                val itemLabel = stringResource(item.labelRes)
                 NavigationDrawerItem(
-                    label = { Text(stringResource(item.labelRes)) },
+                    label = { Text(itemLabel) },
                     selected = false,
                     onClick = { onNavigate(item) },
                     icon = { Icon(painterResource(item.iconRes), contentDescription = null) },

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainGroupTab.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainGroupTab.kt
@@ -6,13 +6,15 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,9 +23,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.v2ray.ang.R
 import com.v2ray.ang.dto.GroupMapItem
 import com.v2ray.ang.dto.entities.ServersCache
 import kotlinx.coroutines.flow.StateFlow
@@ -45,10 +53,14 @@ fun GroupTabBar(
         }
     }
 
+    // Unlike ScrollableTabRow, a lazy list exposes scroll-to-index semantics. TalkBack can
+    // therefore move past the last visible tab (or back before the first visible tab), and the
+    // list brings the newly focused off-screen tab into view instead of leaving the tab strip.
     LazyRow(
         state = listState,
         modifier = modifier
             .fillMaxWidth()
+            .selectableGroup()
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.95f)),
         contentPadding = PaddingValues(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -78,25 +90,41 @@ private fun GroupTabItem(
     onClick: () -> Unit
 ) {
     val servers by serverFlow.collectAsStateWithLifecycle()
+    val accessibilityLabel = pluralStringResource(
+        R.plurals.acc_group_tab,
+        servers.size,
+        group.remarks,
+        servers.size,
+    )
     val text = if (group.id.isEmpty()) {
         group.remarks
     } else {
         "${group.remarks} (${servers.size})"
     }
 
-    Box(Modifier.widthIn(min = 56.dp)) {
-        Tab(
-            selected = selected,
-            onClick = onClick,
-            modifier = Modifier.heightIn(min = 48.dp),
-            text = {
-                Text(
-                    text = text,
-                    maxLines = 1,
-                    softWrap = false,
-                    overflow = TextOverflow.Ellipsis
-                )
+    Box(
+        modifier = Modifier
+            .heightIn(min = 48.dp)
+            .widthIn(min = 56.dp)
+            .selectable(
+                selected = selected,
+                role = Role.Tab,
+                onClick = onClick,
+            )
+            .semantics {
+                contentDescription = accessibilityLabel
             }
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.semantics { hideFromAccessibility() },
+            color = if (selected) MaterialTheme.colorScheme.primary
+            else MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis,
         )
         if (selected) {
             Box(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
@@ -87,7 +87,19 @@ fun ShareMethodDialog(
     )
     SelectListDialog(
         options = menuActions,
-        optionText = { stringResource(it.labelRes) },
+        optionText = { action ->
+            when (action) {
+                ServerMenuAction.Edit -> stringResource(
+                    R.string.acc_edit_config_named,
+                    profile.remarks,
+                )
+                ServerMenuAction.Delete -> stringResource(
+                    R.string.acc_delete_config_named,
+                    profile.remarks,
+                )
+                else -> stringResource(action.labelRes)
+            }
+        },
         onSelected = { action ->
             onDismiss()
             when (action) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -125,6 +125,9 @@ class MainRepository(
     override fun getString(resId: Int, vararg formatArgs: Any): String =
         localizedContext.getString(resId, *formatArgs)
 
+    override fun getQuantityString(resId: Int, quantity: Int, vararg formatArgs: Any): String =
+        localizedContext.resources.getQuantityString(resId, quantity, *formatArgs)
+
     override fun getSubscriptions(): List<SubscriptionCache> {
         val result = mutableListOf<SubscriptionCache>()
         if (isGroupAllDisplayEnabled()) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -44,6 +44,10 @@ fun MainScreen(
     val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
     val isRunning = uiState.isRunning
     val displayText = mainViewModel.formatStatus(uiState.status)
+    val accessibilityText = mainViewModel.formatStatusForAccessibility(
+        status = uiState.status,
+        isRunning = isRunning,
+    )
     val selectedGuid = uiState.selectedGuid
     val doubleColumnDisplay = uiState.doubleColumnDisplay
     val confirmRemove = uiState.confirmRemove
@@ -57,11 +61,15 @@ fun MainScreen(
     var showDelAllConfirm by remember { mutableStateOf(false) }
     var showDelDuplicateConfirm by remember { mutableStateOf(false) }
     var showDelInvalidConfirm by remember { mutableStateOf(false) }
-    var showRemoveConfirm by remember { mutableStateOf<String?>(null) }
+    var showRemoveConfirm by remember { mutableStateOf<ServerDeleteTarget?>(null) }
 
     var shareTarget by remember { mutableStateOf<Triple<String, ProfileItem, Boolean>?>(null) }
-    val removeServer: (String) -> Unit = { guid ->
-        if (confirmRemove) showRemoveConfirm = guid else onAction(MainAction.RemoveServer(guid))
+    val removeServer: (String, ProfileItem) -> Unit = { guid, profile ->
+        if (confirmRemove) {
+            showRemoveConfirm = ServerDeleteTarget(guid, profile.remarks)
+        } else {
+            onAction(MainAction.RemoveServer(guid))
+        }
     }
 
     val pagerState = rememberPagerState(
@@ -123,7 +131,7 @@ fun MainScreen(
             more = more,
             onDismiss = { shareTarget = null },
             onAction = onAction,
-            onRemove = removeServer,
+            onRemove = { targetGuid -> removeServer(targetGuid, profile) },
         )
     }
     if (shareQRCodeBitmap != null) {
@@ -180,6 +188,7 @@ fun MainScreen(
             bottomBar = {
                 MainBottomBar(
                     displayText = displayText,
+                    accessibilityText = accessibilityText,
                     isRunning = isRunning,
                     isDarkTheme = isDarkTheme,
                     onAction = onAction

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
@@ -1,7 +1,6 @@
 package com.v2ray.ang.ui.main
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +23,8 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,9 +38,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineBreak
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,6 +52,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.LocateTarget
 import com.v2ray.ang.dto.entities.ProfileItem
+import com.v2ray.ang.extension.toPluralQuantity
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.ReorderableGridItem
 import com.v2ray.ang.ui.compose.ReorderableListItem
@@ -75,7 +79,7 @@ fun GroupPagerPage(
     onEditServer: (String, ProfileItem) -> Unit,
     onShareServer: (String, ProfileItem) -> Unit,
     onMoreServer: (String, ProfileItem) -> Unit,
-    onRemoveServer: (String) -> Unit,
+    onRemoveServer: (String, ProfileItem) -> Unit,
     contentPadding: PaddingValues
 ) {
     val groupStateFlow = remember(groupId) {
@@ -121,7 +125,7 @@ private class ServerRowActions(
     val edit: (String, ProfileItem) -> Unit,
     val share: (String, ProfileItem) -> Unit,
     val more: (String, ProfileItem) -> Unit,
-    val remove: (String) -> Unit,
+    val remove: (String, ProfileItem) -> Unit,
 )
 
 @Composable
@@ -156,6 +160,7 @@ private fun ServerListPage(
             state = gridState,
             modifier = Modifier
                 .fillMaxSize()
+                .selectableGroup()
                 .verticalScrollbar(gridState),
             contentPadding = contentPadding
         ) {
@@ -199,6 +204,7 @@ private fun ServerListPage(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
+                .selectableGroup()
                 .verticalScrollbar(listState),
             contentPadding = contentPadding
         ) {
@@ -309,21 +315,32 @@ private fun ServerListItem(
     } else {
         stringResource(R.string.server_test_delay_value, row.testDelayMillis)
     }
-    val selectedStateDescription = if (isSelected) {
-        stringResource(R.string.acc_selected_server)
+    val testResultAccessibility = if (row.testDelayMillis == 0L) {
+        ""
     } else {
-        null
+        pluralStringResource(
+            R.plurals.server_test_delay_accessibility_value,
+            row.testDelayMillis.toPluralQuantity(),
+            row.testDelayMillis,
+        )
+    }
+    val testResultModifier = if (row.testDelayMillis == 0L) {
+        Modifier
+    } else {
+        Modifier.semantics {
+            contentDescription = testResultAccessibility
+        }
     }
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .height(IntrinsicSize.Min)
-            .semantics {
-                if (selectedStateDescription != null) {
-                    stateDescription = selectedStateDescription
-                }
-            }
-            .clickable { actions.select(row.guid) }
+            .semantics(mergeDescendants = true) {}
+            .selectable(
+                selected = isSelected,
+                onClick = { actions.select(row.guid) },
+                role = Role.RadioButton,
+            )
     ) {
         Box(
             Modifier
@@ -363,21 +380,24 @@ private fun ServerListItem(
                     IconButton(onClick = { actions.share(row.guid, row.profile) }, Modifier.size(36.dp)) {
                         Icon(
                             painterResource(R.drawable.ic_share_24dp),
-                            stringResource(R.string.title_configuration_share),
+                            stringResource(R.string.acc_share_config_named, row.remarks),
                             Modifier.size(24.dp)
                         )
                     }
                     IconButton(onClick = { actions.edit(row.guid, row.profile) }, Modifier.size(36.dp)) {
                         Icon(
                             painterResource(R.drawable.ic_edit_24dp),
-                            stringResource(R.string.acc_edit),
+                            stringResource(R.string.acc_edit_config_named, row.remarks),
                             Modifier.size(24.dp)
                         )
                     }
-                    IconButton(onClick = { actions.remove(row.guid) }, Modifier.size(36.dp)) {
+                    IconButton(
+                        onClick = { actions.remove(row.guid, row.profile) },
+                        modifier = Modifier.size(36.dp),
+                    ) {
                         Icon(
                             painterResource(R.drawable.ic_delete_24dp),
-                            stringResource(R.string.acc_delete),
+                            stringResource(R.string.acc_delete_config_named, row.remarks),
                             Modifier.size(24.dp)
                         )
                     }
@@ -407,7 +427,7 @@ private fun ServerListItem(
             Spacer(modifier = Modifier.height(6.dp))
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                 Text(row.typeDescription, style = MaterialTheme.typography.bodySmall, color = colorConfigType, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text(testResult, style = MaterialTheme.typography.bodySmall, color = if (row.testDelayMillis < 0L) colorPingRed else colorPing, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(testResult, testResultModifier, style = MaterialTheme.typography.bodySmall, color = if (row.testDelayMillis < 0L) colorPingRed else colorPing, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -17,6 +17,7 @@ import com.v2ray.ang.extension.delay
 import com.v2ray.ang.extension.isComplexType
 import com.v2ray.ang.extension.matchesPattern
 import com.v2ray.ang.extension.moveItem
+import com.v2ray.ang.extension.toPluralQuantity
 import com.v2ray.ang.ui.base.BaseViewModel
 import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CancellationException
@@ -143,12 +144,35 @@ class MainViewModel(
             status.progress
         )
 
-        is MainStatus.ConnectionTest -> formatConnectionTestResult(status.result)
+        is MainStatus.ConnectionTest -> formatConnectionTestResult(status.result, accessible = false)
     }
 
-    private fun formatConnectionTestResult(result: ConnectionTestResult): String {
+    internal fun formatStatusForAccessibility(status: MainStatus, isRunning: Boolean): String =
+        when (status) {
+            is MainStatus.TestProgress -> formatStatus(
+                if (isRunning) MainStatus.Connected else MainStatus.Disconnected
+            )
+            is MainStatus.ConnectionTest -> formatConnectionTestResult(
+                status.result,
+                accessible = true,
+            )
+            else -> formatStatus(status)
+        }
+
+    private fun formatConnectionTestResult(
+        result: ConnectionTestResult,
+        accessible: Boolean,
+    ): String {
         val status = if (result.delayMillis >= 0) {
-            val delay = dataSource.getString(R.string.server_test_delay_value, result.delayMillis)
+            val delay = if (accessible) {
+                dataSource.getQuantityString(
+                    R.plurals.server_test_delay_accessibility_value,
+                    result.delayMillis.toPluralQuantity(),
+                    result.delayMillis,
+                )
+            } else {
+                dataSource.getString(R.string.server_test_delay_value, result.delayMillis)
+            }
             dataSource.getString(R.string.connection_test_available, delay)
         } else {
             val detail = result.errorMessage.ifBlank {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/perappproxy/PerAppProxyActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/perappproxy/PerAppProxyActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,17 +38,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.AppInfo
-import com.v2ray.ang.extension.toastInfo
 import com.v2ray.ang.extension.toastSuccess
 import com.v2ray.ang.ui.base.BaseComponentActivity
 import com.v2ray.ang.ui.compose.AppDivider
 import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppListItem
 import com.v2ray.ang.ui.compose.AppTopBar
+import com.v2ray.ang.ui.compose.ConfirmDialog
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.NavigationBarsBottomPadding
 import com.v2ray.ang.ui.compose.verticalScrollbar
@@ -59,6 +61,51 @@ private enum class PerAppMenuAction(@StringRes val labelRes: Int) {
     SelectProxyApps(R.string.menu_item_select_proxy_app),
     ImportSelection(R.string.menu_item_import_proxy_app),
     ExportSelection(R.string.menu_item_export_proxy_app)
+}
+
+@StringRes
+internal fun perAppRoutingDescription(
+    perAppProxyEnabled: Boolean,
+    bypassApps: Boolean,
+    checked: Boolean
+): Int = when {
+    !perAppProxyEnabled -> R.string.acc_per_app_routing_disabled
+    checked == bypassApps -> R.string.acc_app_routed_directly
+    else -> R.string.acc_app_routed_through
+}
+
+@Composable
+private fun PerAppSwitch(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            ),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Switch(
+            checked = checked,
+            onCheckedChange = null,
+            modifier = Modifier.scale(0.65f),
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = MaterialTheme.colorScheme.onSecondary,
+                checkedTrackColor = MaterialTheme.colorScheme.secondary,
+            ),
+        )
+    }
 }
 
 class PerAppProxyActivity : BaseComponentActivity() {
@@ -87,9 +134,6 @@ class PerAppProxyActivity : BaseComponentActivity() {
             onBackClick = { finish() },
             onPerAppProxyChanged = { viewModel.setPerAppProxyEnabled(it) },
             onBypassAppsChanged = { viewModel.setBypassAppsEnabled(it) },
-            onInfoClick = {
-                toastInfo(R.string.summary_pref_per_app_proxy)
-            },
             onToggleApp = { viewModel.toggle(it) },
             onSearch = { viewModel.filterApps(it) },
             onSelectAll = { viewModel.selectAll() },
@@ -118,7 +162,6 @@ fun PerAppProxyScreen(
     onBackClick: () -> Unit,
     onPerAppProxyChanged: (Boolean) -> Unit,
     onBypassAppsChanged: (Boolean) -> Unit,
-    onInfoClick: () -> Unit,
     onToggleApp: (String) -> Unit,
     onSearch: (String) -> Unit,
     onSelectAll: () -> Unit,
@@ -130,6 +173,7 @@ fun PerAppProxyScreen(
     var showSearch by rememberSaveable { mutableStateOf(false) }
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var showMenu by remember { mutableStateOf(false) }
+    var showInfoDialog by rememberSaveable { mutableStateOf(false) }
     val listState = rememberLazyListState()
 
     LaunchedEffect(Unit) {
@@ -208,48 +252,20 @@ fun PerAppProxyScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.per_app_proxy_settings_enable),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Switch(
-                            checked = perAppProxyEnabled,
-                            modifier = Modifier.scale(0.65f),
-                            onCheckedChange = onPerAppProxyChanged,
-                            colors = SwitchDefaults.colors(
-                                checkedThumbColor = MaterialTheme.colorScheme.onSecondary,
-                                checkedTrackColor = MaterialTheme.colorScheme.secondary
-                            )
-                        )
-                    }
+                    PerAppSwitch(
+                        label = stringResource(R.string.per_app_proxy_settings_enable),
+                        checked = perAppProxyEnabled,
+                        onCheckedChange = onPerAppProxyChanged,
+                        modifier = Modifier.weight(1f),
+                    )
                     Spacer(modifier = Modifier.width(16.dp))
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.switch_bypass_apps_mode),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Switch(
-                            checked = bypassApps,
-                            modifier = Modifier.scale(0.65f),
-                            onCheckedChange = onBypassAppsChanged,
-                            colors = SwitchDefaults.colors(
-                                checkedThumbColor = MaterialTheme.colorScheme.onSecondary,
-                                checkedTrackColor = MaterialTheme.colorScheme.secondary
-                            )
-                        )
-                    }
-                    IconButton(onClick = onInfoClick) {
+                    PerAppSwitch(
+                        label = stringResource(R.string.switch_bypass_apps_mode),
+                        checked = bypassApps,
+                        onCheckedChange = onBypassAppsChanged,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = { showInfoDialog = true }) {
                         Icon(
                             painter = painterResource(R.drawable.ic_about_24dp),
                             contentDescription = stringResource(R.string.acc_per_app_proxy_information),
@@ -269,16 +285,30 @@ fun PerAppProxyScreen(
             ) {
                 items(items = apps, key = { it.packageName }) { app ->
                     val checked = blacklist.contains(app.packageName)
+                    val routingDescription = stringResource(
+                        perAppRoutingDescription(perAppProxyEnabled, bypassApps, checked)
+                    )
                     AppListItem(
                         appName = app.appName,
                         packageName = app.packageName,
                         icon = null,
                         checked = checked,
-                        onCheckedChange = { onToggleApp(app.packageName) }
+                        onCheckedChange = { onToggleApp(app.packageName) },
+                        routingDescription = routingDescription
                     )
                     ItemDivider()
                 }
             }
         }
+    }
+
+    if (showInfoDialog) {
+        ConfirmDialog(
+            title = stringResource(R.string.title_pref_per_app_proxy),
+            message = stringResource(R.string.summary_pref_per_app_proxy),
+            dismissText = null,
+            onConfirm = {},
+            onDismiss = { showInfoDialog = false },
+        )
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
@@ -308,7 +308,10 @@ fun RoutingEditScreen(
 
         if (showDeleteConfirm) {
             DeleteConfirmDialog(
-                message = stringResource(R.string.confirm_delete_routing_rule),
+                message = stringResource(
+                    R.string.confirm_delete_routing_rule_named,
+                    initial?.remarks.orEmpty().ifBlank { remarks }
+                ),
                 onConfirm = onDelete,
                 onDismiss = { showDeleteConfirm = false }
             )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
@@ -38,6 +38,9 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -53,6 +56,7 @@ import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.base.HelperBaseComponentActivity
 import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppTopBar
+import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.NavigationBarsBottomPadding
 import com.v2ray.ang.ui.compose.ReorderableListItem
@@ -205,6 +209,7 @@ fun RoutingSettingScreen(
     val domainStrategy by domainStrategyState.collectAsState()
     var showMenu by remember { mutableStateOf(false) }
     var showPresetDialog by remember { mutableStateOf(false) }
+    var deleteRuleId by remember { mutableStateOf<String?>(null) }
 
     val domainStrategies = stringArrayResource(R.array.routing_domain_strategy).toList()
     val lazyListState = rememberLazyListState()
@@ -295,7 +300,8 @@ fun RoutingSettingScreen(
                             onEnabledChange = { checked ->
                                 val updated = ruleset.copy(enabled = checked)
                                 viewModel.update(index, updated)
-                            }
+                            },
+                            onDelete = { deleteRuleId = ruleset.id }
                         )
                     }
                     ItemDivider()
@@ -304,6 +310,19 @@ fun RoutingSettingScreen(
         }
     }
 
+
+    deleteRuleId?.let { ruleId ->
+        val ruleName = rulesets.firstOrNull { it.id == ruleId }?.remarks.orEmpty()
+        DeleteConfirmDialog(
+            message = stringResource(R.string.confirm_delete_routing_rule_named, ruleName),
+            onConfirm = {
+                val position = rulesets.indexOfFirst { it.id == ruleId }
+                if (position >= 0) viewModel.remove(position)
+                deleteRuleId = null
+            },
+            onDismiss = { deleteRuleId = null }
+        )
+    }
 
     if (showPresetDialog) {
         SelectListDialog(
@@ -323,11 +342,43 @@ fun RoutingSettingScreen(
 private fun RoutingRulesetItem(
     ruleset: RulesetItem,
     onEdit: () -> Unit,
-    onEnabledChange: (Boolean) -> Unit
+    onEnabledChange: (Boolean) -> Unit,
+    onDelete: () -> Unit
 ) {
+    val enabled = ruleset.enabled
+    val ruleName = ruleset.remarks.orEmpty()
+    val outboundTag = ruleset.outboundTag.ifBlank { AppConfig.TAG_PROXY }
+    val routeDescription = when {
+        outboundTag.equals(AppConfig.TAG_BLOCKED, ignoreCase = true) ->
+            stringResource(R.string.acc_routing_rule_blocked)
+
+        outboundTag.equals(AppConfig.TAG_DIRECT, ignoreCase = true) ->
+            stringResource(R.string.acc_routing_rule_routed_directly)
+
+        else ->
+            stringResource(R.string.acc_routing_rule_routed_through, outboundTag)
+    }
+    val ruleState = stringResource(
+        R.string.acc_routing_rule_state,
+        stringResource(if (enabled) R.string.acc_routing_rule_on else R.string.acc_routing_rule_off)
+    )
+    val ruleAnnouncement = stringResource(
+        R.string.acc_routing_rule_announcement,
+        ruleset.remarks.orEmpty(),
+        routeDescription,
+        ruleState
+    )
+    val ruleSwitchLabel = stringResource(
+        R.string.acc_routing_rule_switch_label,
+        ruleName,
+    )
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = ruleAnnouncement
+            }
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -335,6 +386,7 @@ private fun RoutingRulesetItem(
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = ruleset.remarks ?: "",
+                    modifier = Modifier.clearAndSetSemantics {},
                     style = MaterialTheme.typography.bodyLarge,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -343,7 +395,7 @@ private fun RoutingRulesetItem(
                     Spacer(modifier = Modifier.width(4.dp))
                     Icon(
                         painter = painterResource(R.drawable.ic_lock_24dp),
-                        contentDescription = stringResource(R.string.acc_locked),
+                        contentDescription = null,
                         modifier = Modifier.size(16.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -354,6 +406,7 @@ private fun RoutingRulesetItem(
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = domainIpInfo,
+                    modifier = Modifier.clearAndSetSemantics {},
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
@@ -364,6 +417,7 @@ private fun RoutingRulesetItem(
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
                     text = ruleset.outboundTag,
+                    modifier = Modifier.clearAndSetSemantics {},
                     style = MaterialTheme.typography.labelMedium,
                     color = colorConfigType
                 )
@@ -374,17 +428,29 @@ private fun RoutingRulesetItem(
             horizontalAlignment = Alignment.End,
             modifier = Modifier.padding(start = 8.dp)
         ) {
-            IconButton(onClick = onEdit) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_edit_24dp),
-                    contentDescription = stringResource(R.string.acc_edit)
-                )
+            Row {
+                IconButton(onClick = onEdit) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_edit_24dp),
+                        contentDescription = stringResource(R.string.acc_edit_named, ruleName)
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_delete_24dp),
+                        contentDescription = stringResource(R.string.acc_delete_named, ruleName)
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(4.dp))
             Switch(
-                checked = ruleset.enabled ?: false,
+                checked = enabled,
                 onCheckedChange = onEnabledChange,
-                modifier = Modifier.scale(0.7f),
+                modifier = Modifier
+                    .scale(0.7f)
+                    .semantics {
+                        contentDescription = ruleSwitchLabel
+                    },
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.onSecondary,
                     checkedTrackColor = MaterialTheme.colorScheme.secondary

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
@@ -42,6 +42,14 @@ class RoutingSettingsViewModel(application: Application) : BaseViewModel(applica
         }
     }
 
+    fun remove(position: Int) {
+        if (position in rulesets.indices) {
+            SettingsManager.removeRoutingRuleset(position)
+            rulesets.removeAt(position)
+            _rulesetsFlow.value = rulesets.toList()
+        }
+    }
+
     fun move(fromPosition: Int, toPosition: Int) {
         if (rulesets.moveItem(fromPosition, toPosition)) {
             MmkvManager.encodeRoutingRulesets(rulesets)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -490,7 +490,7 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         }
         if (showDeleteDialog) {
             DeleteConfirmDialog(
-                message = stringResource(R.string.confirm_delete_profile),
+                message = stringResource(R.string.confirm_delete_profile_named, initialConfig.remarks),
                 onConfirm = {
                     showDeleteDialog = false
                     deleteServer(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
@@ -518,7 +518,7 @@ fun ServerScreen(
     }
     if (showDeleteDialog) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
+            message = stringResource(R.string.confirm_delete_profile_named, remarks),
             onConfirm = { showDeleteDialog = false; onDelete() },
             onDismiss = { showDeleteDialog = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -485,7 +485,7 @@ fun ServerCustomConfigScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
+            message = stringResource(R.string.confirm_delete_profile_named, remarks),
             onConfirm = {
                 showDeleteConfirm = false
                 onDelete()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -305,7 +305,7 @@ fun ServerGroupScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_policy_group),
+            message = stringResource(R.string.confirm_delete_policy_group_named, initialRemarks),
             onConfirm = onDelete,
             onDismiss = { showDeleteConfirm = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
@@ -334,14 +334,15 @@ fun ProxyChainScreen(
 
     if (showProfileDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
+            message = stringResource(R.string.confirm_delete_profile_named, remarks),
             onConfirm = { showProfileDeleteConfirm = false; onDelete() },
             onDismiss = { showProfileDeleteConfirm = false }
         )
     }
     memberToDeleteIndex?.let { index ->
+        val memberName = members.getOrNull(index).orEmpty()
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_proxy_chain_member),
+            message = stringResource(R.string.confirm_delete_proxy_chain_member_named, memberName),
             onConfirm = {
                 members = members.toMutableList().also { it.removeAt(index) }
                 memberKeys = memberKeys.toMutableList().also { it.removeAt(index) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -246,7 +246,7 @@ fun SubEditScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_subscription_group),
+            message = stringResource(R.string.confirm_delete_subscription_group_named, remarks),
             onConfirm = onDelete,
             onDismiss = { showDeleteConfirm = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubSettingActivity.kt
@@ -3,6 +3,7 @@ package com.v2ray.ang.ui.subscription
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.text.format.DateUtils
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
@@ -33,8 +34,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -62,6 +67,11 @@ private enum class SubscriptionShareAction(@StringRes val labelRes: Int) {
     QRCode(R.string.share_subscription_qrcode),
     Clipboard(R.string.share_subscription_clipboard)
 }
+
+private data class SubscriptionDeleteTarget(
+    val guid: String,
+    val name: String
+)
 
 class SubSettingActivity : BaseComponentActivity() {
     private val viewModel: SubscriptionsViewModel by viewModels()
@@ -115,13 +125,14 @@ fun SubSettingScreen(
 ) {
     val subscriptions by viewModel.subsFlow.collectAsStateWithLifecycle()
     var showUpdateDialog by remember { mutableStateOf(false) }
-    var removeTarget by remember { mutableStateOf<String?>(null) }
+    var removeTarget by remember { mutableStateOf<SubscriptionDeleteTarget?>(null) }
     val confirmRemove = MmkvManager.decodeSettingsBool(AppConfig.PREF_CONFIRM_REMOVE, false)
 
     var shareTarget by remember { mutableStateOf<Pair<String, String>?>(null) }
     var showQRCodeBitmap by remember { mutableStateOf<Bitmap?>(null) }
 
     val lazyListState = rememberLazyListState()
+    val context = LocalContext.current
     val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
         viewModel.move(from.index, to.index)
     }
@@ -156,6 +167,34 @@ fun SubSettingScreen(
                 items = subscriptions,
                 key = { _, item -> item.guid }
             ) { _, subCache ->
+                val lastUpdated = Utils.formatTimestamp(subCache.subscription.lastUpdated)
+                val lastUpdatedAccessibility = if (lastUpdated.isNotEmpty()) {
+                    stringResource(
+                        R.string.acc_last_updated,
+                        DateUtils.formatDateTime(
+                            context,
+                            subCache.subscription.lastUpdated,
+                            DateUtils.FORMAT_SHOW_DATE or
+                                DateUtils.FORMAT_SHOW_TIME or
+                                DateUtils.FORMAT_SHOW_YEAR
+                        )
+                    )
+                } else {
+                    ""
+                }
+                val subscriptionAnnouncement = if (lastUpdatedAccessibility.isNotEmpty()) {
+                    stringResource(
+                        R.string.acc_subscription_announcement,
+                        subCache.subscription.remarks,
+                        lastUpdatedAccessibility
+                    )
+                } else {
+                    subCache.subscription.remarks
+                }
+                val subscriptionUpdateLabel = stringResource(
+                    R.string.acc_subscription_update_label,
+                    subCache.subscription.remarks,
+                )
                 ReorderableItem(reorderableState, key = subCache.guid) { isDragging ->
                     ReorderableListItem(
                         scope = this,
@@ -164,12 +203,16 @@ fun SubSettingScreen(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .semantics(mergeDescendants = true) {
+                                    contentDescription = subscriptionAnnouncement
+                                }
                                 .padding(horizontal = 14.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
                                     text = subCache.subscription.remarks,
+                                    modifier = Modifier.clearAndSetSemantics {},
                                     style = MaterialTheme.typography.bodyLarge,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis
@@ -178,18 +221,22 @@ fun SubSettingScreen(
                                     Spacer(modifier = Modifier.height(2.dp))
                                     Text(
                                         text = subCache.subscription.url,
+                                        modifier = Modifier.clearAndSetSemantics {},
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(2.dp))
-                                Text(
-                                    text = Utils.formatTimestamp(subCache.subscription.lastUpdated),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                if (lastUpdated.isNotEmpty()) {
+                                    Spacer(modifier = Modifier.height(2.dp))
+                                    Text(
+                                        text = lastUpdated,
+                                        modifier = Modifier.clearAndSetSemantics {},
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
 
                             Column(
@@ -203,35 +250,54 @@ fun SubSettingScreen(
                                         }) {
                                             Icon(
                                                 painter = painterResource(R.drawable.ic_share_24dp),
-                                                contentDescription = stringResource(R.string.acc_share_subscription)
+                                                contentDescription = stringResource(
+                                                    R.string.acc_share_named,
+                                                    subCache.subscription.remarks
+                                                )
                                             )
                                         }
                                     }
                                     IconButton(onClick = { onEditSub(subCache.guid) }) {
                                         Icon(
                                             painter = painterResource(R.drawable.ic_edit_24dp),
-                                            contentDescription = stringResource(R.string.acc_edit)
+                                            contentDescription = stringResource(
+                                                R.string.acc_edit_named,
+                                                subCache.subscription.remarks
+                                            )
                                         )
                                     }
                                     IconButton(onClick = {
-                                        if (confirmRemove) removeTarget = subCache.guid
+                                        if (confirmRemove) {
+                                            removeTarget = SubscriptionDeleteTarget(
+                                                guid = subCache.guid,
+                                                name = subCache.subscription.remarks
+                                            )
+                                        }
                                         else onRemoveSub(subCache.guid)
                                     }) {
                                         Icon(
                                             painter = painterResource(R.drawable.ic_delete_24dp),
-                                            contentDescription = stringResource(R.string.acc_delete)
+                                            contentDescription = stringResource(
+                                                R.string.acc_delete_named,
+                                                subCache.subscription.remarks
+                                            )
                                         )
                                     }
                                 }
                                 Spacer(modifier = Modifier.height(4.dp))
+                                val updateSubscription: (Boolean) -> Unit = { checked ->
+                                    val updated = subCache.subscription.copy()
+                                    updated.enabled = checked
+                                    viewModel.update(subCache.guid, updated)
+                                }
                                 Switch(
                                     checked = subCache.subscription.enabled,
-                                    onCheckedChange = { checked ->
-                                        val updated = subCache.subscription.copy()
-                                        updated.enabled = checked
-                                        viewModel.update(subCache.guid, updated)
-                                    },
-                                    modifier = Modifier.scale(0.7f),
+                                    onCheckedChange = updateSubscription,
+                                    modifier = Modifier
+                                        .scale(0.7f)
+                                        .semantics {
+                                            contentDescription = subscriptionUpdateLabel
+                                        },
                                     colors = SwitchDefaults.colors(
                                         checkedThumbColor = MaterialTheme.colorScheme.onSecondary,
                                         checkedTrackColor = MaterialTheme.colorScheme.secondary
@@ -270,11 +336,12 @@ fun SubSettingScreen(
         )
     }
 
-    if (removeTarget != null) {
+    val deleteTarget = removeTarget
+    if (deleteTarget != null) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_subscription_group),
+            message = stringResource(R.string.confirm_delete_subscription_group_named, deleteTarget.name),
             onConfirm = {
-                onRemoveSub(removeTarget!!)
+                onRemoveSub(deleteTarget.guid)
                 removeTarget = null
             },
             onDismiss = { removeTarget = null }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.OpenableColumns
+import android.text.format.DateUtils
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
@@ -34,8 +35,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -66,8 +71,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.text.DateFormat
-import java.util.Date
 
 private enum class AddAssetMenuAction(@StringRes val labelRes: Int) {
     File(R.string.menu_item_add_file),
@@ -353,19 +356,51 @@ private fun UserAssetItem(
     onEdit: () -> Unit,
     onDeleteClick: () -> Unit
 ) {
-    val propertiesText = if (fileMetadata != null) {
-        remember(fileMetadata) {
-            val dateFormat = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM)
-            "${fileMetadata.length.toTrafficString()}  •  ${dateFormat.format(Date(fileMetadata.lastModified))}"
+    val context = LocalContext.current
+    val formattedDate = fileMetadata?.let { metadata ->
+        remember(metadata.lastModified) {
+            DateUtils.formatDateTime(
+                context,
+                metadata.lastModified,
+                DateUtils.FORMAT_SHOW_DATE or
+                    DateUtils.FORMAT_SHOW_TIME or
+                    DateUtils.FORMAT_SHOW_YEAR,
+            )
         }
+    }.orEmpty()
+    val fileSize = fileMetadata?.length?.toTrafficString().orEmpty()
+    val propertiesText = if (fileMetadata != null) {
+        "$fileSize  •  $formattedDate"
     } else {
         stringResource(R.string.msg_file_not_found)
+    }
+    val assetAnnouncement = if (fileMetadata != null) {
+        val fileSizeDescription = stringResource(
+            R.string.acc_asset_file_size,
+            fileSize
+        )
+        val updatedOnDescription = stringResource(R.string.acc_asset_updated_on, formattedDate)
+        stringResource(
+            R.string.acc_asset_announcement,
+            item.assetUrl.remarks,
+            fileSizeDescription,
+            updatedOnDescription
+        )
+    } else {
+        stringResource(
+            R.string.acc_asset_announcement_missing,
+            item.assetUrl.remarks,
+            stringResource(R.string.msg_file_not_found)
+        )
     }
     val showEditButton = item.assetUrl.locked != true && item.assetUrl.url != "file"
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                contentDescription = assetAnnouncement
+            }
             .padding(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -376,6 +411,7 @@ private fun UserAssetItem(
         ) {
             Text(
                 text = item.assetUrl.remarks,
+                modifier = Modifier.clearAndSetSemantics {},
                 style = MaterialTheme.typography.bodyLarge,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
@@ -383,6 +419,7 @@ private fun UserAssetItem(
             Spacer(modifier = Modifier.height(4.dp))
             Text(
                 text = propertiesText,
+                modifier = Modifier.clearAndSetSemantics {},
                 style = MaterialTheme.typography.bodySmall,
                 maxLines = 1,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -392,7 +429,10 @@ private fun UserAssetItem(
             IconButton(onClick = onEdit) {
                 Icon(
                     painter = painterResource(R.drawable.ic_edit_24dp),
-                    contentDescription = stringResource(R.string.acc_edit),
+                    contentDescription = stringResource(
+                        R.string.acc_edit_named,
+                        item.assetUrl.remarks
+                    ),
                     modifier = Modifier.size(24.dp)
                 )
             }
@@ -400,7 +440,10 @@ private fun UserAssetItem(
         IconButton(onClick = onDeleteClick) {
             Icon(
                 painter = painterResource(R.drawable.ic_delete_24dp),
-                contentDescription = stringResource(R.string.acc_delete),
+                contentDescription = stringResource(
+                    R.string.acc_delete_named,
+                    item.assetUrl.remarks
+                ),
                 modifier = Modifier.size(24.dp)
             )
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetUrlActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetUrlActivity.kt
@@ -189,7 +189,7 @@ fun UserAssetUrlScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_asset_source),
+            message = stringResource(R.string.confirm_delete_asset_source_named, initialRemarks),
             onConfirm = onDelete,
             onDismiss = { showDeleteConfirm = false }
         )

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -22,6 +22,30 @@
     <string name="toast_services_stop">إيقاف الخدمات</string>
     <string name="toast_services_success">نجاح بدء الخدمات</string>
     <string name="toast_services_failure">فشل بدء الخدمات</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="zero">%1$d مللي ثانية</item>
+        <item quantity="one">مللي ثانية واحدة</item>
+        <item quantity="two">مللي ثانيتان</item>
+        <item quantity="few">%1$d مللي ثوانٍ</item>
+        <item quantity="many">%1$d مللي ثانية</item>
+        <item quantity="other">%1$d مللي ثانية</item>
+    </plurals>
+
+    <string name="acc_share_config_named">مشاركة التكوين %1$s</string>
+
+    <string name="acc_edit_config_named">تعديل التكوين %1$s</string>
+
+    <string name="acc_delete_config_named">حذف التكوين %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="zero">المجموعة %1$s لا تحتوي على أي خوادم</item>
+        <item quantity="one">المجموعة %1$s تحتوي على خادم واحد</item>
+        <item quantity="two">المجموعة %1$s تحتوي على خادمين</item>
+        <item quantity="few">المجموعة %1$s تحتوي على %2$d خوادم</item>
+        <item quantity="many">المجموعة %1$s تحتوي على %2$d خادمًا</item>
+        <item quantity="other">المجموعة %1$s تحتوي على %2$d خادم</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">ملف التكوين</string>
@@ -46,6 +70,7 @@
     <string name="confirm_delete_duplicate_profiles">هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف المكررة المعروضة حاليًا؟</string>
     <string name="confirm_delete_invalid_profiles">يرجى اختبار ملفات التعريف أولًا. هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف غير الصالحة المعروضة حاليًا؟</string>
     <string name="confirm_delete_profile">هل أنت متأكد من أنك تريد حذف ملف التعريف هذا؟</string>
+    <string name="confirm_delete_profile_named">هل أنت متأكد من أنك تريد حذف ملف التعريف هذا؟\n%1$s</string>
     <string name="confirm_delete_policy_group">هل أنت متأكد من أنك تريد حذف مجموعة السياسات هذه؟</string>
     <string name="confirm_delete_proxy_chain_member">هل أنت متأكد من أنك تريد حذف هذا العضو من سلسلة الوكلاء؟</string>
     <string name="confirm_delete_routing_rule">هل أنت متأكد من أنك تريد حذف قاعدة التوجيه هذه؟</string>
@@ -512,7 +537,7 @@
     <string name="acc_add_asset">إضافة مصدر موارد</string>
     <string name="acc_download_file">تنزيل ملفات الموارد</string>
     <string name="acc_qr_code">رمز QR</string>
-    <string name="acc_copy_log">نسخ السجل</string>
+    <string name="acc_copy_log">نسخ السجل إلى الحافظة</string>
     <string name="acc_clear_log">مسح السجل</string>
     <string name="acc_add_rule">إضافة قاعدة توجيه</string>
     <string name="acc_start">بدء الخدمة</string>
@@ -521,8 +546,36 @@
     <string name="acc_search">بحث</string>
     <string name="acc_add">إضافة تكوين</string>
     <string name="acc_more">المزيد من الخيارات</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">مشاركة رابط الاشتراك</string>
+    <string name="acc_last_updated">آخر تحديث %1$s</string>
+    <string name="acc_subscription_announcement">%1$s، %2$s</string>
+    <string name="acc_subscription_update_label">تحديث %1$s</string>
+    <string name="acc_app_routing_announcement">%1$s. %2$s</string>
+    <string name="acc_app_routed_directly">موجّه مباشرةً</string>
+    <string name="acc_app_routed_through">موجّه عبر التطبيق</string>
+    <string name="acc_per_app_routing_disabled">التوجيه حسب التطبيق غير مفعّل</string>
+    <string name="acc_routing_rule_announcement">%1$s، %2$s، %3$s</string>
+    <string name="acc_routing_rule_blocked">محظورة</string>
+    <string name="acc_routing_rule_routed_through">موجّهة عبر %1$s</string>
+    <string name="acc_routing_rule_routed_directly">موجّهة مباشرة</string>
+    <string name="acc_routing_rule_state">القاعدة %1$s</string>
+    <string name="acc_routing_rule_switch_label">القاعدة %1$s</string>
+    <string name="acc_routing_rule_on">مفعّلة</string>
+    <string name="acc_routing_rule_off">غير مفعّلة</string>
+    <string name="acc_asset_announcement">%1$s. %2$s. %3$s</string>
+    <string name="acc_asset_file_size">حجم الملف %1$s</string>
+    <string name="acc_asset_updated_on">تم التحديث في %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s، %2$s</string>
+    <string name="acc_group_expanded">موسّعة</string>
+    <string name="acc_group_collapsed">مطوية</string>
+    <string name="acc_share_named">مشاركة %1$s</string>
+    <string name="acc_edit_named">تعديل %1$s</string>
+    <string name="acc_delete_named">حذف %1$s</string>
+    <string name="confirm_delete_policy_group_named">هل أنت متأكد من أنك تريد حذف مجموعة السياسات هذه؟\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">هل أنت متأكد من أنك تريد حذف هذا العضو من سلسلة الوكلاء؟\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">هل أنت متأكد من أنك تريد حذف قاعدة التوجيه هذه؟\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">هل أنت متأكد من أنك تريد حذف مجموعة الاشتراك هذه؟ %1$s</string>
+    <string name="confirm_delete_asset_source_named">هل أنت متأكد من أنك تريد حذف مصدر الأصول هذا؟\n%1$s</string>
     <string name="acc_share_log">مشاركة السجل</string>
     <string name="acc_remove">إزالة عضو من سلسلة الوكلاء</string>
     <string name="acc_add_member">إضافة عضو إلى سلسلة الوكلاء</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -22,6 +22,22 @@
     <string name="toast_services_stop">সার্ভিস বন্ধ করুন</string>
     <string name="toast_services_success">সার্ভিস সফলভাবে শুরু হয়েছে</string>
     <string name="toast_services_failure">সার্ভিস শুরু হতে ব্যর্থ হয়েছে</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="one">%1$d মিলিসেকেন্ড</item>
+        <item quantity="other">%1$d মিলিসেকেন্ড</item>
+    </plurals>
+
+    <string name="acc_share_config_named">%1$s কনফিগারেশন শেয়ার করুন</string>
+
+    <string name="acc_edit_config_named">%1$s কনফিগারেশন সম্পাদনা করুন</string>
+
+    <string name="acc_delete_config_named">%1$s কনফিগারেশন মুছুন</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="one">গ্রুপ %1$s-এ %2$dটি সার্ভার রয়েছে</item>
+        <item quantity="other">গ্রুপ %1$s-এ %2$dটি সার্ভার রয়েছে</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">কনফিগারেশন ফাইল</string>
@@ -46,6 +62,7 @@
     <string name="confirm_delete_duplicate_profiles">আপনি কি বর্তমানে প্রদর্শিত সব সদৃশ প্রোফাইল মুছে ফেলতে চান?</string>
     <string name="confirm_delete_invalid_profiles">প্রথমে প্রোফাইলগুলো পরীক্ষা করুন। আপনি কি বর্তমানে প্রদর্শিত সব অবৈধ প্রোফাইল মুছে ফেলতে চান?</string>
     <string name="confirm_delete_profile">আপনি কি এই প্রোফাইলটি মুছে ফেলতে চান?</string>
+    <string name="confirm_delete_profile_named">আপনি কি এই প্রোফাইলটি মুছে ফেলতে চান?\n%1$s</string>
     <string name="confirm_delete_policy_group">আপনি কি এই পলিসি গ্রুপটি মুছে ফেলতে চান?</string>
     <string name="confirm_delete_proxy_chain_member">আপনি কি এই প্রক্সি চেইন সদস্যটিকে মুছে ফেলতে চান?</string>
     <string name="confirm_delete_routing_rule">আপনি কি এই রাউটিং নিয়মটি মুছে ফেলতে চান?</string>
@@ -512,7 +529,7 @@
     <string name="acc_add_asset">অ্যাসেট উৎস যোগ করুন</string>
     <string name="acc_download_file">অ্যাসেট ফাইল ডাউনলোড করুন</string>
     <string name="acc_qr_code">QR কোড</string>
-    <string name="acc_copy_log">লগ কপি করুন</string>
+    <string name="acc_copy_log">ক্লিপবোর্ডে লগ কপি করুন</string>
     <string name="acc_clear_log">লগ মুছুন</string>
     <string name="acc_add_rule">রাউটিং নিয়ম যোগ করুন</string>
     <string name="acc_start">সার্ভিস শুরু করুন</string>
@@ -521,8 +538,36 @@
     <string name="acc_search">অনুসন্ধান করুন</string>
     <string name="acc_add">কনফিগারেশন যোগ করুন</string>
     <string name="acc_more">আরও বিকল্প</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">সাবস্ক্রিপশন লিংক শেয়ার করুন</string>
+    <string name="acc_last_updated">সর্বশেষ আপডেট %1$s</string>
+    <string name="acc_subscription_announcement">%1$s, %2$s</string>
+    <string name="acc_subscription_update_label">%1$s আপডেট</string>
+    <string name="acc_app_routing_announcement">%1$s। %2$s</string>
+    <string name="acc_app_routed_directly">সরাসরি রাউট করা হয়েছে</string>
+    <string name="acc_app_routed_through">অ্যাপের মাধ্যমে রাউট করা হয়েছে</string>
+    <string name="acc_per_app_routing_disabled">অ্যাপভিত্তিক রাউটিং চালু নেই</string>
+    <string name="acc_routing_rule_announcement">%1$s, %2$s, %3$s</string>
+    <string name="acc_routing_rule_blocked">ব্লক করা হয়েছে</string>
+    <string name="acc_routing_rule_routed_through">%1$s-এর মাধ্যমে রাউট করা হয়েছে</string>
+    <string name="acc_routing_rule_routed_directly">সরাসরি রাউট করা হয়েছে</string>
+    <string name="acc_routing_rule_state">নিয়মটি %1$s</string>
+    <string name="acc_routing_rule_switch_label">নিয়ম %1$s</string>
+    <string name="acc_routing_rule_on">চালু</string>
+    <string name="acc_routing_rule_off">বন্ধ</string>
+    <string name="acc_asset_announcement">%1$s। %2$s। %3$s</string>
+    <string name="acc_asset_file_size">ফাইলের আকার %1$s</string>
+    <string name="acc_asset_updated_on">আপডেট হয়েছে %1$s তারিখে</string>
+    <string name="acc_asset_announcement_missing">%1$s, %2$s</string>
+    <string name="acc_group_expanded">প্রসারিত</string>
+    <string name="acc_group_collapsed">সংকুচিত</string>
+    <string name="acc_share_named">%1$s শেয়ার করুন</string>
+    <string name="acc_edit_named">%1$s সম্পাদনা করুন</string>
+    <string name="acc_delete_named">%1$s মুছুন</string>
+    <string name="confirm_delete_policy_group_named">আপনি কি এই পলিসি গ্রুপটি মুছে ফেলতে চান?\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">আপনি কি এই প্রক্সি চেইন সদস্যটিকে মুছে ফেলতে চান?\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">আপনি কি এই রাউটিং নিয়মটি মুছে ফেলতে চান?\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">আপনি কি এই সাবস্ক্রিপশন গ্রুপটি মুছে ফেলতে চান? %1$s</string>
+    <string name="confirm_delete_asset_source_named">আপনি কি এই অ্যাসেট উৎসটি মুছে ফেলতে চান?\n%1$s</string>
     <string name="acc_share_log">লগ শেয়ার করুন</string>
     <string name="acc_remove">প্রক্সি চেইনের সদস্য সরান</string>
     <string name="acc_add_member">প্রক্সি চেইনে সদস্য যোগ করুন</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -22,6 +22,22 @@
     <string name="toast_services_stop">واڌاشتن سرویس</string>
     <string name="toast_services_success">ره وستن سرویس وا مووفقیت ٱنجوم وابی</string>
     <string name="toast_services_failure">ره وستن سرویس وا مووفقیت ٱنجوم نوابی</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="one">%1$d میلی‌ثانیه</item>
+        <item quantity="other">%1$d میلی‌ثانیه</item>
+    </plurals>
+
+    <string name="acc_share_config_named">یک رسۊوی کانفیگ %1$s</string>
+
+    <string name="acc_edit_config_named">آلشتکاری کانفیگ %1$s</string>
+
+    <string name="acc_delete_config_named">پاک کردن کانفیگ %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="one">بونکۊ %1$s، %2$d سرور منس هڌ</item>
+        <item quantity="other">بونکۊ %1$s، %2$d سرور منس هڌ</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">فایل کانفیگ</string>
@@ -46,6 +62,7 @@
     <string name="confirm_delete_duplicate_profiles">پوی کانفیگا تکراری ک هیم سکو نشووݩ داڌه ابۊن پاک ابۊن، هنی هم اخۊی پاکسووݩ کۊنی؟</string>
     <string name="confirm_delete_invalid_profiles">ٱول کانفیگا ن آزمایش کۊنین. پوی کانفیگا نا موئتبر ک هیم سکو نشووݩ داڌه ابۊن پاک ابۊن، هنی هم اخۊی پاکسووݩ کۊنی؟</string>
     <string name="confirm_delete_profile">ای کانفیگ پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
+    <string name="confirm_delete_profile_named">ای کانفیگ پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
     <string name="confirm_delete_policy_group">ای بونکۊ سیاست پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
     <string name="confirm_delete_proxy_chain_member">ای عوزو زنجیره پروکسی پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
     <string name="confirm_delete_routing_rule">ای قانووݩ تور جوستن پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
@@ -512,7 +529,7 @@
     <string name="acc_add_asset">ٱووردن بونچک فایلا جغرافیایی</string>
     <string name="acc_download_file">دانلود فایلا بونچک جغرافیایی</string>
     <string name="acc_qr_code">کود QR</string>
-    <string name="acc_copy_log">لف گیری گوزارش</string>
+    <string name="acc_copy_log">لف گیری گوزارش من ویرگا</string>
     <string name="acc_clear_log">روفتن گوزارش</string>
     <string name="acc_add_rule">ٱووردن قانووݩ</string>
     <string name="acc_start">ره وستن سرویس</string>
@@ -521,8 +538,36 @@
     <string name="acc_search">پیتینیڌن</string>
     <string name="acc_add">ٱووردن کانفیگ</string>
     <string name="acc_more">امکووݩا بؽتر</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">یک رسۊوی لینک اشتراک</string>
+    <string name="acc_last_updated">ورۊ رسۊوی نهایی %1$s</string>
+    <string name="acc_subscription_announcement">%1$s، %2$s</string>
+    <string name="acc_subscription_update_label">ورۊ کردن %1$s</string>
+    <string name="acc_app_routing_announcement">%1$s. %2$s</string>
+    <string name="acc_app_routed_directly">موستقیم ره اڌه</string>
+    <string name="acc_app_routed_through">وا برنومه ره اڌه</string>
+    <string name="acc_per_app_routing_disabled">ره وندن و ری برنومه روون نید</string>
+    <string name="acc_routing_rule_announcement">%1$s، %2$s، %3$s</string>
+    <string name="acc_routing_rule_blocked">مسدود هڌ</string>
+    <string name="acc_routing_rule_routed_through">وا %1$s ره اڌه</string>
+    <string name="acc_routing_rule_routed_directly">موستقیم ره اڌه</string>
+    <string name="acc_routing_rule_state">ای قانووݩ %1$s هڌ</string>
+    <string name="acc_routing_rule_switch_label">ای قانووݩ %1$s</string>
+    <string name="acc_routing_rule_on">روشن</string>
+    <string name="acc_routing_rule_off">خاموش</string>
+    <string name="acc_asset_announcement">%1$s. %2$s. %3$s</string>
+    <string name="acc_asset_file_size">هجم فایل %1$s</string>
+    <string name="acc_asset_updated_on">ورۊ وابیڌه من %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s، %2$s</string>
+    <string name="acc_group_expanded">وا وابیڌه</string>
+    <string name="acc_group_collapsed">بسته وابیڌه</string>
+    <string name="acc_share_named">یک رسۊوی %1$s</string>
+    <string name="acc_edit_named">آلشتکاری %1$s</string>
+    <string name="acc_delete_named">پاک کردن %1$s</string>
+    <string name="confirm_delete_policy_group_named">ای بونکۊ سیاست پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">ای عوزو زنجیره پروکسی پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">ای قانووݩ تور جوستن پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">ای بونکۊ اشتراک پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟ %1$s</string>
+    <string name="confirm_delete_asset_source_named">ای بونچک فایلا جغرافیایی پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
     <string name="acc_share_log">یک رسۊوی گوزارش</string>
     <string name="acc_remove">پاک کردن عوزو زنجیره پروکسی</string>
     <string name="acc_add_member">ٱووردن عوزو زنجیره پروکسی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -22,6 +22,22 @@
     <string name="toast_services_stop">توقف سرویس</string>
     <string name="toast_services_success">سرویس با موفقیت شروع شد</string>
     <string name="toast_services_failure">شروع سرویس با شکست مواجه شد</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="one">%1$d میلی‌ثانیه</item>
+        <item quantity="other">%1$d میلی‌ثانیه</item>
+    </plurals>
+
+    <string name="acc_share_config_named">اشتراک‌گذاری پیکربندی %1$s</string>
+
+    <string name="acc_edit_config_named">ویرایش پیکربندی %1$s</string>
+
+    <string name="acc_delete_config_named">حذف پیکربندی %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="one">گروه %1$s شامل %2$d سرور است</item>
+        <item quantity="other">گروه %1$s شامل %2$d سرور است</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">فایل کانفیگ</string>
@@ -46,6 +62,7 @@
     <string name="confirm_delete_duplicate_profiles">آیا مطمئن هستید که می‌خواهید همه پروفایل‌های تکراری نمایش‌داده‌شده را حذف کنید؟</string>
     <string name="confirm_delete_invalid_profiles">لطفاً ابتدا پروفایل‌ها را آزمایش کنید. آیا مطمئن هستید که می‌خواهید همه پروفایل‌های نامعتبر نمایش‌داده‌شده را حذف کنید؟</string>
     <string name="confirm_delete_profile">آیا مطمئن هستید که می‌خواهید این پروفایل را حذف کنید؟</string>
+    <string name="confirm_delete_profile_named">آیا مطمئن هستید که می‌خواهید این پروفایل را حذف کنید؟\n%1$s</string>
     <string name="confirm_delete_policy_group">آیا مطمئن هستید که می‌خواهید این گروه سیاست را حذف کنید؟</string>
     <string name="confirm_delete_proxy_chain_member">آیا مطمئن هستید که می‌خواهید این عضو زنجیره پراکسی را حذف کنید؟</string>
     <string name="confirm_delete_routing_rule">آیا مطمئن هستید که می‌خواهید این قانون مسیریابی را حذف کنید؟</string>
@@ -512,7 +529,7 @@
     <string name="acc_add_asset">افزودن منبع فایل‌های جغرافیایی</string>
     <string name="acc_download_file">دانلود فایل‌های منبع</string>
     <string name="acc_qr_code">کد QR</string>
-    <string name="acc_copy_log">کپی گزارش</string>
+    <string name="acc_copy_log">کپی گزارش در کلیپ‌بورد</string>
     <string name="acc_clear_log">پاک کردن گزارش</string>
     <string name="acc_add_rule">افزودن قانون مسیریابی</string>
     <string name="acc_start">شروع سرویس</string>
@@ -521,8 +538,36 @@
     <string name="acc_search">جستجو</string>
     <string name="acc_add">افزودن کانفیگ</string>
     <string name="acc_more">گزینه‌های بیشتر</string>
-    <string name="acc_selected_server">انتخاب شده</string>
     <string name="acc_share_subscription">اشتراک‌گذاری لینک اشتراک</string>
+    <string name="acc_last_updated">آخرین به‌روزرسانی %1$s</string>
+    <string name="acc_subscription_announcement">%1$s، %2$s</string>
+    <string name="acc_subscription_update_label">به‌روزرسانی %1$s</string>
+    <string name="acc_app_routing_announcement">%1$s. %2$s</string>
+    <string name="acc_app_routed_directly">به‌طور مستقیم مسیریابی می‌شود</string>
+    <string name="acc_app_routed_through">از طریق برنامه مسیریابی می‌شود</string>
+    <string name="acc_per_app_routing_disabled">مسیریابی به تفکیک برنامه فعال نیست</string>
+    <string name="acc_routing_rule_announcement">%1$s، %2$s، %3$s</string>
+    <string name="acc_routing_rule_blocked">مسدود است</string>
+    <string name="acc_routing_rule_routed_through">از طریق %1$s مسیریابی می‌شود</string>
+    <string name="acc_routing_rule_routed_directly">به‌طور مستقیم مسیریابی می‌شود</string>
+    <string name="acc_routing_rule_state">قانون %1$s است</string>
+    <string name="acc_routing_rule_switch_label">قانون %1$s</string>
+    <string name="acc_routing_rule_on">روشن</string>
+    <string name="acc_routing_rule_off">خاموش</string>
+    <string name="acc_asset_announcement">%1$s. %2$s. %3$s</string>
+    <string name="acc_asset_file_size">اندازه فایل %1$s</string>
+    <string name="acc_asset_updated_on">در %1$s به‌روزرسانی شد</string>
+    <string name="acc_asset_announcement_missing">%1$s، %2$s</string>
+    <string name="acc_group_expanded">باز</string>
+    <string name="acc_group_collapsed">بسته</string>
+    <string name="acc_share_named">اشتراک‌گذاری %1$s</string>
+    <string name="acc_edit_named">ویرایش %1$s</string>
+    <string name="acc_delete_named">حذف %1$s</string>
+    <string name="confirm_delete_policy_group_named">آیا مطمئن هستید که می‌خواهید این گروه سیاست را حذف کنید؟\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">آیا مطمئن هستید که می‌خواهید این عضو زنجیره پراکسی را حذف کنید؟\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">آیا مطمئن هستید که می‌خواهید این قانون مسیریابی را حذف کنید؟\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">آیا مطمئن هستید که می‌خواهید این گروه اشتراک را حذف کنید؟ %1$s</string>
+    <string name="confirm_delete_asset_source_named">آیا مطمئن هستید که می‌خواهید این منبع دارایی را حذف کنید؟\n%1$s</string>
     <string name="acc_share_log">اشتراک‌گذاری گزارش</string>
     <string name="acc_remove">حذف عضو زنجیره پروکسی</string>
     <string name="acc_add_member">افزودن عضو زنجیره پروکسی</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -22,6 +22,26 @@
     <string name="toast_services_stop">Остановка служб</string>
     <string name="toast_services_success">Службы успешно запущены</string>
     <string name="toast_services_failure">Сбой при запуске служб</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="one">%1$d миллисекунда</item>
+        <item quantity="few">%1$d миллисекунды</item>
+        <item quantity="many">%1$d миллисекунд</item>
+        <item quantity="other">%1$d миллисекунды</item>
+    </plurals>
+
+    <string name="acc_share_config_named">Поделиться конфигурацией %1$s</string>
+
+    <string name="acc_edit_config_named">Изменить конфигурацию %1$s</string>
+
+    <string name="acc_delete_config_named">Удалить конфигурацию %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="one">Группа %1$s содержит %2$d сервер</item>
+        <item quantity="few">Группа %1$s содержит %2$d сервера</item>
+        <item quantity="many">Группа %1$s содержит %2$d серверов</item>
+        <item quantity="other">Группа %1$s содержит %2$d серверов</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">Профиль</string>
@@ -46,6 +66,7 @@
     <string name="confirm_delete_duplicate_profiles">Удалить все отображаемые дубликаты профилей?</string>
     <string name="confirm_delete_invalid_profiles">Выполните проверку перед удалением! Удалить все отображаемые нерабочие профили?</string>
     <string name="confirm_delete_profile">Удалить этот профиль?</string>
+    <string name="confirm_delete_profile_named">Удалить этот профиль?\n%1$s</string>
     <string name="confirm_delete_policy_group">Удалить эту политику группы?</string>
     <string name="confirm_delete_proxy_chain_member">Удалить этого участника цепочки прокси?</string>
     <string name="confirm_delete_routing_rule">Удалить это правило маршрутизации?</string>
@@ -512,7 +533,7 @@
     <string name="acc_add_asset">Добавить источник ресурсов</string>
     <string name="acc_download_file">Загрузить файлы ресурсов</string>
     <string name="acc_qr_code">QR-код</string>
-    <string name="acc_copy_log">Копировать журнал</string>
+    <string name="acc_copy_log">Копировать журнал в буфер обмена</string>
     <string name="acc_clear_log">Очистить журнал</string>
     <string name="acc_add_rule">Добавить правило маршрутизации</string>
     <string name="acc_start">Запустить службу</string>
@@ -521,8 +542,36 @@
     <string name="acc_search">Поиск</string>
     <string name="acc_add">Добавить профиль</string>
     <string name="acc_more">Дополнительные параметры</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">Поделиться ссылкой на подписку</string>
+    <string name="acc_last_updated">Последнее обновление: %1$s</string>
+    <string name="acc_subscription_announcement">%1$s, %2$s</string>
+    <string name="acc_subscription_update_label">Обновление %1$s</string>
+    <string name="acc_app_routing_announcement">%1$s. %2$s</string>
+    <string name="acc_app_routed_directly">маршрутизируется напрямую</string>
+    <string name="acc_app_routed_through">маршрутизируется через приложение</string>
+    <string name="acc_per_app_routing_disabled">маршрутизация по приложениям не включена</string>
+    <string name="acc_routing_rule_announcement">%1$s, %2$s, %3$s</string>
+    <string name="acc_routing_rule_blocked">заблокировано</string>
+    <string name="acc_routing_rule_routed_through">маршрутизируется через %1$s</string>
+    <string name="acc_routing_rule_routed_directly">маршрутизируется напрямую</string>
+    <string name="acc_routing_rule_state">правило %1$s</string>
+    <string name="acc_routing_rule_switch_label">Правило %1$s</string>
+    <string name="acc_routing_rule_on">включено</string>
+    <string name="acc_routing_rule_off">выключено</string>
+    <string name="acc_asset_announcement">%1$s. %2$s. %3$s</string>
+    <string name="acc_asset_file_size">размер файла %1$s</string>
+    <string name="acc_asset_updated_on">обновлено: %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s, %2$s</string>
+    <string name="acc_group_expanded">развёрнута</string>
+    <string name="acc_group_collapsed">свёрнута</string>
+    <string name="acc_share_named">Поделиться: %1$s</string>
+    <string name="acc_edit_named">Изменить: %1$s</string>
+    <string name="acc_delete_named">Удалить: %1$s</string>
+    <string name="confirm_delete_policy_group_named">Удалить эту группу политик?\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">Удалить этого участника цепочки прокси?\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">Удалить это правило маршрутизации?\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">Удалить эту подписку? %1$s</string>
+    <string name="confirm_delete_asset_source_named">Удалить этот источник ресурсов?\n%1$s</string>
     <string name="acc_share_log">Поделиться журналом</string>
     <string name="acc_remove">Удалить участника цепочки прокси</string>
     <string name="acc_add_member">Добавить участника цепочки прокси</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -22,6 +22,20 @@
     <string name="toast_services_stop">Đã dừng v2rayNG!</string>
     <string name="toast_services_success">Đã khởi động v2rayNG!</string>
     <string name="toast_services_failure">Không thể khởi động v2rayNG, kiểm tra lại cấu hình!</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="other">%1$d mili giây</item>
+    </plurals>
+
+    <string name="acc_share_config_named">Chia sẻ cấu hình %1$s</string>
+
+    <string name="acc_edit_config_named">Chỉnh sửa cấu hình %1$s</string>
+
+    <string name="acc_delete_config_named">Xóa cấu hình %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="other">Nhóm %1$s chứa %2$d máy chủ</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">v2rayNG</string>
@@ -46,6 +60,7 @@
     <string name="confirm_delete_duplicate_profiles">Bạn có chắc muốn xóa tất cả cấu hình trùng lặp đang hiển thị không?</string>
     <string name="confirm_delete_invalid_profiles">Vui lòng kiểm tra các cấu hình trước. Bạn có chắc muốn xóa tất cả cấu hình không hợp lệ đang hiển thị không?</string>
     <string name="confirm_delete_profile">Bạn có chắc muốn xóa cấu hình này không?</string>
+    <string name="confirm_delete_profile_named">Bạn có chắc muốn xóa cấu hình này không?\n%1$s</string>
     <string name="confirm_delete_policy_group">Bạn có chắc muốn xóa nhóm chính sách này không?</string>
     <string name="confirm_delete_proxy_chain_member">Bạn có chắc muốn xóa thành viên này khỏi chuỗi proxy không?</string>
     <string name="confirm_delete_routing_rule">Bạn có chắc muốn xóa quy tắc định tuyến này không?</string>
@@ -512,7 +527,7 @@
     <string name="acc_add_asset">Thêm nguồn tệp tài nguyên</string>
     <string name="acc_download_file">Tải xuống tệp tài nguyên</string>
     <string name="acc_qr_code">Mã QR</string>
-    <string name="acc_copy_log">Sao chép nhật ký</string>
+    <string name="acc_copy_log">Sao chép nhật ký vào bộ nhớ tạm</string>
     <string name="acc_clear_log">Xóa nhật ký</string>
     <string name="acc_add_rule">Thêm quy tắc định tuyến</string>
     <string name="acc_start">Khởi động dịch vụ</string>
@@ -521,8 +536,36 @@
     <string name="acc_search">Tìm kiếm</string>
     <string name="acc_add">Thêm cấu hình</string>
     <string name="acc_more">Tùy chọn khác</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">Chia sẻ liên kết đăng ký</string>
+    <string name="acc_last_updated">Cập nhật lần cuối vào %1$s</string>
+    <string name="acc_subscription_announcement">%1$s, %2$s</string>
+    <string name="acc_subscription_update_label">Cập nhật %1$s</string>
+    <string name="acc_app_routing_announcement">%1$s. %2$s</string>
+    <string name="acc_app_routed_directly">được định tuyến trực tiếp</string>
+    <string name="acc_app_routed_through">được định tuyến qua ứng dụng</string>
+    <string name="acc_per_app_routing_disabled">định tuyến theo ứng dụng chưa được bật</string>
+    <string name="acc_routing_rule_announcement">%1$s, %2$s, %3$s</string>
+    <string name="acc_routing_rule_blocked">bị chặn</string>
+    <string name="acc_routing_rule_routed_through">được định tuyến qua %1$s</string>
+    <string name="acc_routing_rule_routed_directly">được định tuyến trực tiếp</string>
+    <string name="acc_routing_rule_state">quy tắc đang %1$s</string>
+    <string name="acc_routing_rule_switch_label">Quy tắc %1$s</string>
+    <string name="acc_routing_rule_on">bật</string>
+    <string name="acc_routing_rule_off">tắt</string>
+    <string name="acc_asset_announcement">%1$s. %2$s. %3$s</string>
+    <string name="acc_asset_file_size">kích thước tệp %1$s</string>
+    <string name="acc_asset_updated_on">đã cập nhật vào %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s, %2$s</string>
+    <string name="acc_group_expanded">mở rộng</string>
+    <string name="acc_group_collapsed">thu gọn</string>
+    <string name="acc_share_named">Chia sẻ %1$s</string>
+    <string name="acc_edit_named">Chỉnh sửa %1$s</string>
+    <string name="acc_delete_named">Xóa %1$s</string>
+    <string name="confirm_delete_policy_group_named">Bạn có chắc muốn xóa nhóm chính sách này không?\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">Bạn có chắc muốn xóa thành viên này khỏi chuỗi proxy không?\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">Bạn có chắc muốn xóa quy tắc định tuyến này không?\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">Bạn có chắc muốn xóa nhóm đăng ký này không? %1$s</string>
+    <string name="confirm_delete_asset_source_named">Bạn có chắc muốn xóa nguồn tài nguyên này không?\n%1$s</string>
     <string name="acc_share_log">Chia sẻ nhật ký</string>
     <string name="acc_remove">Xóa thành viên khỏi chuỗi proxy</string>
     <string name="acc_add_member">Thêm thành viên vào chuỗi proxy</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -22,6 +22,20 @@
     <string name="toast_services_stop">关闭服务</string>
     <string name="toast_services_success">启动服务成功</string>
     <string name="toast_services_failure">启动服务失败</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="other">%1$d 毫秒</item>
+    </plurals>
+
+    <string name="acc_share_config_named">分享配置 %1$s</string>
+
+    <string name="acc_edit_config_named">编辑配置 %1$s</string>
+
+    <string name="acc_delete_config_named">删除配置 %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="other">组 %1$s 包含 %2$d 个服务器</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">配置项</string>
@@ -46,6 +60,7 @@
     <string name="confirm_delete_duplicate_profiles">确定要删除当前显示的所有重复配置吗？</string>
     <string name="confirm_delete_invalid_profiles">请先测试配置。确定要删除当前显示的所有无效配置吗？</string>
     <string name="confirm_delete_profile">确定要删除此配置吗？</string>
+    <string name="confirm_delete_profile_named">确定要删除此配置吗？\n%1$s</string>
     <string name="confirm_delete_policy_group">确定要删除此策略组吗？</string>
     <string name="confirm_delete_proxy_chain_member">确定要删除此代理链成员吗？</string>
     <string name="confirm_delete_routing_rule">确定要删除此路由规则吗？</string>
@@ -512,7 +527,7 @@
     <string name="acc_add_asset">添加资源来源</string>
     <string name="acc_download_file">下载资源文件</string>
     <string name="acc_qr_code">二维码</string>
-    <string name="acc_copy_log">复制日志</string>
+    <string name="acc_copy_log">将日志复制到剪贴板</string>
     <string name="acc_clear_log">清除日志</string>
     <string name="acc_add_rule">添加路由规则</string>
     <string name="acc_start">启动服务</string>
@@ -521,8 +536,36 @@
     <string name="acc_search">搜索</string>
     <string name="acc_add">添加配置</string>
     <string name="acc_more">更多选项</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">分享订阅链接</string>
+    <string name="acc_last_updated">上次更新：%1$s</string>
+    <string name="acc_subscription_announcement">%1$s，%2$s</string>
+    <string name="acc_subscription_update_label">%1$s 更新</string>
+    <string name="acc_app_routing_announcement">%1$s。%2$s</string>
+    <string name="acc_app_routed_directly">直接路由</string>
+    <string name="acc_app_routed_through">通过应用路由</string>
+    <string name="acc_per_app_routing_disabled">未启用分应用路由</string>
+    <string name="acc_routing_rule_announcement">%1$s，%2$s，%3$s</string>
+    <string name="acc_routing_rule_blocked">已拦截</string>
+    <string name="acc_routing_rule_routed_through">通过 %1$s 路由</string>
+    <string name="acc_routing_rule_routed_directly">直接路由</string>
+    <string name="acc_routing_rule_state">规则%1$s</string>
+    <string name="acc_routing_rule_switch_label">规则%1$s</string>
+    <string name="acc_routing_rule_on">开启</string>
+    <string name="acc_routing_rule_off">关闭</string>
+    <string name="acc_asset_announcement">%1$s。%2$s。%3$s</string>
+    <string name="acc_asset_file_size">文件大小 %1$s</string>
+    <string name="acc_asset_updated_on">更新于 %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s，%2$s</string>
+    <string name="acc_group_expanded">展开</string>
+    <string name="acc_group_collapsed">折叠</string>
+    <string name="acc_share_named">分享%1$s</string>
+    <string name="acc_edit_named">编辑%1$s</string>
+    <string name="acc_delete_named">删除%1$s</string>
+    <string name="confirm_delete_policy_group_named">确定要删除此策略组吗？\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">确定要删除此代理链成员吗？\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">确定要删除此路由规则吗？\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">确定要删除此订阅组吗？%1$s</string>
+    <string name="confirm_delete_asset_source_named">确定要删除此资源来源吗？\n%1$s</string>
     <string name="acc_share_log">分享日志</string>
     <string name="acc_remove">移除代理链成员</string>
     <string name="acc_add_member">添加代理链成员</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -22,6 +22,20 @@
     <string name="toast_services_stop">停止服務</string>
     <string name="toast_services_success">啟動服務成功</string>
     <string name="toast_services_failure">啟動服務失敗</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="other">%1$d 毫秒</item>
+    </plurals>
+
+    <string name="acc_share_config_named">分享設定 %1$s</string>
+
+    <string name="acc_edit_config_named">編輯設定 %1$s</string>
+
+    <string name="acc_delete_config_named">刪除設定 %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="other">群組 %1$s 包含 %2$d 個伺服器</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">設定檔</string>
@@ -46,6 +60,7 @@
     <string name="confirm_delete_duplicate_profiles">確定要刪除目前顯示的所有重複設定檔嗎？</string>
     <string name="confirm_delete_invalid_profiles">請先測試設定檔。確定要刪除目前顯示的所有無效設定檔嗎？</string>
     <string name="confirm_delete_profile">確定要刪除此設定檔嗎？</string>
+    <string name="confirm_delete_profile_named">確定要刪除此設定檔嗎？\n%1$s</string>
     <string name="confirm_delete_policy_group">確定要刪除此策略組嗎？</string>
     <string name="confirm_delete_proxy_chain_member">確定要刪除此代理鏈成員嗎？</string>
     <string name="confirm_delete_routing_rule">確定要刪除此路由規則嗎？</string>
@@ -512,7 +527,7 @@
     <string name="acc_add_asset">新增資源來源</string>
     <string name="acc_download_file">下載資源檔案</string>
     <string name="acc_qr_code">QR Code</string>
-    <string name="acc_copy_log">複製日誌</string>
+    <string name="acc_copy_log">將日誌複製到剪貼簿</string>
     <string name="acc_clear_log">清除日誌</string>
     <string name="acc_add_rule">新增路由規則</string>
     <string name="acc_start">啟動服務</string>
@@ -521,8 +536,36 @@
     <string name="acc_search">搜尋</string>
     <string name="acc_add">新增設定</string>
     <string name="acc_more">更多選項</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">分享訂閱連結</string>
+    <string name="acc_last_updated">上次更新：%1$s</string>
+    <string name="acc_subscription_announcement">%1$s，%2$s</string>
+    <string name="acc_subscription_update_label">%1$s 更新</string>
+    <string name="acc_app_routing_announcement">%1$s。%2$s</string>
+    <string name="acc_app_routed_directly">直接路由</string>
+    <string name="acc_app_routed_through">透過應用程式路由</string>
+    <string name="acc_per_app_routing_disabled">未啟用個別應用程式路由</string>
+    <string name="acc_routing_rule_announcement">%1$s，%2$s，%3$s</string>
+    <string name="acc_routing_rule_blocked">已封鎖</string>
+    <string name="acc_routing_rule_routed_through">透過 %1$s 路由</string>
+    <string name="acc_routing_rule_routed_directly">直接路由</string>
+    <string name="acc_routing_rule_state">規則%1$s</string>
+    <string name="acc_routing_rule_switch_label">規則%1$s</string>
+    <string name="acc_routing_rule_on">開啟</string>
+    <string name="acc_routing_rule_off">關閉</string>
+    <string name="acc_asset_announcement">%1$s。%2$s。%3$s</string>
+    <string name="acc_asset_file_size">檔案大小 %1$s</string>
+    <string name="acc_asset_updated_on">更新於 %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s，%2$s</string>
+    <string name="acc_group_expanded">展開</string>
+    <string name="acc_group_collapsed">收合</string>
+    <string name="acc_share_named">分享%1$s</string>
+    <string name="acc_edit_named">編輯%1$s</string>
+    <string name="acc_delete_named">刪除%1$s</string>
+    <string name="confirm_delete_policy_group_named">確定要刪除此策略組嗎？\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">確定要刪除此代理鏈成員嗎？\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">確定要刪除此路由規則嗎？\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">確定要刪除此訂閱群組嗎？%1$s</string>
+    <string name="confirm_delete_asset_source_named">確定要刪除此資源來源嗎？\n%1$s</string>
     <string name="acc_share_log">分享日誌</string>
     <string name="acc_remove">移除代理鏈成員</string>
     <string name="acc_add_member">新增代理鏈成員</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -22,6 +22,22 @@
     <string name="toast_services_stop">Stopping service</string>
     <string name="toast_services_success">Service started successfully</string>
     <string name="toast_services_failure">Failed to start service</string>
+    <!-- Compose accessibility resources -->
+    <plurals name="server_test_delay_accessibility_value">
+        <item quantity="one">%1$d millisecond</item>
+        <item quantity="other">%1$d milliseconds</item>
+    </plurals>
+
+    <string name="acc_share_config_named">Share config %1$s</string>
+
+    <string name="acc_edit_config_named">Edit config %1$s</string>
+
+    <string name="acc_delete_config_named">Delete config %1$s</string>
+
+    <plurals name="acc_group_tab">
+        <item quantity="one">Group %1$s contains %2$d server</item>
+        <item quantity="other">Group %1$s contains %2$d servers</item>
+    </plurals>
 
     <!--ServerActivity-->
     <string name="title_server">Config</string>
@@ -46,6 +62,7 @@
     <string name="confirm_delete_duplicate_profiles">Are you sure you want to delete all duplicate profiles currently shown?</string>
     <string name="confirm_delete_invalid_profiles">Please test the profiles first. Are you sure you want to delete all invalid profiles currently shown?</string>
     <string name="confirm_delete_profile">Are you sure you want to delete this profile?</string>
+    <string name="confirm_delete_profile_named">Are you sure you want to delete this profile?\n%1$s</string>
     <string name="confirm_delete_policy_group">Are you sure you want to delete this policy group?</string>
     <string name="confirm_delete_proxy_chain_member">Are you sure you want to delete this chain member?</string>
     <string name="confirm_delete_routing_rule">Are you sure you want to delete this routing rule?</string>
@@ -512,7 +529,7 @@
     <string name="acc_add_asset">Add asset source</string>
     <string name="acc_download_file">Download asset files</string>
     <string name="acc_qr_code">QR code</string>
-    <string name="acc_copy_log">Copy log</string>
+    <string name="acc_copy_log">Copy log to clipboard</string>
     <string name="acc_clear_log">Clear log</string>
     <string name="acc_add_rule">Add routing rule</string>
     <string name="acc_start">Start service</string>
@@ -521,8 +538,36 @@
     <string name="acc_search">Search</string>
     <string name="acc_add">Add configuration</string>
     <string name="acc_more">More options</string>
-    <string name="acc_selected_server">Selected</string>
     <string name="acc_share_subscription">Share subscription link</string>
+    <string name="acc_last_updated">Last updated %1$s</string>
+    <string name="acc_subscription_announcement">%1$s, %2$s</string>
+    <string name="acc_subscription_update_label">%1$s update</string>
+    <string name="acc_app_routing_announcement">%1$s. %2$s</string>
+    <string name="acc_app_routed_directly">routed directly</string>
+    <string name="acc_app_routed_through">routed through the app</string>
+    <string name="acc_per_app_routing_disabled">per-app routing is not enabled</string>
+    <string name="acc_routing_rule_announcement">%1$s, %2$s, %3$s</string>
+    <string name="acc_routing_rule_blocked">is blocked</string>
+    <string name="acc_routing_rule_routed_through">routed through %1$s</string>
+    <string name="acc_routing_rule_routed_directly">routed directly</string>
+    <string name="acc_routing_rule_state">the rule is %1$s</string>
+    <string name="acc_routing_rule_switch_label">Rule %1$s</string>
+    <string name="acc_routing_rule_on">on</string>
+    <string name="acc_routing_rule_off">off</string>
+    <string name="acc_asset_announcement">%1$s. %2$s. %3$s</string>
+    <string name="acc_asset_file_size">file size %1$s</string>
+    <string name="acc_asset_updated_on">updated on %1$s</string>
+    <string name="acc_asset_announcement_missing">%1$s, %2$s</string>
+    <string name="acc_group_expanded">expanded</string>
+    <string name="acc_group_collapsed">collapsed</string>
+    <string name="acc_share_named">Share %1$s</string>
+    <string name="acc_edit_named">Edit %1$s</string>
+    <string name="acc_delete_named">Delete %1$s</string>
+    <string name="confirm_delete_policy_group_named">Are you sure you want to delete this policy group?\n%1$s</string>
+    <string name="confirm_delete_proxy_chain_member_named">Are you sure you want to delete this chain member?\n%1$s</string>
+    <string name="confirm_delete_routing_rule_named">Are you sure you want to delete this routing rule?\n%1$s</string>
+    <string name="confirm_delete_subscription_group_named">Are you sure you want to delete this subscription group? %1$s</string>
+    <string name="confirm_delete_asset_source_named">Are you sure you want to delete this asset source?\n%1$s</string>
     <string name="acc_share_log">Share log</string>
     <string name="acc_remove">Remove proxy chain member</string>
     <string name="acc_add_member">Add proxy chain member</string>

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/perappproxy/PerAppAccessibilityTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/perappproxy/PerAppAccessibilityTest.kt
@@ -1,0 +1,44 @@
+package com.v2ray.ang.ui.perappproxy
+
+import com.v2ray.ang.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PerAppAccessibilityTest {
+
+    @Test
+    fun disabledPerAppRoutingOverridesSelectionAndMode() {
+        listOf(false, true).forEach { bypassApps ->
+            listOf(false, true).forEach { checked ->
+                assertEquals(
+                    R.string.acc_per_app_routing_disabled,
+                    perAppRoutingDescription(false, bypassApps, checked)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun proxyModeRoutesCheckedAppsThroughApp() {
+        assertEquals(
+            R.string.acc_app_routed_directly,
+            perAppRoutingDescription(true, bypassApps = false, checked = false)
+        )
+        assertEquals(
+            R.string.acc_app_routed_through,
+            perAppRoutingDescription(true, bypassApps = false, checked = true)
+        )
+    }
+
+    @Test
+    fun bypassModeRoutesCheckedAppsDirectly() {
+        assertEquals(
+            R.string.acc_app_routed_through,
+            perAppRoutingDescription(true, bypassApps = true, checked = false)
+        )
+        assertEquals(
+            R.string.acc_app_routed_directly,
+            perAppRoutingDescription(true, bypassApps = true, checked = true)
+        )
+    }
+}


### PR DESCRIPTION
## Status

This draft has been rebuilt directly on current `upstream/master` (`13138ddd`, v2.3.6). Its history is now one accessibility-only commit: `17312c04`.

The obsolete pre-merge #6105/service-transition commits are no longer part of this branch. The merged #6105 group paging and #6107 server-row model architecture are inherited from upstream rather than replayed here.

## Summary

- Improve TalkBack semantics for subscriptions, routing rules, asset files, settings, per-app routing, server rows, group tabs, dialogs, actions, confirmations, and important transient results.
- Keep secondary details such as subscription URLs and package IDs out of merged row announcements while retaining useful localized dates, plurals, routing context, named actions, and named deletion confirmations.
- Use genuine Compose clickable, toggleable, selectable, checkbox, switch, radio-button, and tab semantics instead of rebuilding control roles, state, and actions by hand.
- Keep disabled settings as native disabled controls and group each row into one logical accessibility target.
- Remove accessibility-focus restoration and direct `TYPE_ANNOUNCEMENT` dispatch. Important foreground transient results use a polite Compose live region while the visual Snackbar/Toast surface remains outside accessibility navigation.
- Keep all introduced accessibility resources aligned across the nine maintained catalogs.

## Upstream conflict resolution

- Preserved #6107's `ServerRowUiModel` and row-action architecture; the delete action passes the existing `ProfileItem` only so the confirmation can retain the server name.
- Preserved upstream's service lifecycle and restart behavior; no service-transition implementation files are included in this PR.
- Adapted selected server rows, group tabs, and connection-test output to native selectable/state semantics without reintroducing focus manipulation.
- Retained the merged #6105 one-final-result connection-test flow while keeping an immediate localized Testing state and localized plural delay units for accessibility.

## Accessibility implementation policy

The branch now follows the official Android/Compose approach described in the detailed policy comment below: expose correct labels, roles, states, actions, grouping, and enabled/disabled status, then let the accessibility service choose spoken order. Native role announcements are retained even when TalkBack appends words such as “switch”, “radio button”, or “tab” at the end.

This remains a broad consolidation draft. The next publication step is to split its independently reviewable behavior into smaller focused PRs without reintroducing the discarded semantic workarounds.

## Validation

- `:app:processPlaystoreDebugResources`
- `:app:compilePlaystoreDebugKotlin`
- full `:app:testPlaystoreDebugUnitTest`
- all 39 current changed resources present in every maintained locale catalog
- merge-marker, obsolete focus/announcement symbol, service-scope, and `git diff --check` audits