### PR TITLE
fix: prevent ZIP path traversal during backup restore

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/backup/BackupViewModel.kt
@@ -185,17 +185,20 @@ class BackupViewModel(application: Application) : BaseViewModel(application) {
         }
     }
 
-    private fun performRestore(cacheDir: File, zipFile: File): Boolean {
-        val backupDir = cacheDir.absolutePath + "/${System.currentTimeMillis()}"
+    private suspend fun performRestore(cacheDir: File, zipFile: File): Boolean =
+        withContext(Dispatchers.IO) {
+            val backupDir = File(cacheDir, "restore_${System.nanoTime()}")
+            try {
+                if (!ZipUtil.unzipToFolder(zipFile, backupDir.absolutePath)) {
+                    return@withContext false
+                }
 
-        if (!ZipUtil.unzipToFolder(zipFile, backupDir)) {
-            return false
+                val count = MMKV.restoreAllFromDirectory(backupDir.absolutePath)
+                SettingsChangeManager.makeSetupGroupTab()
+                SettingsChangeManager.makeRestartService()
+                count > 0
+            } finally {
+                backupDir.deleteRecursively()
+            }
         }
-
-        val count = MMKV.restoreAllFromDirectory(backupDir)
-        SettingsChangeManager.makeSetupGroupTab()
-        SettingsChangeManager.makeRestartService()
-
-        return count > 0
-    }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/ZipUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/ZipUtil.kt
@@ -8,11 +8,42 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.util.zip.ZipEntry
+import java.util.zip.ZipException
 import java.util.zip.ZipFile
 import java.util.zip.ZipOutputStream
 
 object ZipUtil {
     private const val BUFFER_SIZE = 4096
+    private const val MEBIBYTE = 1024L * 1024L
+
+    private val DEFAULT_EXTRACTION_LIMITS = ExtractionLimits(
+        maxArchiveBytes = 128L * MEBIBYTE,
+        maxEntries = 256,
+        maxEntryBytes = 64L * MEBIBYTE,
+        maxTotalBytes = 256L * MEBIBYTE,
+        maxCompressionRatio = 1000.0,
+    )
+
+    internal data class ExtractionLimits(
+        val maxArchiveBytes: Long,
+        val maxEntries: Int,
+        val maxEntryBytes: Long,
+        val maxTotalBytes: Long,
+        val maxCompressionRatio: Double,
+    ) {
+        init {
+            require(maxArchiveBytes > 0)
+            require(maxEntries > 0)
+            require(maxEntryBytes > 0)
+            require(maxTotalBytes > 0)
+            require(maxCompressionRatio >= 1.0)
+        }
+    }
+
+    private data class ValidatedEntry(
+        val entry: ZipEntry,
+        val target: File,
+    )
 
     /**
      * Zip the contents of a folder.
@@ -78,47 +109,191 @@ object ZipUtil {
      */
     @Throws(IOException::class)
     fun unzipToFolder(zipFile: File, destDirectory: String): Boolean {
-        File(destDirectory).run {
-            if (!exists()) {
-                mkdirs()
-            }
-        }
-        try {
-            ZipFile(zipFile).use { zip ->
-                zip.entries().asSequence().forEach { entry ->
-                    zip.getInputStream(entry).use { input ->
-                        val filePath = destDirectory + File.separator + entry.name
-                        if (!entry.isDirectory) {
-                            extractFile(input, filePath)
-                        } else {
-                            val dir = File(filePath)
-                            dir.mkdir()
-                        }
-                    }
-                }
-            }
+        return try {
+            extractArchive(zipFile, File(destDirectory), DEFAULT_EXTRACTION_LIMITS)
+            true
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to unzip file", e)
+            false
+        }
+    }
+
+    @Throws(IOException::class)
+    internal fun extractArchive(
+        zipFile: File,
+        destination: File,
+        limits: ExtractionLimits,
+    ) {
+        if (!zipFile.isFile || zipFile.length() > limits.maxArchiveBytes) {
+            throw ZipException("ZIP archive is missing or exceeds the compressed-size limit")
+        }
+
+        val root = destination.canonicalFile
+        ZipFile(zipFile).use { zip ->
+            val entries = validateEntries(zip, root, limits)
+            val rootCreated = prepareDestination(root)
+            try {
+                extractEntries(zip, entries, limits)
+            } catch (error: Throwable) {
+                root.listFiles()?.forEach { it.deleteRecursively() }
+                if (rootCreated) root.delete()
+                throw error
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun validateEntries(
+        zip: ZipFile,
+        root: File,
+        limits: ExtractionLimits,
+    ): List<ValidatedEntry> {
+        val result = ArrayList<ValidatedEntry>()
+        val targets = HashMap<String, Boolean>()
+        var totalBytes = 0L
+        val entries = zip.entries()
+
+        while (entries.hasMoreElements()) {
+            if (result.size >= limits.maxEntries) {
+                throw ZipException("ZIP archive exceeds the entry-count limit")
+            }
+
+            val entry = entries.nextElement()
+            if (entry.name.isEmpty()) {
+                throw ZipException("ZIP archive contains an empty entry name")
+            }
+            if (entry.method != ZipEntry.STORED && entry.method != ZipEntry.DEFLATED) {
+                throw ZipException("ZIP archive contains an unsupported compression method")
+            }
+
+            val target = resolveEntryTarget(root, entry)
+            if (targets.put(target.path, entry.isDirectory) != null) {
+                throw ZipException("ZIP archive contains duplicate entry destinations")
+            }
+
+            val entryBytes = entry.size
+            val compressedBytes = entry.compressedSize
+            if (entryBytes < 0L || compressedBytes < 0L) {
+                throw ZipException("ZIP archive contains an entry with an unknown size")
+            }
+            if (entry.isDirectory && entryBytes != 0L) {
+                throw ZipException("ZIP archive contains a non-empty directory entry")
+            }
+            if (entryBytes > limits.maxEntryBytes) {
+                throw ZipException("ZIP archive entry exceeds the expanded-size limit")
+            }
+            if (totalBytes > limits.maxTotalBytes - entryBytes) {
+                throw ZipException("ZIP archive exceeds the total expanded-size limit")
+            }
+            if (
+                entryBytes > 0L && (
+                    compressedBytes == 0L ||
+                        entryBytes.toDouble() / compressedBytes > limits.maxCompressionRatio
+                )
+            ) {
+                throw ZipException("ZIP archive entry exceeds the compression-ratio limit")
+            }
+
+            totalBytes += entryBytes
+            result.add(ValidatedEntry(entry, target))
+        }
+
+        result.forEach { validated ->
+            var parent = validated.target.parentFile
+            while (parent != null && parent != root) {
+                if (targets[parent.path] == false) {
+                    throw ZipException("ZIP archive places an entry below a file")
+                }
+                parent = parent.parentFile
+            }
+        }
+        return result
+    }
+
+    @Throws(IOException::class)
+    private fun resolveEntryTarget(root: File, entry: ZipEntry): File {
+        val target = File(root, entry.name).canonicalFile
+        val rootPrefix = root.path + File.separator
+        if (target == root || !target.path.startsWith(rootPrefix)) {
+            throw ZipException("ZIP entry resolves outside the destination directory")
+        }
+        return target
+    }
+
+    @Throws(IOException::class)
+    private fun prepareDestination(root: File): Boolean {
+        if (root.exists()) {
+            if (!root.isDirectory || root.listFiles()?.isNotEmpty() != false) {
+                throw IOException("ZIP destination must be an empty directory")
+            }
             return false
+        }
+        if (!root.mkdirs()) {
+            throw IOException("Unable to create ZIP destination directory")
         }
         return true
     }
 
-    /**
-     * Extract a file from an input stream.
-     *
-     * @param inputStream The input stream to read from.
-     * @param destFilePath The destination file path.
-     * @throws IOException If an I/O error occurs.
-     */
     @Throws(IOException::class)
-    private fun extractFile(inputStream: InputStream, destFilePath: String) {
-        val bos = BufferedOutputStream(FileOutputStream(destFilePath))
-        val bytesIn = ByteArray(BUFFER_SIZE)
-        var read: Int
-        while (inputStream.read(bytesIn).also { read = it } != -1) {
-            bos.write(bytesIn, 0, read)
+    private fun extractEntries(
+        zip: ZipFile,
+        entries: List<ValidatedEntry>,
+        limits: ExtractionLimits,
+    ) {
+        var totalBytes = 0L
+        entries.forEach { validated ->
+            val entry = validated.entry
+            val target = validated.target
+            if (entry.isDirectory) {
+                if (!target.isDirectory && !target.mkdirs()) {
+                    throw IOException("Unable to create ZIP entry directory")
+                }
+                return@forEach
+            }
+
+            val parent = target.parentFile
+                ?: throw ZipException("ZIP entry has no destination parent")
+            if (!parent.isDirectory && !parent.mkdirs()) {
+                throw IOException("Unable to create ZIP entry parent directory")
+            }
+            if (target.exists()) {
+                throw ZipException("ZIP entry would overwrite an existing file")
+            }
+
+            zip.getInputStream(entry).use { input ->
+                BufferedOutputStream(FileOutputStream(target)).use { output ->
+                    totalBytes += copyEntry(input, output, entry.size, totalBytes, limits)
+                }
+            }
         }
-        bos.close()
+    }
+
+    @Throws(IOException::class)
+    private fun copyEntry(
+        input: InputStream,
+        output: BufferedOutputStream,
+        expectedBytes: Long,
+        currentTotalBytes: Long,
+        limits: ExtractionLimits,
+    ): Long {
+        val buffer = ByteArray(BUFFER_SIZE)
+        var entryBytes = 0L
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            val readBytes = read.toLong()
+            val remainingEntryBytes = limits.maxEntryBytes - entryBytes
+            val remainingTotalBytes = limits.maxTotalBytes - currentTotalBytes - entryBytes
+            if (readBytes > remainingEntryBytes || readBytes > remainingTotalBytes
+            ) {
+                throw ZipException("ZIP entry exceeds the expanded-size limit while extracting")
+            }
+            output.write(buffer, 0, read)
+            entryBytes += readBytes
+        }
+        if (entryBytes != expectedBytes) {
+            throw ZipException("ZIP entry expanded size differs from its declared size")
+        }
+        return entryBytes
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/ZipUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/ZipUtil.kt
@@ -24,7 +24,7 @@ object ZipUtil {
         maxCompressionRatio = 1000.0,
     )
 
-    internal data class ExtractionLimits(
+    internal class ExtractionLimits(
         val maxArchiveBytes: Long,
         val maxEntries: Int,
         val maxEntryBytes: Long,
@@ -39,11 +39,6 @@ object ZipUtil {
             require(maxCompressionRatio >= 1.0)
         }
     }
-
-    private data class ValidatedEntry(
-        val entry: ZipEntry,
-        val target: File,
-    )
 
     /**
      * Zip the contents of a folder.
@@ -118,7 +113,6 @@ object ZipUtil {
         }
     }
 
-    @Throws(IOException::class)
     internal fun extractArchive(
         zipFile: File,
         destination: File,
@@ -142,19 +136,17 @@ object ZipUtil {
         }
     }
 
-    @Throws(IOException::class)
     private fun validateEntries(
         zip: ZipFile,
         root: File,
         limits: ExtractionLimits,
-    ): List<ValidatedEntry> {
-        val result = ArrayList<ValidatedEntry>()
-        val targets = HashMap<String, Boolean>()
+    ): Map<File, ZipEntry> {
+        val entriesByTarget = LinkedHashMap<File, ZipEntry>()
         var totalBytes = 0L
         val entries = zip.entries()
 
         while (entries.hasMoreElements()) {
-            if (result.size >= limits.maxEntries) {
+            if (entriesByTarget.size >= limits.maxEntries) {
                 throw ZipException("ZIP archive exceeds the entry-count limit")
             }
 
@@ -167,7 +159,7 @@ object ZipUtil {
             }
 
             val target = resolveEntryTarget(root, entry)
-            if (targets.put(target.path, entry.isDirectory) != null) {
+            if (entriesByTarget.put(target, entry) != null) {
                 throw ZipException("ZIP archive contains duplicate entry destinations")
             }
 
@@ -195,22 +187,20 @@ object ZipUtil {
             }
 
             totalBytes += entryBytes
-            result.add(ValidatedEntry(entry, target))
         }
 
-        result.forEach { validated ->
-            var parent = validated.target.parentFile
+        entriesByTarget.forEach { (target, _) ->
+            var parent = target.parentFile
             while (parent != null && parent != root) {
-                if (targets[parent.path] == false) {
+                if (entriesByTarget[parent]?.isDirectory == false) {
                     throw ZipException("ZIP archive places an entry below a file")
                 }
                 parent = parent.parentFile
             }
         }
-        return result
+        return entriesByTarget
     }
 
-    @Throws(IOException::class)
     private fun resolveEntryTarget(root: File, entry: ZipEntry): File {
         val target = File(root, entry.name).canonicalFile
         val rootPrefix = root.path + File.separator
@@ -220,7 +210,6 @@ object ZipUtil {
         return target
     }
 
-    @Throws(IOException::class)
     private fun prepareDestination(root: File): Boolean {
         if (root.exists()) {
             if (!root.isDirectory || root.listFiles()?.isNotEmpty() != false) {
@@ -234,16 +223,13 @@ object ZipUtil {
         return true
     }
 
-    @Throws(IOException::class)
     private fun extractEntries(
         zip: ZipFile,
-        entries: List<ValidatedEntry>,
+        entries: Map<File, ZipEntry>,
         limits: ExtractionLimits,
     ) {
         var totalBytes = 0L
-        entries.forEach { validated ->
-            val entry = validated.entry
-            val target = validated.target
+        entries.forEach { (target, entry) ->
             if (entry.isDirectory) {
                 if (!target.isDirectory && !target.mkdirs()) {
                     throw IOException("Unable to create ZIP entry directory")
@@ -268,7 +254,6 @@ object ZipUtil {
         }
     }
 
-    @Throws(IOException::class)
     private fun copyEntry(
         input: InputStream,
         output: BufferedOutputStream,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/util/ZipUtil.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/util/ZipUtil.kt
@@ -18,8 +18,8 @@ object ZipUtil {
 
     private val DEFAULT_EXTRACTION_LIMITS = ExtractionLimits(
         maxArchiveBytes = 128L * MEBIBYTE,
-        maxEntries = 256,
-        maxEntryBytes = 64L * MEBIBYTE,
+        maxEntries = 32,
+        maxEntryBytes = 128L * MEBIBYTE,
         maxTotalBytes = 256L * MEBIBYTE,
         maxCompressionRatio = 1000.0,
     )

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/util/ZipUtilTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/util/ZipUtilTest.kt
@@ -1,0 +1,184 @@
+package com.v2ray.ang.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipException
+import java.util.zip.ZipOutputStream
+
+class ZipUtilTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun unzipToFolderExtractsNestedFile() {
+        val archive = createArchive("nested/config" to "value".toByteArray())
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertTrue(ZipUtil.unzipToFolder(archive, destination.absolutePath))
+        assertEquals("value", File(destination, "nested/config").readText())
+    }
+
+    @Test
+    fun extractArchiveRejectsPathTraversal() {
+        val archive = createArchive("../outside" to "overwrite".toByteArray())
+        val destination = File(temporaryFolder.root, "destination")
+        val outside = File(temporaryFolder.root, "outside")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(archive, destination, extractionLimits())
+        }
+
+        assertFalse(outside.exists())
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsOversizedArchive() {
+        val archive = createArchive("config" to byteArrayOf(1))
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(
+                archive,
+                destination,
+                extractionLimits(maxArchiveBytes = archive.length() - 1),
+            )
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsTooManyEntries() {
+        val archive = createArchive(
+            "first" to byteArrayOf(1),
+            "second" to byteArrayOf(2),
+        )
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(
+                archive,
+                destination,
+                extractionLimits(maxEntries = 1),
+            )
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsOversizedEntry() {
+        val archive = createArchive("config" to ByteArray(5))
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(
+                archive,
+                destination,
+                extractionLimits(maxEntryBytes = 4),
+            )
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsExcessiveTotalSize() {
+        val archive = createArchive(
+            "first" to ByteArray(3),
+            "second" to ByteArray(3),
+        )
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(
+                archive,
+                destination,
+                extractionLimits(maxTotalBytes = 5),
+            )
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsExcessiveCompressionRatio() {
+        val archive = createArchive("config" to ByteArray(4096))
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(
+                archive,
+                destination,
+                extractionLimits(maxCompressionRatio = 2.0),
+            )
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsDuplicateCanonicalDestination() {
+        val archive = createArchive(
+            "config" to byteArrayOf(1),
+            "nested/../config" to byteArrayOf(2),
+        )
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(archive, destination, extractionLimits())
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    @Test
+    fun extractArchiveRejectsEntryBelowFile() {
+        val archive = createArchive(
+            "parent" to byteArrayOf(1),
+            "parent/child" to byteArrayOf(2),
+        )
+        val destination = File(temporaryFolder.root, "destination")
+
+        assertThrows(ZipException::class.java) {
+            ZipUtil.extractArchive(archive, destination, extractionLimits())
+        }
+
+        assertFalse(destination.exists())
+    }
+
+    private fun createArchive(vararg entries: Pair<String, ByteArray>): File {
+        val archive = temporaryFolder.newFile()
+        ZipOutputStream(archive.outputStream()).use { output ->
+            entries.forEach { (name, contents) ->
+                output.putNextEntry(ZipEntry(name))
+                output.write(contents)
+                output.closeEntry()
+            }
+        }
+        return archive
+    }
+
+    private fun extractionLimits(
+        maxArchiveBytes: Long = 1024L * 1024L,
+        maxEntries: Int = 10,
+        maxEntryBytes: Long = 16L * 1024L,
+        maxTotalBytes: Long = 32L * 1024L,
+        maxCompressionRatio: Double = 1000.0,
+    ) = ZipUtil.ExtractionLimits(
+        maxArchiveBytes = maxArchiveBytes,
+        maxEntries = maxEntries,
+        maxEntryBytes = maxEntryBytes,
+        maxTotalBytes = maxTotalBytes,
+        maxCompressionRatio = maxCompressionRatio,
+    )
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/util/ZipUtilTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/util/ZipUtilTest.kt
@@ -29,31 +29,21 @@ class ZipUtilTest {
     @Test
     fun extractArchiveRejectsPathTraversal() {
         val archive = createArchive("../outside" to "overwrite".toByteArray())
-        val destination = File(temporaryFolder.root, "destination")
         val outside = File(temporaryFolder.root, "outside")
 
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(archive, destination, extractionLimits())
-        }
+        assertArchiveRejected(archive)
 
         assertFalse(outside.exists())
-        assertFalse(destination.exists())
     }
 
     @Test
     fun extractArchiveRejectsOversizedArchive() {
         val archive = createArchive("config" to byteArrayOf(1))
-        val destination = File(temporaryFolder.root, "destination")
 
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(
-                archive,
-                destination,
-                extractionLimits(maxArchiveBytes = archive.length() - 1),
-            )
-        }
-
-        assertFalse(destination.exists())
+        assertArchiveRejected(
+            archive,
+            extractionLimits(maxArchiveBytes = archive.length() - 1),
+        )
     }
 
     @Test
@@ -62,33 +52,14 @@ class ZipUtilTest {
             "first" to byteArrayOf(1),
             "second" to byteArrayOf(2),
         )
-        val destination = File(temporaryFolder.root, "destination")
-
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(
-                archive,
-                destination,
-                extractionLimits(maxEntries = 1),
-            )
-        }
-
-        assertFalse(destination.exists())
+        assertArchiveRejected(archive, extractionLimits(maxEntries = 1))
     }
 
     @Test
     fun extractArchiveRejectsOversizedEntry() {
         val archive = createArchive("config" to ByteArray(5))
-        val destination = File(temporaryFolder.root, "destination")
 
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(
-                archive,
-                destination,
-                extractionLimits(maxEntryBytes = 4),
-            )
-        }
-
-        assertFalse(destination.exists())
+        assertArchiveRejected(archive, extractionLimits(maxEntryBytes = 4))
     }
 
     @Test
@@ -97,33 +68,14 @@ class ZipUtilTest {
             "first" to ByteArray(3),
             "second" to ByteArray(3),
         )
-        val destination = File(temporaryFolder.root, "destination")
-
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(
-                archive,
-                destination,
-                extractionLimits(maxTotalBytes = 5),
-            )
-        }
-
-        assertFalse(destination.exists())
+        assertArchiveRejected(archive, extractionLimits(maxTotalBytes = 5))
     }
 
     @Test
     fun extractArchiveRejectsExcessiveCompressionRatio() {
         val archive = createArchive("config" to ByteArray(4096))
-        val destination = File(temporaryFolder.root, "destination")
 
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(
-                archive,
-                destination,
-                extractionLimits(maxCompressionRatio = 2.0),
-            )
-        }
-
-        assertFalse(destination.exists())
+        assertArchiveRejected(archive, extractionLimits(maxCompressionRatio = 2.0))
     }
 
     @Test
@@ -132,13 +84,7 @@ class ZipUtilTest {
             "config" to byteArrayOf(1),
             "nested/../config" to byteArrayOf(2),
         )
-        val destination = File(temporaryFolder.root, "destination")
-
-        assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(archive, destination, extractionLimits())
-        }
-
-        assertFalse(destination.exists())
+        assertArchiveRejected(archive)
     }
 
     @Test
@@ -147,12 +93,17 @@ class ZipUtilTest {
             "parent" to byteArrayOf(1),
             "parent/child" to byteArrayOf(2),
         )
+        assertArchiveRejected(archive)
+    }
+
+    private fun assertArchiveRejected(
+        archive: File,
+        limits: ZipUtil.ExtractionLimits = extractionLimits(),
+    ) {
         val destination = File(temporaryFolder.root, "destination")
-
         assertThrows(ZipException::class.java) {
-            ZipUtil.extractArchive(archive, destination, extractionLimits())
+            ZipUtil.extractArchive(archive, destination, limits)
         }
-
         assertFalse(destination.exists())
     }
 


### PR DESCRIPTION
## Summary

- require every canonicalized ZIP entry target to remain inside a new or empty restore directory
- reject duplicate destinations, file/directory collisions, unsupported compression methods, and inconsistent entry metadata
- bound compressed archive size, entry count, per-entry expansion, total expansion, and compression ratio, with streaming checks against actual extracted bytes
- perform restore I/O on `Dispatchers.IO` and always remove the temporary extraction directory

## Problem

Backup restore previously constructed each output path by appending `ZipEntry.name` to the destination directory without canonical containment validation. A crafted backup selected locally or downloaded from WebDAV could therefore use traversal segments to overwrite files outside the extraction directory.

Extraction also had no resource limits, allowing an archive with excessive entries or expansion to consume disproportionate CPU time and storage.

## Implementation details

The extractor validates the entire central directory before creating the destination:

- maximum compressed archive size: 128 MiB
- maximum entry count: 32
- maximum expanded size per entry: 128 MiB
- maximum total expanded size: 256 MiB
- maximum compression ratio per non-empty entry: 1000:1

The 32-entry cap leaves substantial headroom over the app's current MMKV backup layout, while the 128 MiB per-entry cap accommodates a profile database dominated by an unusually large server list. The compression-ratio and aggregate limits still provide hard upper bounds. Extraction refuses non-empty destinations and existing output files. If streaming fails after extraction begins, newly written output is removed.

The public restore behavior remains unchanged: invalid backups report failure rather than propagating an extraction exception.

## Validation

- `:app:testPlaystoreDebugUnitTest --tests com.v2ray.ang.util.ZipUtilTest`
  - 9 tests covering successful nested extraction, path traversal, archive size, entry count, per-entry size, total expanded size, compression ratio, duplicate canonical destinations, and file/child collisions
- `:app:testPlaystoreDebugUnitTest`
- `:app:compilePlaystoreDebugKotlin`

All checks pass for the Play Store debug variant.
