### PR TITLE
Improve service controls for Android TV

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -39,6 +39,7 @@ fun MainBottomBar(
     displayText: String,
     isRunning: Boolean,
     isDarkTheme: Boolean,
+    showServiceToggle: Boolean,
     onAction: (MainAction) -> Unit
 ) {
     Box(modifier = Modifier.fillMaxWidth()) {
@@ -67,26 +68,28 @@ fun MainBottomBar(
                 )
             }
         }
-        FloatingActionButton(
-            onClick = { onAction(MainAction.ToggleService) },
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(end = 24.dp)
-                .offset(y = (-28).dp)
-                .navigationBarsPadding(),
-            containerColor = if (isRunning) colorFabActive
-            else if (isDarkTheme) colorFabInactiveDark
-            else colorFabInactiveLight
-        ) {
-            Icon(
-                painter = if (isRunning) painterResource(R.drawable.ic_stop_24dp)
-                else painterResource(R.drawable.ic_play_24dp),
-                contentDescription = stringResource(
-                    if (isRunning) R.string.acc_stop else R.string.acc_start
-                ),
-                tint = Color.White,
-                modifier = Modifier.size(24.dp)
-            )
+        if (showServiceToggle) {
+            FloatingActionButton(
+                onClick = { onAction(MainAction.ToggleService) },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(end = 24.dp)
+                    .offset(y = (-28).dp)
+                    .navigationBarsPadding(),
+                containerColor = if (isRunning) colorFabActive
+                else if (isDarkTheme) colorFabInactiveDark
+                else colorFabInactiveLight
+            ) {
+                Icon(
+                    painter = if (isRunning) painterResource(R.drawable.ic_stop_24dp)
+                    else painterResource(R.drawable.ic_play_24dp),
+                    contentDescription = stringResource(
+                        if (isRunning) R.string.acc_stop else R.string.acc_start
+                    ),
+                    tint = Color.White,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
         }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -1,5 +1,7 @@
 package com.v2ray.ang.ui.main
 
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,6 +26,8 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -44,6 +48,10 @@ fun MainScreen(
     val groups = uiState.groups
     val isLoading by mainViewModel.isLoading.collectAsStateWithLifecycle()
     val isRunning = uiState.isRunning
+    val context = LocalContext.current
+    val uiModeType = LocalConfiguration.current.uiMode and Configuration.UI_MODE_TYPE_MASK
+    val isTelevision = uiModeType == Configuration.UI_MODE_TYPE_TELEVISION ||
+        context.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
     val displayText = mainViewModel.formatStatus(uiState.status)
     val selectedGuid = uiState.selectedGuid
     val doubleColumnDisplay = uiState.doubleColumnDisplay
@@ -202,6 +210,8 @@ fun MainScreen(
             topBar = {
                 MainTopBar(
                     isLoading = isLoading,
+                    isRunning = isRunning,
+                    showServiceToggle = isTelevision,
                     showSearch = showSearch,
                     searchQuery = searchQuery,
                     onSearchQueryChange = { query: String ->
@@ -237,6 +247,7 @@ fun MainScreen(
                     displayText = displayText,
                     isRunning = isRunning,
                     isDarkTheme = isDarkTheme,
+                    showServiceToggle = !isTelevision,
                     onAction = onAction
                 )
             },

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
@@ -30,6 +30,8 @@ import com.v2ray.ang.ui.compose.verticalScrollbar
 @Composable
 fun MainTopBar(
     isLoading: Boolean,
+    isRunning: Boolean,
+    showServiceToggle: Boolean,
     showSearch: Boolean,
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
@@ -71,6 +73,18 @@ fun MainTopBar(
             if (!showSearch) {
                 IconButton(onClick = { onSearchToggle(true) }) {
                     Icon(painterResource(R.drawable.ic_search_24dp), contentDescription = stringResource(R.string.acc_search))
+                }
+            }
+            if (showServiceToggle) {
+                IconButton(onClick = { onAction(MainAction.ToggleService) }) {
+                    Icon(
+                        painter = painterResource(
+                            if (isRunning) R.drawable.ic_stop_24dp else R.drawable.ic_play_24dp
+                        ),
+                        contentDescription = stringResource(
+                            if (isRunning) R.string.acc_stop else R.string.acc_start
+                        )
+                    )
                 }
             }
             Box(modifier = Modifier.wrapContentSize(Alignment.TopEnd)) {


### PR DESCRIPTION
## Summary

- detect television devices using the masked UI mode type or `FEATURE_LEANBACK`
- place the start/stop service action in the top app bar on TV devices so it is reachable with a D-pad
- keep the existing floating action button unchanged on non-TV devices

## Motivation

On some Android TV devices and projectors, the floating service button cannot be reached using the remote control. Moving the same action next to the add button for TV layouts makes service control accessible without introducing a separate UI.

## Testing

- built and installed the F-Droid variant on a JMGO N1 Pro projector
- verified D-pad focus and start/stop behavior
- verified the non-TV floating action button remains selected by the existing layout path