### PR TITLE
fix #6126

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/DPadFocus.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/DPadFocus.kt
@@ -1,0 +1,43 @@
+package com.v2ray.ang.ui.main
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+
+class DPadFocusTargets {
+    val fab = FocusRequester()
+    val firstDrawerItem = FocusRequester()
+    val menuButton = FocusRequester()
+}
+
+val LocalDPadFocusTargets = staticCompositionLocalOf<DPadFocusTargets?> { null }
+
+internal fun isLastRowItem(index: Int, itemCount: Int, columns: Int): Boolean {
+    if (itemCount <= 0 || columns <= 0 || index !in 0 until itemCount) return false
+    val lastRowStart = itemCount - ((itemCount - 1) % columns + 1)
+    return index >= lastRowStart
+}
+
+fun FocusRequester.tryRequestFocus(): Boolean =
+    try {
+        requestFocus()
+        true
+    } catch (_: IllegalStateException) {
+        false
+    }
+
+fun Modifier.dPadDownTo(target: FocusRequester?): Modifier {
+    if (target == null) return this
+    return focusProperties { down = target }
+        .onKeyEvent { event ->
+            event.type == KeyEventType.KeyDown &&
+                event.key == Key.DirectionDown &&
+                target.tryRequestFocus()
+        }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainBottomBar.kt
@@ -2,10 +2,8 @@ package com.v2ray.ang.ui.main
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,6 +13,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -22,11 +21,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.AppDivider
@@ -41,31 +42,36 @@ fun MainBottomBar(
     isDarkTheme: Boolean,
     onAction: (MainAction) -> Unit
 ) {
+    val focusTargets = LocalDPadFocusTargets.current
+
     Box(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.surface)
-                .clickable(onClick = { onAction(MainAction.TestCurrentServer) })
                 .windowInsetsPadding(WindowInsets.navigationBars)
         ) {
             AppDivider()
-            Row(
+            Text(
+                text = displayText,
+                style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(64.dp)
-                    .padding(horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = displayText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.semantics {
+                    .padding(start = 16.dp, end = 88.dp)
+                    .clickable(onClick = { onAction(MainAction.TestCurrentServer) })
+                    .wrapContentHeight(Alignment.CenterVertically)
+                    .then(
+                        if (focusTargets != null) {
+                            Modifier.focusProperties { right = focusTargets.fab }
+                        } else {
+                            Modifier
+                        }
+                    )
+                    .semantics {
                         contentDescription = displayText
                     }
-                )
-            }
+            )
         }
         FloatingActionButton(
             onClick = { onAction(MainAction.ToggleService) },
@@ -73,7 +79,10 @@ fun MainBottomBar(
                 .align(Alignment.TopEnd)
                 .padding(end = 24.dp)
                 .offset(y = (-28).dp)
-                .navigationBarsPadding(),
+                .navigationBarsPadding()
+                .then(
+                    if (focusTargets != null) Modifier.focusRequester(focusTargets.fab) else Modifier
+                ),
             containerColor = if (isRunning) colorFabActive
             else if (isDarkTheme) colorFabInactiveDark
             else colorFabInactiveLight

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDrawer.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -66,6 +67,7 @@ private val drawerItems = primaryDrawerItems + listOf(
 @Composable
 fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) -> Unit) {
     val drawerScrollState = rememberScrollState()
+    val focusTargets = LocalDPadFocusTargets.current
 
     ModalDrawerSheet(
         drawerState = drawerState,
@@ -114,7 +116,15 @@ fun MainDrawerContent(drawerState: DrawerState, onNavigate: (MainDestination) ->
                     selected = false,
                     onClick = { onNavigate(item) },
                     icon = { Icon(painterResource(item.iconRes), contentDescription = null) },
-                    modifier = Modifier.padding(NavigationDrawerItemDefaults.ItemPadding)
+                    modifier = Modifier
+                        .padding(NavigationDrawerItemDefaults.ItemPadding)
+                        .then(
+                            if (index == 0 && focusTargets != null) {
+                                Modifier.focusRequester(focusTargets.firstDrawerItem)
+                            } else {
+                                Modifier
+                            }
+                        )
                 )
             }
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
@@ -32,6 +33,7 @@ import com.v2ray.ang.ui.compose.LocalDarkTheme
 import com.v2ray.ang.ui.compose.QRCodeDialog
 import com.v2ray.ang.extension.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 
 @Composable
@@ -53,6 +55,7 @@ fun MainScreen(
     val isDarkTheme = LocalDarkTheme.current
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
+    val dPadFocusTargets = remember { DPadFocusTargets() }
     var showSearch by remember { mutableStateOf(false) }
     var searchQuery by remember { mutableStateOf("") }
     var showDelAllConfirm by remember { mutableStateOf(false) }
@@ -185,18 +188,35 @@ fun MainScreen(
         QRCodeDialog(bitmap = shareQRCodeBitmap, onDismiss = { onAction(MainAction.DismissQRCodeDialog) })
     }
 
-    ModalNavigationDrawer(
-        drawerState = drawerState,
-        drawerContent = {
-            MainDrawerContent(
-                drawerState = drawerState,
-                onNavigate = { route ->
-                    scope.launch { drawerState.close() }
-                    onNavigate(route)
+    LaunchedEffect(drawerState) {
+        snapshotFlow { drawerState.targetValue == DrawerValue.Open }
+            .distinctUntilChanged()
+            .drop(1)
+            .collect { isOpen ->
+                if (isOpen) {
+                    for (i in 0 until 8) {
+                        delay(32)
+                        if (dPadFocusTargets.firstDrawerItem.tryRequestFocus()) break
+                    }
+                } else {
+                    dPadFocusTargets.menuButton.tryRequestFocus()
                 }
-            )
-        }
-    ) {
+            }
+    }
+
+    CompositionLocalProvider(LocalDPadFocusTargets provides dPadFocusTargets) {
+        ModalNavigationDrawer(
+            drawerState = drawerState,
+            drawerContent = {
+                MainDrawerContent(
+                    drawerState = drawerState,
+                    onNavigate = { route ->
+                        scope.launch { drawerState.close() }
+                        onNavigate(route)
+                    }
+                )
+            }
+        ) {
         Scaffold(
             contentWindowInsets = ScaffoldDefaults.contentWindowInsets,
             topBar = {
@@ -270,7 +290,7 @@ fun MainScreen(
                         state = pagerState,
                         modifier = Modifier.fillMaxSize(),
                         userScrollEnabled = true,
-                        beyondViewportPageCount = 1,
+                        beyondViewportPageCount = 0,
                         key = { page -> groups.getOrNull(page)?.id ?: "group-page-$page" }
                     ) { page ->
                         val group = groups.getOrNull(page) ?: return@HorizontalPager
@@ -304,5 +324,6 @@ fun MainScreen(
                 }
             }
         }
+    }
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
@@ -143,13 +143,15 @@ private fun ServerListPage(
                 .verticalScrollbar(gridState),
             contentPadding = contentPadding
         ) {
-            itemsIndexed(items = servers, key = { _, item -> item.guid }) { _, serverCache ->
+            itemsIndexed(items = servers, key = { _, item -> item.guid }) { index, serverCache ->
+                val isLastRow = isLastRowItem(index, servers.size, columns = 2)
                 val content: @Composable () -> Unit = {
                     ServerItemColumn(
                         serverCache = serverCache,
                         selectedGuid = selectedGuid,
                         subscriptionId = subscriptionId,
                         doubleColumnDisplay = true,
+                        isLastRow = isLastRow,
                         onSelectServer = onSelectServer,
                         onEditServer = onEditServer,
                         onShareServer = onShareServer,
@@ -189,7 +191,8 @@ private fun ServerListPage(
                 .verticalScrollbar(listState),
             contentPadding = contentPadding
         ) {
-            itemsIndexed(items = servers, key = { _, item -> item.guid }) { _, serverCache ->
+            itemsIndexed(items = servers, key = { _, item -> item.guid }) { index, serverCache ->
+                val isLastRow = isLastRowItem(index, servers.size, columns = 1)
                 if (canReorder && reorderableState != null) {
                     ReorderableItem(
                         reorderableState,
@@ -203,6 +206,7 @@ private fun ServerListPage(
                                 serverCache = serverCache,
                                 selectedGuid = selectedGuid,
                                 subscriptionId = subscriptionId,
+                                isLastRow = isLastRow,
                                 onSelectServer = onSelectServer,
                                 onEditServer = onEditServer,
                                 onShareServer = onShareServer,
@@ -217,6 +221,7 @@ private fun ServerListPage(
                         serverCache = serverCache,
                         selectedGuid = selectedGuid,
                         subscriptionId = subscriptionId,
+                        isLastRow = isLastRow,
                         onSelectServer = onSelectServer,
                         onEditServer = onEditServer,
                         onShareServer = onShareServer,
@@ -235,6 +240,7 @@ private fun ServerItemRow(
     serverCache: ServersCache,
     selectedGuid: String?,
     subscriptionId: String,
+    isLastRow: Boolean,
     onSelectServer: (String) -> Unit,
     onEditServer: (String, ProfileItem) -> Unit,
     onShareServer: (String, ProfileItem) -> Unit,
@@ -256,6 +262,7 @@ private fun ServerItemRow(
         isSelected = serverCache.guid == selectedGuid,
         subscriptionRemarks = subRemarks,
         doubleColumnDisplay = false,
+        isLastRow = isLastRow,
         onClick = { onSelectServer(serverCache.guid) },
         onShare = { onShareServer(serverCache.guid, profile) },
         onEdit = { onEditServer(serverCache.guid, profile) },
@@ -270,6 +277,7 @@ private fun ServerItemColumn(
     selectedGuid: String?,
     subscriptionId: String,
     doubleColumnDisplay: Boolean,
+    isLastRow: Boolean,
     onSelectServer: (String) -> Unit,
     onEditServer: (String, ProfileItem) -> Unit,
     onShareServer: (String, ProfileItem) -> Unit,
@@ -289,6 +297,7 @@ private fun ServerItemColumn(
             isSelected = serverCache.guid == selectedGuid,
             subscriptionRemarks = subRemarks,
             doubleColumnDisplay = doubleColumnDisplay,
+            isLastRow = isLastRow,
             onClick = { onSelectServer(serverCache.guid) },
             onEdit = { onEditServer(serverCache.guid, profile) },
             onShare = { onShareServer(serverCache.guid, profile) },
@@ -308,6 +317,7 @@ fun ServerListItem(
     isSelected: Boolean,
     subscriptionRemarks: String,
     doubleColumnDisplay: Boolean,
+    isLastRow: Boolean = false,
     onClick: () -> Unit,
     onEdit: () -> Unit,
     onShare: () -> Unit,
@@ -326,6 +336,9 @@ fun ServerListItem(
     } else {
         null
     }
+    val lastRowDown = Modifier.dPadDownTo(
+        if (isLastRow) LocalDPadFocusTargets.current?.fab else null
+    )
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -335,6 +348,7 @@ fun ServerListItem(
                     stateDescription = selectedStateDescription
                 }
             }
+            .then(lastRowDown)
             .clickable(onClick = onClick)
             .then(dragModifier)
     ) {
@@ -365,7 +379,7 @@ fun ServerListItem(
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 Text(remarks, Modifier.weight(1f), style = MaterialTheme.typography.bodyLarge.copy(lineBreak = LineBreak.Paragraph), maxLines = 2, overflow = TextOverflow.Ellipsis)
                 if (doubleColumnDisplay) {
-                    IconButton(onClick = onMore, Modifier.size(36.dp)) {
+                    IconButton(onClick = onMore, Modifier.size(36.dp).then(lastRowDown)) {
                         Icon(
                             painterResource(R.drawable.ic_more_vert_24dp),
                             stringResource(R.string.acc_more),
@@ -373,21 +387,21 @@ fun ServerListItem(
                         )
                     }
                 } else {
-                    IconButton(onClick = onShare, Modifier.size(36.dp)) {
+                    IconButton(onClick = onShare, Modifier.size(36.dp).then(lastRowDown)) {
                         Icon(
                             painterResource(R.drawable.ic_share_24dp),
                             stringResource(R.string.title_configuration_share),
                             Modifier.size(24.dp)
                         )
                     }
-                    IconButton(onClick = onEdit, Modifier.size(36.dp)) {
+                    IconButton(onClick = onEdit, Modifier.size(36.dp).then(lastRowDown)) {
                         Icon(
                             painterResource(R.drawable.ic_edit_24dp),
                             stringResource(R.string.acc_edit),
                             Modifier.size(24.dp)
                         )
                     }
-                    IconButton(onClick = onRemove, Modifier.size(36.dp)) {
+                    IconButton(onClick = onRemove, Modifier.size(36.dp).then(lastRowDown)) {
                         Icon(
                             painterResource(R.drawable.ic_delete_24dp),
                             stringResource(R.string.acc_delete),

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainTopBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -62,7 +63,9 @@ fun MainTopBar(
                     Icon(painterResource(R.drawable.ic_arrow_back_24dp), contentDescription = stringResource(R.string.acc_back))
                 }
             } else {
-                IconButton(onClick = onMenuClick) {
+                val menuModifier = LocalDPadFocusTargets.current?.let { Modifier.focusRequester(it.menuButton) }
+                    ?: Modifier
+                IconButton(onClick = onMenuClick, modifier = menuModifier) {
                     Icon(painterResource(R.drawable.ic_menu_24dp), contentDescription = stringResource(R.string.acc_open_menu))
                 }
             }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/DPadFocusTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/DPadFocusTest.kt
@@ -1,0 +1,36 @@
+package com.v2ray.ang.ui.main
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DPadFocusTest {
+
+    @Test
+    fun lastRowInSingleColumnIsOnlyTheFinalItem() {
+        assertFalse(isLastRowItem(index = 3, itemCount = 5, columns = 1))
+        assertTrue(isLastRowItem(index = 4, itemCount = 5, columns = 1))
+    }
+
+    @Test
+    fun lastRowInTwoColumnsIncludesIncompleteRow() {
+        assertFalse(isLastRowItem(index = 2, itemCount = 5, columns = 2))
+        assertFalse(isLastRowItem(index = 3, itemCount = 5, columns = 2))
+        assertTrue(isLastRowItem(index = 4, itemCount = 5, columns = 2))
+    }
+
+    @Test
+    fun lastRowInTwoColumnsIncludesBothItemsWhenEven() {
+        assertFalse(isLastRowItem(index = 1, itemCount = 4, columns = 2))
+        assertTrue(isLastRowItem(index = 2, itemCount = 4, columns = 2))
+        assertTrue(isLastRowItem(index = 3, itemCount = 4, columns = 2))
+    }
+
+    @Test
+    fun lastRowRejectsEmptyOrInvalidInput() {
+        assertFalse(isLastRowItem(index = 0, itemCount = 0, columns = 1))
+        assertFalse(isLastRowItem(index = 0, itemCount = 2, columns = 0))
+        assertFalse(isLastRowItem(index = -1, itemCount = 2, columns = 1))
+        assertFalse(isLastRowItem(index = 2, itemCount = 2, columns = 1))
+    }
+}


### PR DESCRIPTION
Compose spatial focus was blocked by the full-width bottom bar and the modal drawer scrim, so the start button and side menu were unreachable with a TV remote.