### PR TITLE
Isolate and optimize RealDelay probing without library changes

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -259,7 +259,7 @@
             android:name=".service.CoreTestService"
             android:exported="false"
             android:foregroundServiceType="specialUse"
-            android:process=":RunSoLibV2RayDaemon">
+            android:process=":Probe">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="test" />
@@ -269,7 +269,7 @@
             android:name=".service.SubscriptionUpdateService"
             android:exported="false"
             android:foregroundServiceType="specialUse"
-            android:process=":RunSoLibV2RayDaemon">
+            android:process=":SubscriptionUpdate">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="test" />

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingBatchStatus.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingBatchStatus.kt
@@ -1,0 +1,26 @@
+package com.v2ray.ang.dto
+
+import java.io.Serializable
+
+/** One persisted delay-test result delivered from the probe process to the UI. */
+data class RealPingResult(
+    val testId: String,
+    val guid: String,
+    val delayMillis: Long,
+) : Serializable
+
+/** Completed profile count for one active delay-test batch. */
+data class RealPingProgress(
+    val testId: String,
+    val completed: Int,
+    val total: Int,
+) : Serializable
+
+/** Terminal result for one delay-test batch. */
+data class RealPingSummary(
+    val testId: String,
+    val live: Int,
+    val total: Int,
+    val cancelled: Boolean,
+    val listChanged: Boolean = false,
+) : Serializable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingEvent.kt
@@ -3,12 +3,16 @@ package com.v2ray.ang.dto
 sealed class RealPingEvent {
 
     /** Periodic progress update while the batch is still running. */
-    data class Progress(val text: String) : RealPingEvent()
+    data class Progress(val completed: Int, val total: Int) : RealPingEvent()
 
     /** A single server result is available. */
     data class Result(val guid: String, val delayMillis: Long) : RealPingEvent()
 
-    /** The entire batch has finished or been cancelled. */
-    data class Finish(val status: String) : RealPingEvent()
+    /** Terminal counts for the batch. */
+    data class Finish(
+        val live: Int,
+        val completed: Int,
+        val total: Int,
+    ) : RealPingEvent()
 }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/TestServiceMessage.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/TestServiceMessage.kt
@@ -6,7 +6,8 @@ data class TestServiceMessage(
     val key: Int,
     val testId: String = "",
     val subscriptionId: String = "",
-    val serverGuids: List<String> = emptyList(),
+    val serverGuids: List<String>? = null,
+    val excludedServerGuids: List<String> = emptyList(),
     val onlyTcp: Boolean = false
 ) : Serializable
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/TestServiceMessage.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/TestServiceMessage.kt
@@ -4,6 +4,7 @@ import java.io.Serializable
 
 data class TestServiceMessage(
     val key: Int,
+    val testId: String = "",
     val subscriptionId: String = "",
     val serverGuids: List<String> = emptyList(),
     val onlyTcp: Boolean = false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -4,12 +4,18 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
+import android.os.Process
 import androidx.core.app.NotificationCompat
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreNativeManager
 import com.v2ray.ang.dto.RealPingEvent
+import com.v2ray.ang.dto.RealPingProgress
+import com.v2ray.ang.dto.RealPingResult
+import com.v2ray.ang.dto.RealPingSummary
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.enums.NotificationChannelType
 import com.v2ray.ang.extension.serializable
@@ -19,78 +25,68 @@ import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.helper.NotificationHelper
 import com.v2ray.ang.util.LogUtil
-import java.util.Collections
 
 class CoreTestService : Service() {
+    @Volatile
+    private var activeWorker: RealPingWorkerService? = null
+
+    @Volatile
+    private var activeMessage: TestServiceMessage? = null
+
+    @Volatile
+    private var suppressWorkerEvents = false
+
+    private val terminalLock = Any()
+    private var batchStarted = false
 
     override fun attachBaseContext(newBase: Context?) {
         super.attachBaseContext(newBase?.let(AppLocaleManager::localizedContext))
     }
 
-    // manage active batch workers so each batch is independent and cancellable
-    private val activeWorkers = Collections.synchronizedList(mutableListOf<RealPingWorkerService>())
     private val cancelAction by lazy {
         val intent = Intent(this, CoreTestService::class.java).putExtra(
             "content",
-            TestServiceMessage(AppConfig.MSG_MEASURE_CONFIG_CANCEL)
+            TestServiceMessage(AppConfig.MSG_MEASURE_CONFIG_CANCEL),
         )
         val pendingIntent = PendingIntent.getService(
             this,
             NotificationChannelType.CORE_TEST.notificationId,
             intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
         NotificationCompat.Action.Builder(
             R.drawable.ic_stop_24dp,
             getString(R.string.action_cancel),
-            pendingIntent
+            pendingIntent,
         ).build()
     }
 
-    /**
-     * Initializes the V2Ray environment.
-     */
     override fun onCreate() {
         super.onCreate()
         CoreNativeManager.initCoreEnv(this)
     }
 
-    /**
-     * Binds the service.
-     * @param intent The intent.
-     * @return The binder.
-     */
-    override fun onBind(intent: Intent?): IBinder? {
-        return null
-    }
+    override fun onBind(intent: Intent?): IBinder? = null
 
-    /**
-     * Cleans up resources when the service is destroyed.
-     */
     override fun onDestroy() {
-        LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed, cancelling ${activeWorkers.size} active workers")
-        // cancel any active workers
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
+        LogUtil.i(AppConfig.TAG, "CoreTestService is being destroyed")
+        suppressWorkerEvents = true
+        activeWorker?.cancel()
+        activeWorker = null
+        activeMessage = null
         NotificationHelper.stopForeground(this)
         super.onDestroy()
+        // Xray owns process-wide dialer state. Do not reuse this process after a batch.
+        disposeProcess()
     }
 
-    /**
-     * Handles the start command for the service.
-     * @param intent The intent.
-     * @param flags The flags.
-     * @param startId The start ID.
-     * @return The start mode.
-     */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         NotificationHelper.startForeground(
             this,
             NotificationChannelType.CORE_TEST,
             getString(R.string.app_name),
             getString(R.string.title_real_ping_all_server),
-            cancelAction
+            cancelAction,
         )
         val message = intent?.serializable<TestServiceMessage>("content")
         if (message == null) {
@@ -98,86 +94,162 @@ class CoreTestService : Service() {
             return START_NOT_STICKY
         }
 
-        when (message.key) {
+        return when (message.key) {
             AppConfig.MSG_MEASURE_CONFIG_START -> handleMeasureStart(message, startId)
-            AppConfig.MSG_MEASURE_CONFIG_CANCEL -> handleMeasureCancel()
+            AppConfig.MSG_MEASURE_CONFIG_CANCEL -> handleMeasureCancel(startId)
             else -> {
-                NotificationHelper.stopForeground(this); stopSelf(startId)
+                NotificationHelper.stopForeground(this)
+                stopSelf(startId)
+                START_NOT_STICKY
             }
         }
-        return START_NOT_STICKY
     }
 
-    private fun handleMeasureStart(message: TestServiceMessage, startId: Int) {
-        LogUtil.i(AppConfig.TAG, "CoreTestService starting worker   subscription ${message.subscriptionId}")
+    private fun handleMeasureStart(message: TestServiceMessage, startId: Int): Int {
+        if (batchStarted) {
+            // Never let two per-profile worker pools multiply the configured limit.
+            // Redeliver only the newest request after this disposable process exits.
+            synchronized(terminalLock) {
+                suppressWorkerEvents = true
+                activeWorker?.cancel()
+            }
+            LogUtil.i(AppConfig.TAG, "CoreTestService handing replacement batch to a fresh process")
+            disposeProcess()
+            return START_REDELIVER_INTENT
+        }
+        batchStarted = true
+        activeMessage = message
 
-        val guidsList = when {
+        val guids = when {
             message.serverGuids.isNotEmpty() -> message.serverGuids
             message.subscriptionId.isNotEmpty() -> MmkvManager.decodeServerList(message.subscriptionId)
             else -> MmkvManager.decodeAllServerList()
-        }
+        }.distinct()
 
-        if (guidsList.isNotEmpty()) {
-            lateinit var worker: RealPingWorkerService
-            worker = RealPingWorkerService(
-                context = this,
-                guids = guidsList,
-                onlyTcp = message.onlyTcp,
-                onEvent = { event -> handleWorkerEvent(event, message) { activeWorkers.remove(worker) } }
+        if (guids.isEmpty()) {
+            sendSummary(
+                RealPingSummary(
+                    testId = message.testId,
+                    live = 0,
+                    total = 0,
+                    cancelled = false,
+                ),
             )
-            activeWorkers.add(worker)
-            worker.start()
-        } else {
             NotificationHelper.stopForeground(this)
             stopSelf(startId)
+            return START_NOT_STICKY
         }
+
+        LogUtil.i(AppConfig.TAG, "CoreTestService starting ${guids.size} probes")
+        activeWorker = RealPingWorkerService(
+            context = this,
+            guids = guids,
+            onlyTcp = message.onlyTcp,
+            onEvent = ::handleWorkerEvent,
+        ).also { it.start() }
+        return START_NOT_STICKY
     }
 
-    private fun handleWorkerEvent(event: RealPingEvent, message: TestServiceMessage, onWorkerDone: () -> Unit) {
+    private fun handleMeasureCancel(startId: Int): Int {
+        LogUtil.i(AppConfig.TAG, "CoreTestService cancelling the active batch")
+        synchronized(terminalLock) {
+            suppressWorkerEvents = true
+            val message = activeMessage
+            val summary = activeWorker?.cancel()
+            activeWorker = null
+            activeMessage = null
+            if (message != null && summary != null) {
+                sendSummary(
+                    RealPingSummary(
+                        testId = message.testId,
+                        live = summary.live,
+                        total = summary.total,
+                        cancelled = true,
+                    ),
+                )
+            }
+        }
+        NotificationHelper.stopForeground(this)
+        stopSelf(startId)
+        return START_NOT_STICKY
+    }
+
+    private fun handleWorkerEvent(event: RealPingEvent) {
+        if (suppressWorkerEvents) return
+        val message = activeMessage ?: return
         when (event) {
             is RealPingEvent.Progress -> {
+                val progressText = "${event.completed} / ${event.total}"
                 NotificationHelper.updateNotification(
                     channelType = NotificationChannelType.CORE_TEST,
                     context = this,
                     title = getString(R.string.app_name),
-                    content = getString(R.string.connection_running_task_left, event.text)
+                    content = getString(R.string.connection_running_task_left, progressText),
                 )
-                MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_NOTIFY, event.text)
+                MessageHelper.sendMsg2UI(
+                    this,
+                    AppConfig.MSG_MEASURE_CONFIG_NOTIFY,
+                    RealPingProgress(message.testId, event.completed, event.total),
+                )
             }
 
             is RealPingEvent.Result -> {
                 MmkvManager.encodeServerTestDelayMillis(event.guid, event.delayMillis)
-                MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, event.guid)
+                MessageHelper.sendMsg2UI(
+                    this,
+                    AppConfig.MSG_MEASURE_CONFIG_SUCCESS,
+                    RealPingResult(message.testId, event.guid, event.delayMillis),
+                )
             }
 
-            is RealPingEvent.Finish -> {
-                if (message.subscriptionId.isNotEmpty()) {
-                    if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST, false)) {
-                        AngConfigManager.removeInvalidServer(message.subscriptionId)
-                    }
-
-                    if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST, false)) {
-                        AngConfigManager.sortByTestResultsForSub(message.subscriptionId)
-                    }
-                }
-
-                MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, event.status)
-                onWorkerDone()
-                if (activeWorkers.isEmpty()) {
-                    NotificationHelper.stopForeground(this)
-                    stopSelf()
+            is RealPingEvent.Finish -> synchronized(terminalLock) {
+                if (!suppressWorkerEvents && activeMessage == message) {
+                    finishBatch(message, event)
                 }
             }
         }
     }
 
-    private fun handleMeasureCancel() {
-        MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, "0")
-        LogUtil.i(AppConfig.TAG, "CoreTestService received cancel message, cancelling ${activeWorkers.size} active workers")
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
+    private fun finishBatch(message: TestServiceMessage, event: RealPingEvent.Finish) {
+        val autoRemove = message.subscriptionId.isNotEmpty() &&
+                MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST, false)
+        val autoSort = message.subscriptionId.isNotEmpty() &&
+                MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST, false)
+        val listBefore = if (autoRemove || autoSort) {
+            MmkvManager.decodeServerList(message.subscriptionId)
+        } else {
+            emptyList()
+        }
+        if (autoRemove) {
+            AngConfigManager.removeInvalidServer(message.subscriptionId)
+        }
+        if (autoSort) {
+            AngConfigManager.sortByTestResultsForSub(message.subscriptionId)
+        }
+        val listChanged = (autoRemove || autoSort) &&
+                listBefore != MmkvManager.decodeServerList(message.subscriptionId)
+
+        sendSummary(
+            RealPingSummary(
+                testId = message.testId,
+                live = event.live,
+                total = event.total,
+                cancelled = false,
+                listChanged = listChanged,
+            ),
+        )
+        suppressWorkerEvents = true
+        activeWorker = null
+        activeMessage = null
         NotificationHelper.stopForeground(this)
         stopSelf()
+    }
+
+    private fun sendSummary(summary: RealPingSummary) {
+        MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_FINISH, summary)
+    }
+
+    private fun disposeProcess() {
+        Handler(Looper.getMainLooper()).post { Process.killProcess(Process.myPid()) }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -120,11 +120,13 @@ class CoreTestService : Service() {
         batchStarted = true
         activeMessage = message
 
-        val guids = when {
-            message.serverGuids.isNotEmpty() -> message.serverGuids
+        val requestedGuids = when {
+            message.serverGuids != null -> message.serverGuids
             message.subscriptionId.isNotEmpty() -> MmkvManager.decodeServerList(message.subscriptionId)
             else -> MmkvManager.decodeAllServerList()
-        }.distinct()
+        }
+        val excludedGuids = message.excludedServerGuids.toHashSet()
+        val guids = requestedGuids.distinct().filterNot(excludedGuids::contains)
 
         if (guids.isEmpty()) {
             sendSummary(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/RealPingWorkerService.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.service
 
 import android.content.Context
+import android.os.SystemClock
 import com.v2ray.ang.core.CoreConfigManager
 import com.v2ray.ang.core.CoreNativeManager
 import com.v2ray.ang.dto.RealPingEvent
@@ -13,15 +14,15 @@ import com.v2ray.ang.handler.SpeedtestManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.isActive
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal object RealPingExecutionLimiter {
     private val customConfigMutex = Mutex()
@@ -38,76 +39,84 @@ internal object RealPingExecutionLimiter {
     }
 }
 
-/**
- * Worker that runs a batch of real-ping tests independently.
- * Each batch owns its own CoroutineScope/dispatcher and can be cancelled separately.
- */
+private class RealPingProgressState(private val total: Int) {
+    private var completed = 0
+    private var live = 0
+    private var lastProgressAt = SystemClock.elapsedRealtime()
+
+    @Synchronized
+    fun record(delayMillis: Long): RealPingEvent.Progress? {
+        if (completed >= total) return null
+        completed++
+        if (delayMillis >= 0L) live++
+
+        val now = SystemClock.elapsedRealtime()
+        if (completed < total && now - lastProgressAt < PROGRESS_UPDATE_INTERVAL_MS) return null
+        lastProgressAt = now
+        return RealPingEvent.Progress(completed = completed, total = total)
+    }
+
+    @Synchronized
+    fun summary(): RealPingEvent.Finish = RealPingEvent.Finish(
+        live = live,
+        completed = completed,
+        total = total,
+    )
+
+    private companion object {
+        const val PROGRESS_UPDATE_INTERVAL_MS = 100L
+    }
+}
+
+/** Runs one bounded batch of individual delay tests in the disposable probe process. */
 class RealPingWorkerService(
     private val context: Context,
-    private val guids: List<String>,
+    guids: List<String>,
     private val onlyTcp: Boolean = false,
-    private val onEvent: (RealPingEvent) -> Unit = {}
+    private val onEvent: (RealPingEvent) -> Unit = {},
 ) {
+    private val guids = guids.distinct()
     private val job = SupervisorJob()
-    private val concurrency = SettingsManager.getRealPingConcurrency()
-    private val dispatcher = Executors.newFixedThreadPool(if (onlyTcp) concurrency * 2 else concurrency).asCoroutineDispatcher()
+    private val dispatcher = Dispatchers.IO.limitedParallelism(SettingsManager.getRealPingConcurrency())
     private val scope = CoroutineScope(job + dispatcher + CoroutineName("RealPingBatchWorker"))
-
-    private val runningCount = AtomicInteger(0)
-    private val totalCount = AtomicInteger(0)
+    private val progress = RealPingProgressState(this.guids.size)
+    private val finished = AtomicBoolean(false)
 
     fun start() {
+        onEvent(RealPingEvent.Progress(completed = 0, total = guids.size))
         val jobs = guids.map { guid ->
-            totalCount.incrementAndGet()
             scope.launch {
-                runningCount.incrementAndGet()
-                try {
-                    val result = if (onlyTcp) startTcping(guid) else startRealPing(guid)
-                    if (scope.isActive) {
-                        onEvent(RealPingEvent.Result(guid, result))
-                    }
-                } catch (_: Throwable) {
-                    // ignore
-                } finally {
-                    val count = totalCount.decrementAndGet()
-                    val left = runningCount.decrementAndGet()
-                    if (scope.isActive) {
-                        onEvent(RealPingEvent.Progress("$left / $count"))
-                    }
-                }
+                val delayMillis = safelyProbe(guid)
+                currentCoroutineContext().ensureActive()
+                onEvent(RealPingEvent.Result(guid, delayMillis))
+                progress.record(delayMillis)?.let(onEvent)
             }
         }
 
         scope.launch {
-            try {
-                joinAll(*jobs.toTypedArray())
-                if (isActive) {
-                    onEvent(RealPingEvent.Finish("0"))
-                }
-            } catch (_: CancellationException) {
-                // If cancelled, don't send finish event to avoid confusion
-            } finally {
-                close()
+            jobs.joinAll()
+            if (finished.compareAndSet(false, true)) {
+                onEvent(progress.summary())
             }
         }
     }
 
-    fun cancel() {
+    fun cancel(): RealPingEvent.Finish {
+        finished.set(true)
         job.cancel()
+        return progress.summary()
     }
 
-    private fun close() {
-        try {
-            dispatcher.close()
-        } catch (_: Throwable) {
-            // ignore
-        }
+    private suspend fun safelyProbe(guid: String): Long = try {
+        if (onlyTcp) startTcping(guid) else startRealPing(guid)
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        -1L
     }
 
     private suspend fun startRealPing(guid: String): Long {
-        val retFailure = -1L
-
-        val config = MmkvManager.decodeServerConfig(guid) ?: return retFailure
+        val config = MmkvManager.decodeServerConfig(guid) ?: return -1L
         if (!config.configType.isComplexType()
             && config.configType != EConfigType.HYSTERIA2
             && config.configType != EConfigType.WIREGUARD
@@ -115,27 +124,26 @@ class RealPingWorkerService(
             && config.server.isNotNullEmpty()
             && config.serverPort?.toIntOrNull() != null
         ) {
-            val url = config.server.orEmpty()
-            val port = config.serverPort.orEmpty().toInt()
-            val tcpTime = SpeedtestManager.socketConnectTime(url, port, 1000)
-            if (tcpTime <= -1L) {
-                return retFailure
-            }
+            val tcpTime = SpeedtestManager.socketConnectTime(
+                config.server.orEmpty(),
+                config.serverPort.orEmpty().toInt(),
+                1000,
+            )
+            if (tcpTime <= -1L) return -1L
         }
 
         val configResult = CoreConfigManager.getV2rayConfig4Speedtest(context, guid)
-        if (!configResult.status) {
-            return retFailure
-        }
+        if (!configResult.status) return -1L
         return RealPingExecutionLimiter.run(config.configType) {
-            CoreNativeManager.measureOutboundDelay(configResult.content, SettingsManager.getDelayTestUrl())
+            CoreNativeManager.measureOutboundDelay(
+                configResult.content,
+                SettingsManager.getDelayTestUrl(),
+            )
         }
     }
 
     private fun startTcping(guid: String): Long {
-        val retFailure = -1L
-
-        val config = MmkvManager.decodeServerConfig(guid) ?: return retFailure
+        val config = MmkvManager.decodeServerConfig(guid) ?: return -1L
         if (!config.configType.isComplexType()
             && config.configType != EConfigType.HYSTERIA2
             && config.configType != EConfigType.WIREGUARD
@@ -143,13 +151,12 @@ class RealPingWorkerService(
             && config.server.isNotNullEmpty()
             && config.serverPort?.toIntOrNull() != null
         ) {
-            val url = config.server.orEmpty()
-            val port = config.serverPort.orEmpty().toInt()
-            val tcpTime = SpeedtestManager.socketConnectTime(url, port, 1000)
-
-            return tcpTime
+            return SpeedtestManager.socketConnectTime(
+                config.server.orEmpty(),
+                config.serverPort.orEmpty().toInt(),
+                1000,
+            )
         }
-
-        return retFailure
+        return -1L
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
@@ -3,7 +3,10 @@ package com.v2ray.ang.service
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
+import android.os.Process
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreNativeManager
@@ -24,7 +27,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
-import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 
 class SubscriptionUpdateService : Service() {
@@ -38,10 +40,12 @@ class SubscriptionUpdateService : Service() {
 
     private val runningTasks = AtomicInteger(0)
 
-    // manage active batch workers so each batch is independent and cancellable
-    private val activeWorkers = Collections.synchronizedList(mutableListOf<RealPingWorkerService>())
+    @Volatile
+    private var activeWorker: RealPingWorkerService? = null
 
     private val updateSemaphore = Semaphore(2)
+    // Downloads may overlap, but native probe batches in this process may not.
+    private val probeSemaphore = Semaphore(1)
 
     override fun onCreate() {
         super.onCreate()
@@ -52,13 +56,14 @@ class SubscriptionUpdateService : Service() {
 
     override fun onDestroy() {
         LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService is being destroyed")
-        val snapshot = ArrayList(activeWorkers)
-        snapshot.forEach { it.cancel() }
-        activeWorkers.clear()
+        activeWorker?.cancel()
+        activeWorker = null
         serviceJob.cancel()
         NotificationHelper.stopForeground(this)
         NotificationHelper.cancel(NotificationChannelType.SUBSCRIPTION_UPDATE, this)
         super.onDestroy()
+        // Auto-test cores share process-wide Xray state, so discard it after the run.
+        Handler(Looper.getMainLooper()).post { Process.killProcess(Process.myPid()) }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -102,7 +107,7 @@ class SubscriptionUpdateService : Service() {
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "SubscriptionUpdateService update failed", e)
                 } finally {
-                    if (runningTasks.decrementAndGet() == 0 && activeWorkers.isEmpty()) {
+                    if (runningTasks.decrementAndGet() == 0) {
                         NotificationHelper.stopForeground(this@SubscriptionUpdateService)
                         stopSelf()
                     }
@@ -131,9 +136,13 @@ class SubscriptionUpdateService : Service() {
         }
 
         if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_TEST_AFTER_UPDATE_SUBSCRIPTION, false)) {
-            testSubscriptionServers(sub)
+            val testCompleted = probeSemaphore.withPermit {
+                testSubscriptionServers(sub)
+            }
 
-            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST, false)) {
+            if (testCompleted &&
+                MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST, false)
+            ) {
                 LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: removing invalid servers for ${subItem.remarks}")
                 showNotification(
                     context = this,
@@ -142,7 +151,9 @@ class SubscriptionUpdateService : Service() {
                 )
                 AngConfigManager.removeInvalidServer(subId)
             }
-            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST, false)) {
+            if (testCompleted &&
+                MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST, false)
+            ) {
                 LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: sorting servers for ${subItem.remarks}")
                 showNotification(
                     context = this,
@@ -156,7 +167,7 @@ class SubscriptionUpdateService : Service() {
         LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: Finished ${subItem.remarks}")
     }
 
-    private suspend fun testSubscriptionServers(sub: SubscriptionCache) {
+    private suspend fun testSubscriptionServers(sub: SubscriptionCache): Boolean {
         val subId = sub.guid
         LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: starting test phase for ${sub.subscription.remarks}")
         showNotification(
@@ -166,32 +177,39 @@ class SubscriptionUpdateService : Service() {
         )
 
         val guids = MmkvManager.decodeServerList(subId)
-        if (guids.isNotEmpty()) {
-            val deferred = CompletableDeferred<Unit>()
-            lateinit var worker: RealPingWorkerService
-            worker = RealPingWorkerService(
-                context = this,
-                guids = guids,
-                onEvent = { event ->
-                    handleWorkerEvent(event, sub.subscription.remarks) {
-                        activeWorkers.remove(worker)
-                        deferred.complete(Unit)
-                    }
+        if (guids.isEmpty()) return true
+
+        val deferred = CompletableDeferred<Boolean>()
+        val worker = RealPingWorkerService(
+            context = this,
+            guids = guids,
+            onEvent = { event ->
+                handleWorkerEvent(event, sub.subscription.remarks) { completed ->
+                    deferred.complete(completed)
                 }
-            )
-            activeWorkers.add(worker)
+            },
+        )
+        activeWorker = worker
+        return try {
             worker.start()
-            deferred.await()
-            LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: test phase finished for ${sub.subscription.remarks}")
+            val completed = deferred.await()
+            LogUtil.i(
+                AppConfig.TAG,
+                "SubscriptionUpdateService: test phase finished for ${sub.subscription.remarks}",
+            )
+            completed
+        } finally {
+            activeWorker = null
         }
     }
 
-    private fun handleWorkerEvent(event: RealPingEvent, remarks: String, onWorkerDone: () -> Unit) {
+    private fun handleWorkerEvent(event: RealPingEvent, remarks: String, onWorkerDone: (Boolean) -> Unit) {
         when (event) {
             is RealPingEvent.Progress -> {
+                val progressText = "${event.completed} / ${event.total}"
                 val notificationText = getString(
                     R.string.subscription_update_progress,
-                    event.text,
+                    progressText,
                     remarks
                 )
                 showNotification(
@@ -199,7 +217,7 @@ class SubscriptionUpdateService : Service() {
                     titleResId = R.string.title_real_ping_all_server,
                     content = notificationText
                 )
-                LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: ${event.text} in $remarks")
+                LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: $progressText in $remarks")
             }
 
             is RealPingEvent.Result -> {
@@ -207,7 +225,7 @@ class SubscriptionUpdateService : Service() {
             }
 
             is RealPingEvent.Finish -> {
-                onWorkerDone()
+                onWorkerDone(event.completed == event.total)
             }
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
@@ -13,6 +13,7 @@ import com.v2ray.ang.core.CoreNativeManager
 import com.v2ray.ang.dto.RealPingEvent
 import com.v2ray.ang.dto.SubscriptionUpdateMessage
 import com.v2ray.ang.dto.entities.SubscriptionCache
+import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.enums.NotificationChannelType
 import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.handler.AngConfigManager
@@ -176,7 +177,9 @@ class SubscriptionUpdateService : Service() {
             content = sub.subscription.remarks
         )
 
-        val guids = MmkvManager.decodeServerList(subId)
+        val guids = MmkvManager.decodeServerList(subId).filterNot { guid ->
+            MmkvManager.decodeServerConfig(guid)?.configType == EConfigType.POLICYGROUP
+        }
         if (guids.isEmpty()) return true
 
         val deferred = CompletableDeferred<Boolean>()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -9,7 +9,8 @@ sealed interface MainStatus {
     data object Disconnected : MainStatus
     data object Connected : MainStatus
     data object Testing : MainStatus
-    data class TestProgress(val progress: String) : MainStatus
+    data class TestProgress(val completed: Int, val total: Int) : MainStatus
+    data class TestSummary(val live: Int, val total: Int) : MainStatus
     data class ConnectionTest(val result: ConnectionTestResult) : MainStatus
 }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -9,6 +9,9 @@ import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.ConnectionTestResult
+import com.v2ray.ang.dto.RealPingProgress
+import com.v2ray.ang.dto.RealPingResult
+import com.v2ray.ang.dto.RealPingSummary
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -24,10 +27,9 @@ import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import java.util.concurrent.atomic.AtomicBoolean
 
 class MainRepository(
@@ -39,13 +41,10 @@ class MainRepository(
 
     private val closed = AtomicBoolean(false)
 
-    private val _mainServiceEvent = MutableSharedFlow<MainServiceEvent>(
-        replay = 0,
-        extraBufferCapacity = 64,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
+    // Delay results must remain ordered and lossless; the ViewModel coalesces their UI updates.
+    private val mainServiceEventChannel = Channel<MainServiceEvent>(Channel.UNLIMITED)
 
-    override val mainServiceEvent: SharedFlow<MainServiceEvent> = _mainServiceEvent.asSharedFlow()
+    override val mainServiceEvent: Flow<MainServiceEvent> = mainServiceEventChannel.receiveAsFlow()
 
     private val serviceReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -61,18 +60,21 @@ class MainRepository(
                     .serializable<ConnectionTestResult>("content")
                     ?.let { MainServiceEvent.MeasureDelayResult(it) }
 
-                AppConfig.MSG_MEASURE_CONFIG_SUCCESS -> MainServiceEvent.MeasureConfigSuccess
-                AppConfig.MSG_MEASURE_CONFIG_NOTIFY -> MainServiceEvent.MeasureConfigNotify(
-                    safeIntent.getStringExtra("content").orEmpty()
-                )
+                AppConfig.MSG_MEASURE_CONFIG_SUCCESS -> safeIntent
+                    .serializable<RealPingResult>("content")
+                    ?.let { MainServiceEvent.MeasureConfigSuccess(it) }
 
-                AppConfig.MSG_MEASURE_CONFIG_FINISH -> MainServiceEvent.MeasureConfigFinish(
-                    safeIntent.getStringExtra("content")
-                )
+                AppConfig.MSG_MEASURE_CONFIG_NOTIFY -> safeIntent
+                    .serializable<RealPingProgress>("content")
+                    ?.let { MainServiceEvent.MeasureConfigNotify(it) }
+
+                AppConfig.MSG_MEASURE_CONFIG_FINISH -> safeIntent
+                    .serializable<RealPingSummary>("content")
+                    ?.let { MainServiceEvent.MeasureConfigFinish(it) }
 
                 else -> null
             }
-            event?.let { _mainServiceEvent.tryEmit(it) }
+            event?.let { mainServiceEventChannel.trySend(it) }
         }
     }
 
@@ -98,6 +100,7 @@ class MainRepository(
         }.onFailure {
             LogUtil.e(AppConfig.TAG, "Failed to unregister main service receiver", it)
         }
+        mainServiceEventChannel.close()
     }
 
     override fun getSelectedSubscriptionId(): String =

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
@@ -1,6 +1,9 @@
 package com.v2ray.ang.ui.main
 
 import com.v2ray.ang.dto.ConnectionTestResult
+import com.v2ray.ang.dto.RealPingProgress
+import com.v2ray.ang.dto.RealPingResult
+import com.v2ray.ang.dto.RealPingSummary
 
 sealed class MainServiceEvent {
     data object StateRunning : MainServiceEvent()
@@ -9,7 +12,7 @@ sealed class MainServiceEvent {
     data object StateStartFailure : MainServiceEvent()
     data object StateStopSuccess : MainServiceEvent()
     data class MeasureDelayResult(val result: ConnectionTestResult) : MainServiceEvent()
-    data object MeasureConfigSuccess : MainServiceEvent()
-    data class MeasureConfigNotify(val progress: String) : MainServiceEvent()
-    data class MeasureConfigFinish(val finishedCount: String?) : MainServiceEvent()
+    data class MeasureConfigSuccess(val result: RealPingResult) : MainServiceEvent()
+    data class MeasureConfigNotify(val progress: RealPingProgress) : MainServiceEvent()
+    data class MeasureConfigFinish(val summary: RealPingSummary) : MainServiceEvent()
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -15,6 +15,7 @@ import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.ServersCache
 import com.v2ray.ang.dto.entities.SubscriptionCache
+import com.v2ray.ang.enums.EConfigType
 import com.v2ray.ang.extension.delay
 import com.v2ray.ang.extension.isComplexType
 import com.v2ray.ang.extension.matchesPattern
@@ -830,6 +831,7 @@ class MainViewModel(
     fun testAllRealPing(onlyTcp: Boolean = false) {
         val groupId = uiState.value.selectedGroupId
         val servers = currentServers()
+        val hasKeywordFilter = keywordFilter.isNotEmpty()
         activeTestId = null
         canAdoptTestSession = false
         dataSource.cancelAllPing()
@@ -839,7 +841,11 @@ class MainViewModel(
             _uiState.update { it.copy(isTesting = false) }
             return
         }
+        val (policyGroups, probeServers) = servers.partition {
+            it.profile.configType == EConfigType.POLICYGROUP
+        }
         val serverGuids = servers.map { it.guid }
+        val probeGuids = probeServers.map { it.guid }
         val testId = UUID.randomUUID().toString()
         activeTestId = testId
         mutableServerGroupState(groupId).update { current ->
@@ -879,7 +885,8 @@ class MainViewModel(
                     key = AppConfig.MSG_MEASURE_CONFIG_START,
                     testId = testId,
                     subscriptionId = groupId,
-                    serverGuids = if (keywordFilter.isNotEmpty()) serverGuids else emptyList(),
+                    serverGuids = probeGuids.takeIf { hasKeywordFilter },
+                    excludedServerGuids = policyGroups.map { it.guid },
                     onlyTcp = onlyTcp
                 )
             )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -9,6 +9,8 @@ import com.v2ray.ang.R
 import com.v2ray.ang.dto.ConnectionTestResult
 import com.v2ray.ang.dto.GroupMapItem
 import com.v2ray.ang.dto.LocateTarget
+import com.v2ray.ang.dto.RealPingResult
+import com.v2ray.ang.dto.RealPingSummary
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.ServersCache
@@ -24,6 +26,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -38,7 +41,32 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
+import java.util.UUID
 import java.util.regex.PatternSyntaxException
+
+private fun applyTestDelayResults(
+    servers: List<ServersCache>,
+    updates: Map<String, Long>,
+): List<ServersCache> = servers.map { server ->
+    val delayMillis = updates[server.guid]
+    if (delayMillis == null || delayMillis == server.testDelayMillis) {
+        server
+    } else {
+        server.copy(testDelayMillis = delayMillis)
+    }
+}
+
+private fun applyTestDelayResults(
+    rows: List<ServerRowUiModel>,
+    updates: Map<String, Long>,
+): List<ServerRowUiModel> = rows.map { row ->
+    val delayMillis = updates[row.guid]
+    if (delayMillis == null || delayMillis == row.testDelayMillis) {
+        row
+    } else {
+        row.copy(testDelayMillis = delayMillis)
+    }
+}
 
 class MainViewModel(
     application: Application,
@@ -48,6 +76,7 @@ class MainViewModel(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
     private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
     private val preloadDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1)
+    private val testResetDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1)
 
     // ---------- UI state ----------
     private val _uiState = MutableStateFlow(
@@ -77,9 +106,16 @@ class MainViewModel(
     private var preloadJob: Job? = null
     private var selectedGroupLoadJob: Job? = null
     private var reloadJob: Job? = null
+    private var testStartJob: Job? = null
+    private var testResultFlushJob: Job? = null
+    private val pendingTestResults = linkedMapOf<String, Long>()
 
     @Volatile
     private var testingGroupId: String? = null
+
+    @Volatile
+    private var activeTestId: String? = null
+    private var canAdoptTestSession = true
 
     private val initialPageReady = CompletableDeferred<Unit>()
 
@@ -116,22 +152,76 @@ class MainViewModel(
                 _uiState.update { it.copy(status = MainStatus.ConnectionTest(event.result)) }
             }
 
-            MainServiceEvent.MeasureConfigSuccess -> {
-                viewModelScope.launch(ioDispatcher) {
-                    val gid = testingGroupId ?: uiState.value.selectedGroupId
-                    cacheMutex.withLock { groupDataCache.remove(gid) }
-                    updateGroupUi(gid, loadGroup(gid, forceRefresh = true))
+            is MainServiceEvent.MeasureConfigSuccess -> queueTestResult(event.result)
+
+            is MainServiceEvent.MeasureConfigNotify -> {
+                val progress = event.progress
+                if (acceptsTestEvent(progress.testId)) {
+                    _uiState.update {
+                        it.copy(
+                            isTesting = true,
+                            status = MainStatus.TestProgress(progress.completed, progress.total),
+                        )
+                    }
                 }
             }
 
-            is MainServiceEvent.MeasureConfigNotify -> {
-                _uiState.update { it.copy(status = MainStatus.TestProgress(event.progress)) }
-            }
-
             is MainServiceEvent.MeasureConfigFinish -> {
-                onTestsFinished()
+                val summary = event.summary
+                if (acceptsTestEvent(summary.testId)) {
+                    val scheduledFlush = testResultFlushJob
+                    testResultFlushJob = viewModelScope.launch {
+                        scheduledFlush?.cancelAndJoin()
+                        flushPendingTestResults(summary.testId)
+                        onTestsFinished(summary)
+                    }
+                }
             }
         }
+    }
+
+    private fun queueTestResult(result: RealPingResult) {
+        if (!acceptsTestEvent(result.testId)) return
+        pendingTestResults[result.guid] = result.delayMillis
+        if (testResultFlushJob?.isActive == true) return
+
+        testResultFlushJob = viewModelScope.launch {
+            while (activeTestId == result.testId && pendingTestResults.isNotEmpty()) {
+                delay(TEST_RESULT_FLUSH_INTERVAL_MS)
+                flushPendingTestResults(result.testId)
+            }
+        }
+    }
+
+    private suspend fun flushPendingTestResults(testId: String) {
+        if (testId != activeTestId) {
+            pendingTestResults.clear()
+            return
+        }
+        if (pendingTestResults.isEmpty()) return
+
+        val updates = pendingTestResults.toMap()
+        pendingTestResults.clear()
+        val groupId = testingGroupId ?: uiState.value.selectedGroupId
+        cacheMutex.withLock {
+            groupDataCache[groupId]?.let {
+                groupDataCache[groupId] = applyTestDelayResults(it, updates)
+            }
+        }
+        mutableServerGroupState(groupId).update { current ->
+            current.copy(
+                servers = applyTestDelayResults(current.servers, updates),
+                rows = applyTestDelayResults(current.rows, updates),
+            )
+        }
+    }
+
+    private fun acceptsTestEvent(testId: String): Boolean {
+        if (activeTestId == null && canAdoptTestSession) {
+            activeTestId = testId
+            testingGroupId = uiState.value.selectedGroupId
+        }
+        return testId == activeTestId
     }
 
     internal fun formatStatus(status: MainStatus): String = when (status) {
@@ -140,7 +230,13 @@ class MainViewModel(
         MainStatus.Testing -> dataSource.getString(R.string.connection_test_testing)
         is MainStatus.TestProgress -> dataSource.getString(
             R.string.connection_running_task_left,
-            status.progress
+            "${status.completed} / ${status.total}"
+        )
+
+        is MainStatus.TestSummary -> dataSource.getString(
+            R.string.connection_test_servers_live,
+            status.live,
+            status.total,
         )
 
         is MainStatus.ConnectionTest -> formatConnectionTestResult(status.result)
@@ -718,7 +814,10 @@ class MainViewModel(
 
     // ---------- Testing ----------
     fun cancelAllPing() {
+        activeTestId = null
+        canAdoptTestSession = false
         dataSource.cancelAllPing()
+        cancelPendingTestWork()
         testingGroupId = null
         _uiState.update {
             it.copy(
@@ -729,14 +828,20 @@ class MainViewModel(
     }
 
     fun testAllRealPing(onlyTcp: Boolean = false) {
-        dataSource.cancelAllPing()
         val groupId = uiState.value.selectedGroupId
         val servers = currentServers()
+        activeTestId = null
+        canAdoptTestSession = false
+        dataSource.cancelAllPing()
+        cancelPendingTestWork()
         if (servers.isEmpty()) {
+            testingGroupId = null
             _uiState.update { it.copy(isTesting = false) }
             return
         }
         val serverGuids = servers.map { it.guid }
+        val testId = UUID.randomUUID().toString()
+        activeTestId = testId
         mutableServerGroupState(groupId).update { current ->
             current.copy(
                 servers = current.servers.map { server ->
@@ -756,12 +861,23 @@ class MainViewModel(
                 status = MainStatus.Testing
             )
         }
-        viewModelScope.launch(ioDispatcher) {
+        testStartJob = viewModelScope.launch(testResetDispatcher) {
+            val resetGuids = serverGuids.toHashSet()
+            cacheMutex.withLock {
+                groupDataCache[groupId]?.let { cached ->
+                    groupDataCache[groupId] = cached.map { server ->
+                        if (server.guid !in resetGuids || server.testDelayMillis == 0L) server
+                        else server.copy(testDelayMillis = 0L)
+                    }
+                }
+            }
             dataSource.clearAllTestDelayResults(serverGuids)
-            cacheMutex.withLock { groupDataCache.remove(groupId) }
+            ensureActive()
+            if (activeTestId != testId) return@launch
             dataSource.sendMsg2TestService(
                 TestServiceMessage(
                     key = AppConfig.MSG_MEASURE_CONFIG_START,
+                    testId = testId,
                     subscriptionId = groupId,
                     serverGuids = if (keywordFilter.isNotEmpty()) serverGuids else emptyList(),
                     onlyTcp = onlyTcp
@@ -770,22 +886,39 @@ class MainViewModel(
         }
     }
 
+    private fun cancelPendingTestWork() {
+        testStartJob?.cancel()
+        testStartJob = null
+        testResultFlushJob?.cancel()
+        testResultFlushJob = null
+        pendingTestResults.clear()
+    }
+
     fun testCurrentServerRealPing() {
         _uiState.update { it.copy(status = MainStatus.Testing) }
         dataSource.testCurrentServerRealPing()
     }
 
-    private fun onTestsFinished() {
-        viewModelScope.launch(ioDispatcher) {
-            cacheMutex.withLock { groupDataCache.clear() }
-            testingGroupId = null
-            _uiState.update {
-                it.copy(
-                    isTesting = false,
-                    status = if (it.isRunning) MainStatus.Connected else MainStatus.Disconnected
-                )
+    private suspend fun onTestsFinished(summary: RealPingSummary) {
+        if (summary.testId != activeTestId) return
+        val groupId = testingGroupId
+        activeTestId = null
+        canAdoptTestSession = false
+        testingGroupId = null
+        _uiState.update {
+            it.copy(
+                isTesting = false,
+                status = if (summary.cancelled) {
+                    if (it.isRunning) MainStatus.Connected else MainStatus.Disconnected
+                } else {
+                    MainStatus.TestSummary(summary.live, summary.total)
+                },
+            )
+        }
+        if (summary.listChanged && groupId != null) {
+            withContext(ioDispatcher) {
+                updateGroupUi(groupId, loadGroup(groupId, forceRefresh = true))
             }
-            reloadAllGroups(_uiState.value.groups.map { it.id })
         }
     }
 
@@ -841,5 +974,9 @@ class MainViewModel(
             }
             throw IllegalArgumentException("Unknown ViewModel class")
         }
+    }
+
+    private companion object {
+        const val TEST_RESULT_FLUSH_INTERVAL_MS = 500L
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -57,7 +57,7 @@ private fun applyTestDelayResults(
     }
 }
 
-private fun applyTestDelayResults(
+private fun applyTestDelayResultsToRows(
     rows: List<ServerRowUiModel>,
     updates: Map<String, Long>,
 ): List<ServerRowUiModel> = rows.map { row ->
@@ -212,7 +212,7 @@ class MainViewModel(
         mutableServerGroupState(groupId).update { current ->
             current.copy(
                 servers = applyTestDelayResults(current.servers, updates),
-                rows = applyTestDelayResults(current.rows, updates),
+                rows = applyTestDelayResultsToRows(current.rows, updates),
             )
         }
     }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">متصل. اضغط للتحقق من الاتصال.</string>
     <string name="connection_not_connected">غير متصل</string>
     <string name="connection_running_task_left">الاختبارات قيد التشغيل: %s</string>
+    <string name="connection_test_servers_live">%1$d/%2$d من الخوادم متاحة</string>
 
     <string name="import_subscription_success">تم استيراد الاشتراك بنجاح</string>
     <string name="import_subscription_failure">فشل استيراد الاشتراك</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">সংযুক্ত।\nসংযোগ পরীক্ষা করতে ট্যাপ করুন।</string>
     <string name="connection_not_connected">সংযুক্ত নয়</string>
     <string name="connection_running_task_left">চলমান পরীক্ষা: %s</string>
+    <string name="connection_test_servers_live">%1$d/%2$dটি সার্ভার সচল</string>
 
     <string name="import_subscription_success">সাবস্ক্রিপশন সফলভাবে আমদানি করা হয়েছে</string>
     <string name="import_subscription_failure">সাবস্ক্রিপশন আমদানি ব্যর্থ</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">منپیز هڌ. سی واجۊری کیلیک کوݩ.</string>
     <string name="connection_not_connected">منپیز نؽڌ</string>
     <string name="connection_running_task_left">آزمایشا هونی ٱنجوم ابۊن: %s</string>
+    <string name="connection_test_servers_live">%1$d/%2$d سرور فعالن</string>
 
     <string name="import_subscription_success">اشتراک وا مووفقیت و من ٱووڌه وابی</string>
     <string name="import_subscription_failure">و من ٱووردن اشتراک مووفق نبی</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">متصل است.\nبرای بررسی اتصال ضربه بزنید.</string>
     <string name="connection_not_connected">متصل نیست</string>
     <string name="connection_running_task_left">آزمایش‌های در حال اجرا: %s</string>
+    <string name="connection_test_servers_live">%1$d/%2$d سرور فعال</string>
 
     <string name="import_subscription_success">اشتراک با موفقیت وارد شد</string>
     <string name="import_subscription_failure">وارد کردن اشتراک ناموفق بود</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">Подключено.\nНажмите, чтобы проверить соединение.</string>
     <string name="connection_not_connected">Нет соединения</string>
     <string name="connection_running_task_left">Выполняется проверок: %s</string>
+    <string name="connection_test_servers_live">Доступно серверов: %1$d/%2$d</string>
 
     <string name="import_subscription_success">Подписка импортирована</string>
     <string name="import_subscription_failure">Невозможно импортировать подписку</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">Đã kết nối.\nNhấn để kiểm tra kết nối.</string>
     <string name="connection_not_connected">Chưa kết nối</string>
     <string name="connection_running_task_left">Số lượt kiểm tra đang chạy: %s</string>
+    <string name="connection_test_servers_live">%1$d/%2$d máy chủ hoạt động</string>
 
     <string name="import_subscription_success">Nhập gói đăng ký thành công!</string>
     <string name="import_subscription_failure">Nhập gói đăng ký không thành công!</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">"已连接。点击检查连接。"</string>
     <string name="connection_not_connected">"未连接"</string>
     <string name="connection_running_task_left">正在运行的测试：%s</string>
+    <string name="connection_test_servers_live">存活服务器：%1$d/%2$d</string>
 
     <string name="import_subscription_success">订阅导入成功</string>
     <string name="import_subscription_failure">导入订阅失败</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">"已連線。輕觸以檢查連線。"</string>
     <string name="connection_not_connected">"未連線"</string>
     <string name="connection_running_task_left">正在執行的測試：%s</string>
+    <string name="connection_test_servers_live">可用伺服器：%1$d/%2$d</string>
 
     <string name="import_subscription_success">匯入訂閱成功</string>
     <string name="import_subscription_failure">匯入訂閱失敗</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -395,6 +395,7 @@
     <string name="connection_connected">Connected. Tap to check connection.</string>
     <string name="connection_not_connected">Not connected</string>
     <string name="connection_running_task_left">Tests running: %s</string>
+    <string name="connection_test_servers_live">%1$d/%2$d servers live</string>
 
     <string name="import_subscription_success">Subscription imported successfully</string>
     <string name="import_subscription_failure">Import subscription failed</string>


### PR DESCRIPTION
## Context

This is a focused, app-only follow-up to #6050 based on the maintainer feedback there. It keeps the existing per-profile RealDelay implementation, does not use Xray Observatory, and makes no changes to `AndroidLibXrayLite` or xray-core.

The goal is to address the isolation, concurrency, progress, cancellation, and UI-delivery problems without introducing a batch-config builder or new native APIs.

Fixes #6143
Fixes #6089

## What changes

- Run interactive probes in one shared disposable `:Probe` service process instead of the process that hosts the long-running VPN core.
- Run subscription-update probes in their own `:SubscriptionUpdate` process for the same reason.
- Keep one existing short-lived Xray core per profile, but apply the configured concurrency limit to the actual worker dispatcher. Custom configurations are additionally serialized because their full native configs can interfere during teardown.
- Skip policy-group rows for RealDelay and TCPing. Cold-starting a policy group can select the wrong member; support can be revisited after #6109 exposes the target selected by the running core. Interactive probing uses the already-materialized row type, so this adds no serial profile-decode pass before scheduling.
- Carry the test session ID, profile GUID, and delay through the result pipeline.
- Coalesce keyed row updates every 500 ms, force the final pending flush before completion, and preserve unchanged row objects. The UI no longer invalidates, reloads, and republishes the complete group for every result.
- Throttle progress delivery separately to 100 ms. Progress counts completed scheduled probes, while successful completion ends with `x/y servers live` for the probeable rows.
- Make an active batch cancellable from the foreground notification and reject stale events from replaced/cancelled sessions.
- Apply the same coalesced result path to TCPing as well as RealDelay.

## Difference from #6050

| | #6050 Observatory proposal | This PR |
|---|---|---|
| Native/library changes | New AndroidLib APIs and a modified native library | **None**; the AndroidLib gitlink and tested AAR are byte-identical to upstream |
| Probe model | Combined compatible profiles into one Observatory core, with fallbacks | Retains individual per-profile probes; policy rows are skipped until the running-core target API from #6109 is available |
| Xray Observatory | Required | **Not used** |
| Process safety | Disposable probe process | Disposable probe process |
| UI delivery | Identified, coalesced results | Identified, coalesced results, without the batch-probing machinery |
| Maintenance surface | App plus AndroidLib/native adapter and combined-config logic | App-side service lifecycle, event DTOs, and UI state only |

The Observatory approach remains faster for its natural one-request-per-profile workload. This version deliberately gives up that optimization to keep the native library unchanged and the review/maintenance boundary smaller.

## Related bugs

This should address the same user-visible problems cited by #6050: #6077 and probably #6089.

For #6089 specifically, the permanent OEM/device-specific freeze was not reproduced on the emulator, so this PR does not claim controlled proof of the root cause. It does remove the two leading app-side contributors: lossy/bursty identity-less result delivery and the per-result full-group reload/recomposition queue. It also covers the reported TCPing path.

## 500-profile performance comparison

Controlled emulator workload:

- one Android 13/API 33 x86_64 emulator, four virtual CPUs;
- one deterministic subscription containing 500 SOCKS profiles;
- emulator-local SOCKS and HTTP fixtures, with each HTTP response delayed by 100 ms;
- configured concurrency 16;
- one excluded warm-up and five accepted measured runs per build;
- CPU sampled every 250 ms for every app process; memory sampled approximately once per second;
- upstream `63f557242bdd071214c4037c76c912b66da925c8` (current when the controlled set was collected) versus candidate `1408ef43d753e8fca54acf4e92563f8af1a02965`;
- the same byte-identical upstream AAR in both builds.

The final branch is rebased onto current upstream `13138dddcab291ba3618cc54721ce4c7dd926be0`. The policy-skip follow-up does not change the worker loop, and this 500-profile dataset contains no policy groups; the table reports the retained controlled five-run set rather than mixing in later runs from an emulator session that developed abnormal QEMU disk activity.

Values below are medians; ranges and raw samples were retained locally.

| Metric | Upstream baseline | This PR | Change |
|---|---:|---:|---:|
| Network complete | 18.06 s | 13.08 s | **27.6% faster** |
| Final UI observed | 20.87 s | 15.93 s | **23.7% sooner** |
| Total app CPU | 35.57 s | 17.94 s | **49.6% less** |
| Main-process CPU | 18.13 s | 5.38 s | **70.3% less** |
| Average app CPU | 170.3% of one core | 114.5% | **32.7% lower** |
| Peak combined PSS | 252.7 MiB | 284.7 MiB | **12.7% higher** |
| Peak summed RSS | 405.7 MiB | 513.1 MiB | **26.5% higher** |
| Frames rendered during flow | 295 | 215 | **27.1% fewer** |
| Janky frames | 170 | 115 | **32.4% fewer** |
| Frame p50 / p99 | 48 / 550 ms | 32 / 250 ms | improved |

The CPU reduction includes all app processes. The memory increase is the expected tradeoff of process isolation: during the measured peak, the main process, normal daemon, and disposable `:Probe` process overlapped. The probe process was gone after every completed run.

Every accepted upstream and candidate run completed the full natural workload: 1,000/1,000 HTTP GETs, 1,500/1,500 socket accepts, and exact observed HTTP/SOCKS concurrency of 16. No crash, ANR, SIGSEGV, or native abort marker was found. The gfxinfo values are directional emulator/debug-build evidence rather than production frame-rate claims.

### Historical Observatory reference

The old #6050 build was also measured five times with the same 500-profile fixture:

| Metric | Observatory median |
|---|---:|
| Network complete | 9.42 s |
| Final UI observed | 12.22 s |
| Total app CPU | 11.66 s |
| Peak combined PSS | 275.1 MiB |
| Peak summed RSS | 503.5 MiB |

This is an architectural reference, not a controlled source-only comparison: the historical Observatory build uses an older app/native base and naturally performs 500 HEAD requests with no separate TCP precheck, whereas upstream and this PR each perform 1,000 GET requests plus 500 TCP prechecks. The matched conclusion is therefore the upstream-baseline-versus-candidate table above.

## Validation

- Play Store debug build installed and exercised on the emulator.
- Verified normal completion, accurate final summary, notification cancellation, concurrency-setting changes, stale-session rejection, and disposable probe-process exit.
- Verified mixed groups on-device for both RealDelay and TCPing: the ordinary SOCKS row received the only result, policy rows remained blank, and the final UI showed `1/1 servers live`. TCPing produced one fixture socket accept.
- Verified a policy-only group reports `0/0 servers live`, produces zero fixture traffic, starts no short-lived Xray core, and exits the disposable service process cleanly.
- Five accepted 500-profile runs for upstream, this PR, and the historical Observatory build, after one warm-up each; exactly one emulator was connected throughout.
- `git diff --check` passes.
- No benchmark harness or test source is included in this branch.
