### PR TITLE
Make profile storage mutations failure-atomic

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -202,6 +202,7 @@ dependencies {
 
     // Testing Libraries
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     testImplementation(libs.org.mockito.mockito.inline)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -240,7 +240,12 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseBatchConfig(servers: String?, subid: String, append: Boolean): Int {
+    private fun parseBatchConfig(
+        servers: String?,
+        subid: String,
+        append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
+    ): Int {
         try {
             if (servers == null) {
                 return 0
@@ -264,6 +269,7 @@ object AngConfigManager {
                     configs = configs.map(::ParsedProfile),
                     subid = subid,
                     append = append,
+                    subscriptionUpdate = subscriptionUpdate,
                 )
             }
 
@@ -287,6 +293,7 @@ object AngConfigManager {
         configs: List<ParsedProfile>,
         subid: String,
         append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
     ) {
         val keyToProfile = linkedMapOf<String, ProfileItem>()
         val rawConfigs = mutableMapOf<String, String>()
@@ -302,6 +309,7 @@ object AngConfigManager {
             rawConfigs = rawConfigs,
             subscriptionId = subid,
             append = append,
+            subscriptionUpdate = subscriptionUpdate,
         )
     }
 
@@ -313,7 +321,12 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseCustomConfigServer(server: String?, subid: String, append: Boolean): Int {
+    private fun parseCustomConfigServer(
+        server: String?,
+        subid: String,
+        append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
+    ): Int {
         if (server == null) {
             return 0
         }
@@ -335,7 +348,7 @@ object AngConfigManager {
                             rawConfig = JsonUtil.toJsonPretty(srv) ?: "",
                         )
                     }
-                    commitProfiles(configs, subid, append)
+                    commitProfiles(configs, subid, append, subscriptionUpdate)
                     return configs.size
                 }
             } catch (e: ProfileStorageException) {
@@ -353,6 +366,7 @@ object AngConfigManager {
                     configs = listOf(ParsedProfile(config, server)),
                     subid = subid,
                     append = append,
+                    subscriptionUpdate = subscriptionUpdate,
                 )
                 return 1
             } catch (e: ProfileStorageException) {
@@ -370,6 +384,7 @@ object AngConfigManager {
                     configs = listOf(ParsedProfile(config, server)),
                     subid = subid,
                     append = append,
+                    subscriptionUpdate = subscriptionUpdate,
                 )
                 return 1
             } catch (e: ProfileStorageException) {
@@ -480,7 +495,8 @@ object AngConfigManager {
                     return SubscriptionUpdateResult(failureCount = 1)
                 }
             }
-            LogUtil.i(AppConfig.TAG, url)
+            val expectedSubscription = it.subscription.copy()
+            LogUtil.i(AppConfig.TAG, "Updating subscription ${it.guid}")
             val userAgent = it.subscription.userAgent
             val requestHeaders = it.subscription.requestHeaders
             val proxyUsername = SettingsManager.getSocksUsername()
@@ -521,11 +537,20 @@ object AngConfigManager {
                 return SubscriptionUpdateResult(failureCount = 1)
             }
 
-            val count = parseConfigViaSub(configText, it.guid, false)
+            val updatedSubscription = expectedSubscription.copy(
+                lastUpdated = System.currentTimeMillis(),
+            )
+            val count = parseConfigViaSub(
+                server = configText,
+                subid = it.guid,
+                append = false,
+                subscriptionUpdate = SubscriptionUpdateCommit(
+                    expected = expectedSubscription,
+                    replacement = updatedSubscription,
+                ),
+            )
             if (count > 0) {
-                it.subscription.lastUpdated = System.currentTimeMillis()
-                MmkvManager.encodeSubscription(it.guid, it.subscription)
-                LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")
+                LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.guid}, $count configs")
                 return SubscriptionUpdateResult(
                     configCount = count,
                     successCount = 1
@@ -534,6 +559,9 @@ object AngConfigManager {
                 // Got response but no valid configs parsed
                 return SubscriptionUpdateResult(failureCount = 1)
             }
+        } catch (e: SubscriptionUpdateAbortedException) {
+            LogUtil.i(AppConfig.TAG, "Subscription update skipped after metadata changed: ${it.guid}")
+            return SubscriptionUpdateResult(skipCount = 1)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to update config via subscription", e)
             return SubscriptionUpdateResult(failureCount = 1)
@@ -583,13 +611,18 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseConfigViaSub(server: String?, subid: String, append: Boolean): Int {
-        var count = parseBatchConfig(Utils.decode(server), subid, append)
+    private fun parseConfigViaSub(
+        server: String?,
+        subid: String,
+        append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
+    ): Int {
+        var count = parseBatchConfig(Utils.decode(server), subid, append, subscriptionUpdate)
         if (count <= 0) {
-            count = parseBatchConfig(server, subid, append)
+            count = parseBatchConfig(server, subid, append, subscriptionUpdate)
         }
         if (count <= 0) {
-            count = parseCustomConfigServer(server, subid, append)
+            count = parseCustomConfigServer(server, subid, append, subscriptionUpdate)
         }
         return count
     }
@@ -611,8 +644,7 @@ object AngConfigManager {
         val subItem = SubscriptionItem()
         subItem.remarks = uri.fragment ?: "import sub"
         subItem.url = url
-        MmkvManager.encodeSubscription("", subItem)
-        return 1
+        return if (MmkvManager.encodeSubscription("", subItem) != null) 1 else 0
     }
 
     /** Generates a description for the profile.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -182,13 +182,7 @@ object AngConfigManager {
      */
     fun importBatchConfig(server: String?, subid: String, append: Boolean): Pair<Int, Int> {
         return try {
-            var count = parseBatchConfig(Utils.decode(server), subid, append)
-            if (count <= 0) {
-                count = parseBatchConfig(server, subid, append)
-            }
-            if (count <= 0) {
-                count = parseCustomConfigServer(server, subid, append)
-            }
+            val count = parseAndCommitProfiles(server, subid, append)
 
             var countSub = parseBatchSubscription(server)
             if (countSub <= 0) {
@@ -540,7 +534,7 @@ object AngConfigManager {
             val updatedSubscription = expectedSubscription.copy(
                 lastUpdated = System.currentTimeMillis(),
             )
-            val count = parseConfigViaSub(
+            val count = parseAndCommitProfiles(
                 server = configText,
                 subid = it.guid,
                 append = false,
@@ -604,14 +598,14 @@ object AngConfigManager {
     }
 
     /**
-     * Parses the configuration via a subscription.
+     * Parses and commits profiles from encoded, plain, or custom configuration text.
      *
      * @param server The server string.
      * @param subid The subscription ID.
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseConfigViaSub(
+    private fun parseAndCommitProfiles(
         server: String?,
         subid: String,
         append: Boolean,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -596,7 +596,7 @@ object AngConfigManager {
             .sortedBy { it.second }
             .map { it.first }
             .toMutableList()
-        MmkvManager.encodeServerList(sorted, subId)
+        MmkvManager.reorderServerList(sorted, subId)
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -239,7 +239,12 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseBatchConfig(servers: String?, subid: String, append: Boolean): Int {
+    private fun parseBatchConfig(
+        servers: String?,
+        subid: String,
+        append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
+    ): Int {
         try {
             if (servers == null) {
                 return 0
@@ -272,6 +277,7 @@ object AngConfigManager {
                     configs = allConfigs.map(::ParsedProfile),
                     subid = subid,
                     append = append,
+                    subscriptionUpdate = subscriptionUpdate,
                 )
             }
 
@@ -295,6 +301,7 @@ object AngConfigManager {
         configs: List<ParsedProfile>,
         subid: String,
         append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
     ) {
         val keyToProfile = linkedMapOf<String, ProfileItem>()
         val rawConfigs = mutableMapOf<String, String>()
@@ -310,6 +317,7 @@ object AngConfigManager {
             rawConfigs = rawConfigs,
             subscriptionId = subid,
             append = append,
+            subscriptionUpdate = subscriptionUpdate,
         )
     }
 
@@ -321,7 +329,12 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseCustomConfigServer(server: String?, subid: String, append: Boolean): Int {
+    private fun parseCustomConfigServer(
+        server: String?,
+        subid: String,
+        append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
+    ): Int {
         if (server == null) {
             return 0
         }
@@ -343,7 +356,7 @@ object AngConfigManager {
                             rawConfig = JsonUtil.toJsonPretty(srv) ?: "",
                         )
                     }
-                    commitProfiles(configs, subid, append)
+                    commitProfiles(configs, subid, append, subscriptionUpdate)
                     return configs.size
                 }
             } catch (e: ProfileStorageException) {
@@ -361,6 +374,7 @@ object AngConfigManager {
                     configs = listOf(ParsedProfile(config, server)),
                     subid = subid,
                     append = append,
+                    subscriptionUpdate = subscriptionUpdate,
                 )
                 return 1
             } catch (e: ProfileStorageException) {
@@ -378,6 +392,7 @@ object AngConfigManager {
                     configs = listOf(ParsedProfile(config, server)),
                     subid = subid,
                     append = append,
+                    subscriptionUpdate = subscriptionUpdate,
                 )
                 return 1
             } catch (e: ProfileStorageException) {
@@ -482,7 +497,8 @@ object AngConfigManager {
                     return SubscriptionUpdateResult(failureCount = 1)
                 }
             }
-            LogUtil.i(AppConfig.TAG, url)
+            val expectedSubscription = it.subscription.copy()
+            LogUtil.i(AppConfig.TAG, "Updating subscription ${it.guid}")
             val userAgent = it.subscription.userAgent
             val requestHeaders = it.subscription.requestHeaders
             val proxyUsername = SettingsManager.getSocksUsername()
@@ -523,11 +539,20 @@ object AngConfigManager {
                 return SubscriptionUpdateResult(failureCount = 1)
             }
 
-            val count = parseConfigViaSub(configText, it.guid, false)
+            val updatedSubscription = expectedSubscription.copy(
+                lastUpdated = System.currentTimeMillis(),
+            )
+            val count = parseConfigViaSub(
+                server = configText,
+                subid = it.guid,
+                append = false,
+                subscriptionUpdate = SubscriptionUpdateCommit(
+                    expected = expectedSubscription,
+                    replacement = updatedSubscription,
+                ),
+            )
             if (count > 0) {
-                it.subscription.lastUpdated = System.currentTimeMillis()
-                MmkvManager.encodeSubscription(it.guid, it.subscription)
-                LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.subscription.remarks}, $count configs")
+                LogUtil.i(AppConfig.TAG, "Subscription updated: ${it.guid}, $count configs")
                 return SubscriptionUpdateResult(
                     configCount = count,
                     successCount = 1
@@ -536,6 +561,9 @@ object AngConfigManager {
                 // Got response but no valid configs parsed
                 return SubscriptionUpdateResult(failureCount = 1)
             }
+        } catch (e: SubscriptionUpdateAbortedException) {
+            LogUtil.i(AppConfig.TAG, "Subscription update skipped after metadata changed: ${it.guid}")
+            return SubscriptionUpdateResult(skipCount = 1)
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to update config via subscription", e)
             return SubscriptionUpdateResult(failureCount = 1)
@@ -585,13 +613,18 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseConfigViaSub(server: String?, subid: String, append: Boolean): Int {
-        var count = parseBatchConfig(Utils.decode(server), subid, append)
+    private fun parseConfigViaSub(
+        server: String?,
+        subid: String,
+        append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
+    ): Int {
+        var count = parseBatchConfig(Utils.decode(server), subid, append, subscriptionUpdate)
         if (count <= 0) {
-            count = parseBatchConfig(server, subid, append)
+            count = parseBatchConfig(server, subid, append, subscriptionUpdate)
         }
         if (count <= 0) {
-            count = parseCustomConfigServer(server, subid, append)
+            count = parseCustomConfigServer(server, subid, append, subscriptionUpdate)
         }
         return count
     }
@@ -613,8 +646,7 @@ object AngConfigManager {
         val subItem = SubscriptionItem()
         subItem.remarks = uri.fragment ?: "import sub"
         subItem.url = url
-        MmkvManager.encodeSubscription("", subItem)
-        return 1
+        return if (MmkvManager.encodeSubscription("", subItem) != null) 1 else 0
     }
 
     /** Generates a description for the profile.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -181,13 +181,7 @@ object AngConfigManager {
      */
     fun importBatchConfig(server: String?, subid: String, append: Boolean): Pair<Int, Int> {
         return try {
-            var count = parseBatchConfig(Utils.decode(server), subid, append)
-            if (count <= 0) {
-                count = parseBatchConfig(server, subid, append)
-            }
-            if (count <= 0) {
-                count = parseCustomConfigServer(server, subid, append)
-            }
+            val count = parseAndCommitProfiles(server, subid, append)
 
             var countSub = parseBatchSubscription(server)
             if (countSub <= 0) {
@@ -542,7 +536,7 @@ object AngConfigManager {
             val updatedSubscription = expectedSubscription.copy(
                 lastUpdated = System.currentTimeMillis(),
             )
-            val count = parseConfigViaSub(
+            val count = parseAndCommitProfiles(
                 server = configText,
                 subid = it.guid,
                 append = false,
@@ -606,14 +600,14 @@ object AngConfigManager {
     }
 
     /**
-     * Parses the configuration via a subscription.
+     * Parses and commits profiles from encoded, plain, or custom configuration text.
      *
      * @param server The server string.
      * @param subid The subscription ID.
      * @param append Whether to append the configurations.
      * @return The number of configurations parsed.
      */
-    private fun parseConfigViaSub(
+    private fun parseAndCommitProfiles(
         server: String?,
         subid: String,
         append: Boolean,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -338,14 +338,23 @@ object MmkvManager {
 
     //region Server
 
-    /**
-     * Reads the legacy server list from KEY_ANG_CONFIGS for migration.
-     * This method is for migration purposes only.
-     *
-     * @return The JSON string of legacy server list, or null if not exists.
-     */
-    fun readLegacyServerList(): String? {
-        return mainStorage.decodeString(KEY_ANG_CONFIGS)
+    /** Missing records may be skipped; existing unreadable indexes or payloads abort migration. */
+    internal fun readProfilesForMigration(legacy: Boolean = false): Map<String, ProfileItem> {
+        return withProfileIndexLock {
+            val ids = if (legacy) {
+                decodeStringListForWrite(KEY_ANG_CONFIGS, "legacy profile index")
+            } else {
+                (decodeSubsListForWrite() + DEFAULT_SUBSCRIPTION_ID).distinct()
+                    .flatMap { decodeServerListForWrite(it) }
+            }
+            val profiles = linkedMapOf<String, ProfileItem>()
+            for (guid in ids.distinct()) {
+                val json = readStoredString(profileFullStorage, guid, "migration profile $guid") ?: continue
+                profiles[guid] = JsonUtil.fromJsonSafe(json, ProfileItem::class.java)
+                    ?: throw ProfileStorageException("Failed to decode migration profile $guid")
+            }
+            profiles
+        }
     }
 
 
@@ -370,22 +379,43 @@ object MmkvManager {
     }
 
     /**
-     * Encodes the server list for a given subscription.
-     * Saves to the subscription's serverList (including default subscription for ungrouped servers).
+     * Adds legacy server IDs without dropping profiles imported since a failed migration attempt.
+     * Reordering must use [reorderServerList] instead.
      *
      * @param serverList The list of server GUIDs.
      * @param subscriptionId The subscription ID.
      */
-    fun encodeServerList(serverList: MutableList<String>, subscriptionId: String): Boolean {
+    internal fun migrateServerList(serverList: List<String>, subscriptionId: String): Boolean {
         return try {
             withProfileIndexLock {
+                val merged = (decodeServerListForWrite(subscriptionId) + serverList).distinct()
                 runStorageMutationTransaction {
-                    writeProfileIndex(serverListKey(subscriptionId), serverList)
+                    writeProfileIndex(serverListKey(subscriptionId), merged)
                 }
             }
             true
         } catch (e: Exception) {
-            LogUtil.e(TAG, "Failed to persist profile order for group $subscriptionId", e)
+            LogUtil.e(TAG, "Failed to migrate profile index for group $subscriptionId", e)
+            false
+        }
+    }
+
+    fun reorderServerList(serverList: List<String>, subscriptionId: String): Boolean =
+        reorderIndex(serverListKey(subscriptionId), serverList)
+
+    /** A stale UI snapshot may change order, but must never change current membership. */
+    private fun reorderIndex(key: String, requestedOrder: List<String>): Boolean {
+        return try {
+            withProfileIndexLock {
+                val current = decodeStringListForWrite(key, "index $key").toMutableSet()
+                val reordered = requestedOrder.filter { current.remove(it) } + current
+                runStorageMutationTransaction {
+                    writeString(mainStorage, key, JsonUtil.toJson(reordered), "index $key")
+                }
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to reorder index $key", e)
             false
         }
     }
@@ -512,17 +542,8 @@ object MmkvManager {
         if (profiles.isEmpty()) return
 
         withProfileIndexLock {
-            subscriptionUpdate?.let { update ->
-                val subscriptionIds = decodeSubsListForWrite()
-                val currentSubscription = decodeSubscription(subscriptionId)
-                if (!SubscriptionUpdateGuard.canCommit(
-                        isIndexed = subscriptionId in subscriptionIds,
-                        current = currentSubscription,
-                        expected = update.expected,
-                    )
-                ) {
-                    throw SubscriptionUpdateAbortedException()
-                }
+            val updatedSubscription = subscriptionUpdate?.let { update ->
+                mergeSubscriptionUpdate(subscriptionId, update.expected, update.replacement, update.replacement.lastUpdated)
             }
             val replacedServers = if (append) {
                 emptyList()
@@ -559,7 +580,7 @@ object MmkvManager {
             val removablePayloads = runStorageMutationTransaction {
                 rawConfigs.forEach { (guid, raw) -> writeRawProfilePayload(guid, raw) }
                 profiles.forEach { (guid, profile) -> writeProfilePayload(guid, profile) }
-                subscriptionUpdate?.let { writeSubscriptionPayload(subscriptionId, it.replacement) }
+                updatedSubscription?.let { writeSubscriptionPayload(subscriptionId, it) }
                 replacementSelection?.let { writeSelectedProfile(it) }
 
                 val removable = if (replacedServers.isEmpty()) {
@@ -779,17 +800,23 @@ object MmkvManager {
     }
 
     /**
-     * Initializes the subscription list.
+     * Migrates the pre-index subscription format at startup, never during normal reads.
+     * An explicitly empty index is authoritative even if payload cleanup previously failed.
      */
-    private fun initSubsList() {
-        val subsList = decodeSubsList()
-        if (subsList.isNotEmpty()) {
-            return
+    internal fun migrateSubscriptionIndex(): Boolean {
+        return try {
+            withProfileIndexLock {
+                if (!mainStorage.containsKey(KEY_SUB_IDS)) {
+                    val ids = subStorage.allKeys()?.toList()
+                        ?: throw ProfileStorageException("Failed to read legacy subscriptions")
+                    runStorageMutationTransaction { writeSubscriptionIndex(ids) }
+                }
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to migrate subscription index", e)
+            false
         }
-        subStorage.allKeys()?.forEach { key ->
-            subsList.add(key)
-        }
-        encodeSubsList(subsList)
     }
 
     /**
@@ -798,8 +825,6 @@ object MmkvManager {
      * @return The list of subscriptions.
      */
     fun decodeSubscriptions(): List<SubscriptionCache> {
-        initSubsList()
-
         val subscriptions = mutableListOf<SubscriptionCache>()
         decodeSubsList().forEach { key ->
             val json = subStorage.decodeString(key)
@@ -884,28 +909,20 @@ object MmkvManager {
     }
 
     /**
-     * Replaces an existing subscription only if it has not changed since the caller read it.
+     * Replaces unchanged subscription settings, preserving the stored refresh timestamp.
+     * A refresh supplies [updatedAt] and additionally requires unchanged refresh metadata.
      */
     fun updateSubscription(
         guid: String,
         expected: SubscriptionItem,
         replacement: SubscriptionItem,
+        updatedAt: Long? = null,
     ): Boolean {
         return try {
             withProfileIndexLock {
-                val subscriptionIds = decodeSubsListForWrite()
-                val current = decodeSubscription(guid)
-                if (!SubscriptionUpdateGuard.canCommit(
-                        isIndexed = guid in subscriptionIds,
-                        current = current,
-                        expected = expected,
-                    )
-                ) {
-                    throw SubscriptionUpdateAbortedException()
-                }
-
+                val updated = mergeSubscriptionUpdate(guid, expected, replacement, updatedAt)
                 runStorageMutationTransaction {
-                    writeSubscriptionPayload(guid, replacement)
+                    writeSubscriptionPayload(guid, updated)
                 }
             }
             true
@@ -916,6 +933,24 @@ object MmkvManager {
             LogUtil.e(TAG, "Failed to update subscription $guid", e)
             false
         }
+    }
+
+    // Caller holds the profile index lock across validation and persistence.
+    private fun mergeSubscriptionUpdate(
+        guid: String,
+        expected: SubscriptionItem,
+        replacement: SubscriptionItem,
+        updatedAt: Long?,
+    ): SubscriptionItem {
+        val current = decodeSubscription(guid) ?: throw SubscriptionUpdateAbortedException()
+        if (!SubscriptionUpdateGuard.canCommit(guid in decodeSubsListForWrite(), current, expected) ||
+            (updatedAt != null && current.lastUpdated != expected.lastUpdated)
+        ) {
+            throw SubscriptionUpdateAbortedException()
+        }
+        // Wall-clock time may move backwards. Reject stale refreshes by their expected state,
+        // not by ordering timestamps; a settings edit never owns this metadata.
+        return replacement.copy(lastUpdated = updatedAt ?: current.lastUpdated)
     }
 
     /**
@@ -930,23 +965,11 @@ object MmkvManager {
     }
 
     /**
-     * Encodes the subscription list.
+     * Reorders existing subscriptions without publishing or removing IDs.
      *
      * @param subsList The list of subscription IDs.
      */
-    fun encodeSubsList(subsList: MutableList<String>): Boolean {
-        return try {
-            withProfileIndexLock {
-                runStorageMutationTransaction {
-                    writeSubscriptionIndex(subsList)
-                }
-            }
-            true
-        } catch (e: Exception) {
-            LogUtil.e(TAG, "Failed to persist subscription order", e)
-            false
-        }
-    }
+    fun reorderSubscriptions(subsList: List<String>): Boolean = reorderIndex(KEY_SUB_IDS, subsList)
 
     /**
      * Decodes the subscription list.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -54,22 +54,6 @@ internal class StorageMutationTransaction {
         if (!change()) throw ProfileStorageException(failureMessage)
     }
 
-    /**
-     * Prepares a profile mutation and writes its authoritative index as the final step.
-     */
-    fun <T> prepareThenPublish(
-        prepare: StorageMutationTransaction.() -> T,
-        publish: StorageMutationTransaction.() -> Unit,
-    ): T {
-        val result = prepare()
-        publish()
-        return result
-    }
-
-    fun commit() {
-        rollbackActions.clear()
-    }
-
     fun rollback(failure: Throwable) {
         rollbackActions.asReversed().forEach { action ->
             try {
@@ -82,7 +66,6 @@ internal class StorageMutationTransaction {
                 failure.addSuppressed(rollbackFailure)
             }
         }
-        rollbackActions.clear()
     }
 }
 
@@ -91,7 +74,7 @@ internal fun <T> runStorageMutationTransaction(
 ): T {
     val transaction = StorageMutationTransaction()
     return try {
-        transaction.block().also { transaction.commit() }
+        transaction.block()
     } catch (failure: Throwable) {
         transaction.rollback(failure)
         throw failure
@@ -141,11 +124,6 @@ object MmkvManager {
     private val assetStorage by lazy { MMKV.mmkvWithID(ID_ASSET, MMKV.MULTI_PROCESS_MODE) }
     private val settingsStorage by lazy { MMKV.mmkvWithID(ID_SETTING, MMKV.MULTI_PROCESS_MODE) }
 
-    private data class StoredString(
-        val isPresent: Boolean,
-        val value: String?,
-    )
-
     private inline fun <T> withProfileIndexLock(block: () -> T): T {
         return synchronized(mainStorage) {
             mainStorage.lock()
@@ -165,16 +143,15 @@ object MmkvManager {
         serverRawStorage.removeValuesForKeys(keys)
     }
 
-    private fun readStoredString(storage: MMKV, key: String, description: String): StoredString {
-        if (!storage.containsKey(key)) return StoredString(isPresent = false, value = null)
-        val value = storage.decodeString(key)
+    private fun readStoredString(storage: MMKV, key: String, description: String): String? {
+        if (!storage.containsKey(key)) return null
+        return storage.decodeString(key)
             ?: throw ProfileStorageException("Failed to read $description")
-        return StoredString(isPresent = true, value = value)
     }
 
-    private fun restoreStoredString(storage: MMKV, key: String, stored: StoredString): Boolean {
-        return if (stored.isPresent) {
-            storage.encode(key, stored.value!!)
+    private fun restoreStoredString(storage: MMKV, key: String, stored: String?): Boolean {
+        return if (stored != null) {
+            storage.encode(key, stored)
         } else {
             storage.remove(key)
             !storage.containsKey(key)
@@ -188,7 +165,7 @@ object MmkvManager {
         description: String,
     ) {
         val stored = readStoredString(storage, key, description)
-        if (stored.isPresent && stored.value == value) return
+        if (stored == value) return
         mutate(
             change = { storage.encode(key, value) },
             restore = { restoreStoredString(storage, key, stored) },
@@ -202,7 +179,7 @@ object MmkvManager {
         description: String,
     ) {
         val stored = readStoredString(storage, key, description)
-        if (!stored.isPresent) return
+        if (stored == null) return
         mutate(
             change = {
                 storage.remove(key)
@@ -213,28 +190,53 @@ object MmkvManager {
         )
     }
 
+    private fun StorageMutationTransaction.writeProfilePayload(guid: String, profile: ProfileItem) {
+        writeString(profileFullStorage, guid, JsonUtil.toJson(profile), "profile payload")
+    }
+
+    private fun StorageMutationTransaction.writeRawProfilePayload(guid: String, raw: String) {
+        writeString(serverRawStorage, guid, raw, "raw profile payload")
+    }
+
+    private fun StorageMutationTransaction.writeProfileIndex(
+        profileIndexKey: String,
+        serverList: List<String>,
+    ) {
+        writeString(mainStorage, profileIndexKey, JsonUtil.toJson(serverList), "profile index")
+    }
+
+    private fun StorageMutationTransaction.writeSelectedProfile(guid: String) {
+        writeString(mainStorage, KEY_SELECTED_SERVER, guid, "selected profile")
+    }
+
+    private fun StorageMutationTransaction.removeSelectedProfile() {
+        removeString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
+    }
+
+    private fun StorageMutationTransaction.writeSubscriptionPayload(
+        guid: String,
+        subscription: SubscriptionItem,
+    ) {
+        writeString(subStorage, guid, JsonUtil.toJson(subscription), "subscription payload")
+    }
+
+    private fun StorageMutationTransaction.writeSubscriptionIndex(subsList: List<String>) {
+        writeString(mainStorage, KEY_SUB_IDS, JsonUtil.toJson(subsList), "subscription index")
+    }
+
+    private fun decodeStringListForWrite(key: String, description: String): MutableList<String> {
+        val stored = readStoredString(mainStorage, key, description) ?: return mutableListOf()
+        if (stored.isBlank()) throw ProfileStorageException("Failed to decode $description")
+        return JsonUtil.fromJsonSafe(stored, Array<String>::class.java)?.toMutableList()
+            ?: throw ProfileStorageException("Failed to decode $description")
+    }
+
     private fun decodeServerListForWrite(subscriptionId: String): MutableList<String> {
-        val stored = readStoredString(
-            storage = mainStorage,
-            key = serverListKey(subscriptionId),
-            description = "profile index",
-        )
-        if (!stored.isPresent) return mutableListOf()
-        if (stored.value.isNullOrBlank()) {
-            throw ProfileStorageException("Failed to decode profile index")
-        }
-        return JsonUtil.fromJsonSafe(stored.value, Array<String>::class.java)?.toMutableList()
-            ?: throw ProfileStorageException("Failed to decode profile index")
+        return decodeStringListForWrite(serverListKey(subscriptionId), "profile index")
     }
 
     private fun decodeSubsListForWrite(): MutableList<String> {
-        val stored = readStoredString(mainStorage, KEY_SUB_IDS, "subscription index")
-        if (!stored.isPresent) return mutableListOf()
-        if (stored.value.isNullOrBlank()) {
-            throw ProfileStorageException("Failed to decode subscription index")
-        }
-        return JsonUtil.fromJsonSafe(stored.value, Array<String>::class.java)?.toMutableList()
-            ?: throw ProfileStorageException("Failed to decode subscription index")
+        return decodeStringListForWrite(KEY_SUB_IDS, "subscription index")
     }
 
     private fun serverListKey(subscriptionId: String): String {
@@ -281,28 +283,32 @@ object MmkvManager {
             protectedServer = null,
             serversReferencedByOtherGroups = referencedByOtherGroups,
         )
-        return prepareThenPublish(
-            prepare = {
-                val selectedServer = readStoredString(
-                    storage = mainStorage,
-                    key = KEY_SELECTED_SERVER,
-                    description = "selected profile",
-                )
-                if (selectedServer.value in removablePayloads) {
-                    removeString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
+        val selectedServer = readStoredString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
+        if (selectedServer != null && selectedServer in removablePayloads) {
+            removeSelectedProfile()
+        }
+        serverList.removeAll(removedServers)
+        writeProfileIndex(serverListKey(subscriptionId), serverList)
+        return removablePayloads
+    }
+
+    private fun removeProfiles(
+        requestedGuids: Set<String>?,
+        failureMessage: String,
+        resolveSubscriptionId: () -> String,
+    ): Boolean {
+        return try {
+            withProfileIndexLock {
+                val removablePayloads = runStorageMutationTransaction {
+                    removeProfilesFromGroup(resolveSubscriptionId(), requestedGuids)
                 }
-                removablePayloads
-            },
-            publish = {
-                serverList.removeAll(removedServers)
-                writeString(
-                    storage = mainStorage,
-                    key = serverListKey(subscriptionId),
-                    value = JsonUtil.toJson(serverList),
-                    description = "profile index",
-                )
-            },
-        )
+                removeProfilePayloads(removablePayloads)
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, failureMessage, e)
+            false
+        }
     }
 
     //endregion
@@ -374,12 +380,7 @@ object MmkvManager {
         return try {
             withProfileIndexLock {
                 runStorageMutationTransaction {
-                    writeString(
-                        storage = mainStorage,
-                        key = serverListKey(subscriptionId),
-                        value = JsonUtil.toJson(serverList),
-                        description = "profile index",
-                    )
+                    writeProfileIndex(serverListKey(subscriptionId), serverList)
                 }
             }
             true
@@ -469,54 +470,21 @@ object MmkvManager {
                 val serverList = decodeServerListForWrite(subId)
                 val needsIndexWrite = !serverList.contains(key)
                 val selectedServer = if (needsIndexWrite) {
-                    readStoredString(
-                        storage = mainStorage,
-                        key = KEY_SELECTED_SERVER,
-                        description = "selected profile",
-                    )
+                    readStoredString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
                 } else {
                     null
                 }
 
                 runStorageMutationTransaction {
-                    prepareThenPublish(
-                        prepare = {
-                            rawConfig?.let { raw ->
-                                writeString(
-                                    storage = serverRawStorage,
-                                    key = key,
-                                    value = raw,
-                                    description = "raw profile payload",
-                                )
-                            }
-                            writeString(
-                                storage = profileFullStorage,
-                                key = key,
-                                value = JsonUtil.toJson(config),
-                                description = "profile payload",
-                            )
-
-                            if (needsIndexWrite && selectedServer?.value.isNullOrBlank()) {
-                                writeString(
-                                    storage = mainStorage,
-                                    key = KEY_SELECTED_SERVER,
-                                    value = key,
-                                    description = "selected profile",
-                                )
-                            }
-                        },
-                        publish = {
-                            if (needsIndexWrite) {
-                                serverList.add(0, key)
-                                writeString(
-                                    storage = mainStorage,
-                                    key = serverListKey(subId),
-                                    value = JsonUtil.toJson(serverList),
-                                    description = "profile index",
-                                )
-                            }
-                        },
-                    )
+                    rawConfig?.let { writeRawProfilePayload(key, it) }
+                    writeProfilePayload(key, config)
+                    if (needsIndexWrite && selectedServer.isNullOrBlank()) {
+                        writeSelectedProfile(key)
+                    }
+                    if (needsIndexWrite) {
+                        serverList.add(0, key)
+                        writeProfileIndex(serverListKey(subId), serverList)
+                    }
                 }
             }
             key
@@ -561,11 +529,7 @@ object MmkvManager {
             } else {
                 decodeServerListForWrite(subscriptionId).toList()
             }
-            val previousSelection = readStoredString(
-                storage = mainStorage,
-                key = KEY_SELECTED_SERVER,
-                description = "selected profile",
-            ).value
+            val previousSelection = readStoredString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
             val selectedProfile = if (!append &&
                 previousSelection != null &&
                 previousSelection in replacedServers
@@ -593,60 +557,24 @@ object MmkvManager {
             }
 
             val removablePayloads = runStorageMutationTransaction {
-                prepareThenPublish(
-                    prepare = {
-                        rawConfigs.forEach { (guid, raw) ->
-                            writeString(
-                                storage = serverRawStorage,
-                                key = guid,
-                                value = raw,
-                                description = "raw profile payload",
-                            )
-                        }
-                        profiles.forEach { (guid, profile) ->
-                            writeString(
-                                storage = profileFullStorage,
-                                key = guid,
-                                value = JsonUtil.toJson(profile),
-                                description = "profile payload",
-                            )
-                        }
-                        subscriptionUpdate?.let { update ->
-                            writeString(
-                                storage = subStorage,
-                                key = subscriptionId,
-                                value = JsonUtil.toJson(update.replacement),
-                                description = "subscription payload",
-                            )
-                        }
-                        replacementSelection?.let { guid ->
-                            writeString(
-                                storage = mainStorage,
-                                key = KEY_SELECTED_SERVER,
-                                value = guid,
-                                description = "selected profile",
-                            )
-                        }
+                rawConfigs.forEach { (guid, raw) -> writeRawProfilePayload(guid, raw) }
+                profiles.forEach { (guid, profile) -> writeProfilePayload(guid, profile) }
+                subscriptionUpdate?.let { writeSubscriptionPayload(subscriptionId, it.replacement) }
+                replacementSelection?.let { writeSelectedProfile(it) }
 
-                        if (replacedServers.isEmpty()) return@prepareThenPublish emptySet()
-                        val protectedServer = replacementSelection ?: previousSelection
-                        val referencedByOtherGroups = decodeServersReferencedByOtherGroups(subscriptionId)
-                        ProfileReplacement.findRemovablePayloads(
-                            replacedServers = replacedServers,
-                            replacementServers = profiles.keys,
-                            protectedServer = protectedServer,
-                            serversReferencedByOtherGroups = referencedByOtherGroups,
-                        )
-                    },
-                    publish = {
-                        writeString(
-                            storage = mainStorage,
-                            key = serverListKey(subscriptionId),
-                            value = JsonUtil.toJson(serverList),
-                            description = "profile index",
-                        )
-                    },
-                )
+                val removable = if (replacedServers.isEmpty()) {
+                    emptySet()
+                } else {
+                    ProfileReplacement.findRemovablePayloads(
+                        replacedServers = replacedServers,
+                        replacementServers = profiles.keys,
+                        protectedServer = replacementSelection ?: previousSelection,
+                        serversReferencedByOtherGroups =
+                            decodeServersReferencedByOtherGroups(subscriptionId),
+                    )
+                }
+                writeProfileIndex(serverListKey(subscriptionId), serverList)
+                removable
             }
             removeProfilePayloads(removablePayloads)
         }
@@ -658,24 +586,9 @@ object MmkvManager {
      * @param guid The server GUID.
      */
     fun removeServer(guid: String): Boolean {
-        if (guid.isBlank()) {
-            return false
-        }
-
-        return try {
-            withProfileIndexLock {
-                // Get config to determine which subscription to update
-                val config = decodeServerConfig(guid)
-                val subId = getSubscriptionId(config?.subscriptionId)
-                val removablePayloads = runStorageMutationTransaction {
-                    removeProfilesFromGroup(subId, setOf(guid))
-                }
-                removeProfilePayloads(removablePayloads)
-            }
-            true
-        } catch (e: Exception) {
-            LogUtil.e(TAG, "Failed to remove profile $guid", e)
-            false
+        if (guid.isBlank()) return false
+        return removeProfiles(setOf(guid), "Failed to remove profile $guid") {
+            getSubscriptionId(decodeServerConfig(guid)?.subscriptionId)
         }
     }
 
@@ -686,18 +599,7 @@ object MmkvManager {
      */
     fun removeServerViaSubid(subscriptionId: String?): Boolean {
         val subId = getSubscriptionId(subscriptionId)
-        return try {
-            withProfileIndexLock {
-                val removablePayloads = runStorageMutationTransaction {
-                    removeProfilesFromGroup(subId, requestedGuids = null)
-                }
-                removeProfilePayloads(removablePayloads)
-            }
-            true
-        } catch (e: Exception) {
-            LogUtil.e(TAG, "Failed to remove profiles for group $subId", e)
-            false
-        }
+        return removeProfiles(null, "Failed to remove profiles for group $subId") { subId }
     }
 
     /**
@@ -709,18 +611,7 @@ object MmkvManager {
     fun removeServers(guids: List<String>, subscriptionId: String): Boolean {
         if (guids.isEmpty()) return true
         val subId = getSubscriptionId(subscriptionId)
-        return try {
-            withProfileIndexLock {
-                val removablePayloads = runStorageMutationTransaction {
-                    removeProfilesFromGroup(subId, guids.toSet())
-                }
-                removeProfilePayloads(removablePayloads)
-            }
-            true
-        } catch (e: Exception) {
-            LogUtil.e(TAG, "Failed to remove profiles for group $subId", e)
-            false
-        }
+        return removeProfiles(guids.toSet(), "Failed to remove profiles for group $subId") { subId }
     }
 
     /**
@@ -781,14 +672,9 @@ object MmkvManager {
                 .filter { key -> key.startsWith(KEY_SUB_SERVER_PREFIX) }
             runStorageMutationTransaction {
                 profileIndexKeys.forEach { key ->
-                    writeString(
-                        storage = mainStorage,
-                        key = key,
-                        value = JsonUtil.toJson(emptyList<String>()),
-                        description = "profile index",
-                    )
+                    writeProfileIndex(key, emptyList())
                 }
-                removeString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
+                removeSelectedProfile()
             }
 
             profileFullStorage.clearAll()
@@ -938,12 +824,7 @@ object MmkvManager {
                     if (subsList.remove(subid)) {
                         // Unpublish first. A process stop after this write can leave only an
                         // unreachable payload, and every in-flight update guard rejects the ID.
-                        writeString(
-                            storage = mainStorage,
-                            key = KEY_SUB_IDS,
-                            value = JsonUtil.toJson(subsList),
-                            description = "subscription index",
-                        )
+                        writeSubscriptionIndex(subsList)
                     }
                 }
 
@@ -991,26 +872,8 @@ object MmkvManager {
                 if (needsIndexWrite) subsList.add(key)
 
                 runStorageMutationTransaction {
-                    prepareThenPublish(
-                        prepare = {
-                            writeString(
-                                storage = subStorage,
-                                key = key,
-                                value = JsonUtil.toJson(subItem),
-                                description = "subscription payload",
-                            )
-                        },
-                        publish = {
-                            if (needsIndexWrite) {
-                                writeString(
-                                    storage = mainStorage,
-                                    key = KEY_SUB_IDS,
-                                    value = JsonUtil.toJson(subsList),
-                                    description = "subscription index",
-                                )
-                            }
-                        },
-                    )
+                    writeSubscriptionPayload(key, subItem)
+                    if (needsIndexWrite) writeSubscriptionIndex(subsList)
                 }
             }
             key
@@ -1042,12 +905,7 @@ object MmkvManager {
                 }
 
                 runStorageMutationTransaction {
-                    writeString(
-                        storage = subStorage,
-                        key = guid,
-                        value = JsonUtil.toJson(replacement),
-                        description = "subscription payload",
-                    )
+                    writeSubscriptionPayload(guid, replacement)
                 }
             }
             true
@@ -1080,12 +938,7 @@ object MmkvManager {
         return try {
             withProfileIndexLock {
                 runStorageMutationTransaction {
-                    writeString(
-                        storage = mainStorage,
-                        key = KEY_SUB_IDS,
-                        value = JsonUtil.toJson(subsList),
-                        description = "subscription index",
-                    )
+                    writeSubscriptionIndex(subsList)
                 }
             }
             true

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -32,55 +32,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 
-internal open class ProfileStorageException(message: String) : IllegalStateException(message)
-
-internal class SubscriptionUpdateAbortedException :
-    ProfileStorageException("Subscription changed while its update was running")
-
-internal class StorageMutationTransaction {
-    private data class RollbackAction(
-        val restore: () -> Boolean,
-        val failureMessage: String,
-    )
-
-    private val rollbackActions = mutableListOf<RollbackAction>()
-
-    fun mutate(
-        change: () -> Boolean,
-        restore: () -> Boolean,
-        failureMessage: String,
-    ) {
-        rollbackActions.add(RollbackAction(restore, failureMessage))
-        if (!change()) throw ProfileStorageException(failureMessage)
-    }
-
-    fun rollback(failure: Throwable) {
-        rollbackActions.asReversed().forEach { action ->
-            try {
-                if (!action.restore()) {
-                    failure.addSuppressed(
-                        ProfileStorageException("Rollback failed: ${action.failureMessage}"),
-                    )
-                }
-            } catch (rollbackFailure: Throwable) {
-                failure.addSuppressed(rollbackFailure)
-            }
-        }
-    }
-}
-
-internal fun <T> runStorageMutationTransaction(
-    block: StorageMutationTransaction.() -> T,
-): T {
-    val transaction = StorageMutationTransaction()
-    return try {
-        transaction.block()
-    } catch (failure: Throwable) {
-        transaction.rollback(failure)
-        throw failure
-    }
-}
-
 object MmkvManager {
 
     //region private
@@ -543,7 +494,7 @@ object MmkvManager {
 
         withProfileIndexLock {
             val updatedSubscription = subscriptionUpdate?.let { update ->
-                mergeSubscriptionUpdate(subscriptionId, update.expected, update.replacement, update.replacement.lastUpdated)
+                prepareSubscriptionUpdate(subscriptionId, update.expected, update.replacement, update.replacement.lastUpdated)
             }
             val replacedServers = if (append) {
                 emptyList()
@@ -920,7 +871,7 @@ object MmkvManager {
     ): Boolean {
         return try {
             withProfileIndexLock {
-                val updated = mergeSubscriptionUpdate(guid, expected, replacement, updatedAt)
+                val updated = prepareSubscriptionUpdate(guid, expected, replacement, updatedAt)
                 runStorageMutationTransaction {
                     writeSubscriptionPayload(guid, updated)
                 }
@@ -936,21 +887,19 @@ object MmkvManager {
     }
 
     // Caller holds the profile index lock across validation and persistence.
-    private fun mergeSubscriptionUpdate(
+    private fun prepareSubscriptionUpdate(
         guid: String,
         expected: SubscriptionItem,
         replacement: SubscriptionItem,
         updatedAt: Long?,
     ): SubscriptionItem {
-        val current = decodeSubscription(guid) ?: throw SubscriptionUpdateAbortedException()
-        if (!SubscriptionUpdateGuard.canCommit(guid in decodeSubsListForWrite(), current, expected) ||
-            (updatedAt != null && current.lastUpdated != expected.lastUpdated)
-        ) {
-            throw SubscriptionUpdateAbortedException()
-        }
-        // Wall-clock time may move backwards. Reject stale refreshes by their expected state,
-        // not by ordering timestamps; a settings edit never owns this metadata.
-        return replacement.copy(lastUpdated = updatedAt ?: current.lastUpdated)
+        return SubscriptionUpdateGuard.prepare(
+            isIndexed = guid in decodeSubsListForWrite(),
+            current = decodeSubscription(guid),
+            expected = expected,
+            replacement = replacement,
+            updatedAt = updatedAt,
+        ) ?: throw SubscriptionUpdateAbortedException()
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -26,12 +26,77 @@ import com.v2ray.ang.dto.entities.SubscriptionCache
 import com.v2ray.ang.dto.entities.SubscriptionItem
 import com.v2ray.ang.dto.entities.WebDavConfig
 import com.v2ray.ang.util.JsonUtil
+import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 
-internal class ProfileStorageException(message: String) : IllegalStateException(message)
+internal open class ProfileStorageException(message: String) : IllegalStateException(message)
+
+internal class SubscriptionUpdateAbortedException :
+    ProfileStorageException("Subscription changed while its update was running")
+
+internal class StorageMutationTransaction {
+    private data class RollbackAction(
+        val restore: () -> Boolean,
+        val failureMessage: String,
+    )
+
+    private val rollbackActions = mutableListOf<RollbackAction>()
+
+    fun mutate(
+        change: () -> Boolean,
+        restore: () -> Boolean,
+        failureMessage: String,
+    ) {
+        rollbackActions.add(RollbackAction(restore, failureMessage))
+        if (!change()) throw ProfileStorageException(failureMessage)
+    }
+
+    /**
+     * Prepares a profile mutation and writes its authoritative index as the final step.
+     */
+    fun <T> prepareThenPublish(
+        prepare: StorageMutationTransaction.() -> T,
+        publish: StorageMutationTransaction.() -> Unit,
+    ): T {
+        val result = prepare()
+        publish()
+        return result
+    }
+
+    fun commit() {
+        rollbackActions.clear()
+    }
+
+    fun rollback(failure: Throwable) {
+        rollbackActions.asReversed().forEach { action ->
+            try {
+                if (!action.restore()) {
+                    failure.addSuppressed(
+                        ProfileStorageException("Rollback failed: ${action.failureMessage}"),
+                    )
+                }
+            } catch (rollbackFailure: Throwable) {
+                failure.addSuppressed(rollbackFailure)
+            }
+        }
+        rollbackActions.clear()
+    }
+}
+
+internal fun <T> runStorageMutationTransaction(
+    block: StorageMutationTransaction.() -> T,
+): T {
+    val transaction = StorageMutationTransaction()
+    return try {
+        transaction.block().also { transaction.commit() }
+    } catch (failure: Throwable) {
+        transaction.rollback(failure)
+        throw failure
+    }
+}
 
 object MmkvManager {
 
@@ -76,6 +141,11 @@ object MmkvManager {
     private val assetStorage by lazy { MMKV.mmkvWithID(ID_ASSET, MMKV.MULTI_PROCESS_MODE) }
     private val settingsStorage by lazy { MMKV.mmkvWithID(ID_SETTING, MMKV.MULTI_PROCESS_MODE) }
 
+    private data class StoredString(
+        val isPresent: Boolean,
+        val value: String?,
+    )
+
     private inline fun <T> withProfileIndexLock(block: () -> T): T {
         return synchronized(mainStorage) {
             mainStorage.lock()
@@ -95,12 +165,76 @@ object MmkvManager {
         serverRawStorage.removeValuesForKeys(keys)
     }
 
-    private fun requireStorageWrite(success: Boolean, message: String) {
-        if (!success) throw ProfileStorageException(message)
+    private fun readStoredString(storage: MMKV, key: String, description: String): StoredString {
+        if (!storage.containsKey(key)) return StoredString(isPresent = false, value = null)
+        val value = storage.decodeString(key)
+            ?: throw ProfileStorageException("Failed to read $description")
+        return StoredString(isPresent = true, value = value)
     }
 
-    private fun persistServerList(serverList: List<String>, subscriptionId: String): Boolean {
-        return mainStorage.encode(serverListKey(subscriptionId), JsonUtil.toJson(serverList))
+    private fun restoreStoredString(storage: MMKV, key: String, stored: StoredString): Boolean {
+        return if (stored.isPresent) {
+            storage.encode(key, stored.value!!)
+        } else {
+            storage.remove(key)
+            !storage.containsKey(key)
+        }
+    }
+
+    private fun StorageMutationTransaction.writeString(
+        storage: MMKV,
+        key: String,
+        value: String,
+        description: String,
+    ) {
+        val stored = readStoredString(storage, key, description)
+        if (stored.isPresent && stored.value == value) return
+        mutate(
+            change = { storage.encode(key, value) },
+            restore = { restoreStoredString(storage, key, stored) },
+            failureMessage = "Failed to write $description",
+        )
+    }
+
+    private fun StorageMutationTransaction.removeString(
+        storage: MMKV,
+        key: String,
+        description: String,
+    ) {
+        val stored = readStoredString(storage, key, description)
+        if (!stored.isPresent) return
+        mutate(
+            change = {
+                storage.remove(key)
+                !storage.containsKey(key)
+            },
+            restore = { restoreStoredString(storage, key, stored) },
+            failureMessage = "Failed to remove $description",
+        )
+    }
+
+    private fun decodeServerListForWrite(subscriptionId: String): MutableList<String> {
+        val stored = readStoredString(
+            storage = mainStorage,
+            key = serverListKey(subscriptionId),
+            description = "profile index",
+        )
+        if (!stored.isPresent) return mutableListOf()
+        if (stored.value.isNullOrBlank()) {
+            throw ProfileStorageException("Failed to decode profile index")
+        }
+        return JsonUtil.fromJsonSafe(stored.value, Array<String>::class.java)?.toMutableList()
+            ?: throw ProfileStorageException("Failed to decode profile index")
+    }
+
+    private fun decodeSubsListForWrite(): MutableList<String> {
+        val stored = readStoredString(mainStorage, KEY_SUB_IDS, "subscription index")
+        if (!stored.isPresent) return mutableListOf()
+        if (stored.value.isNullOrBlank()) {
+            throw ProfileStorageException("Failed to decode subscription index")
+        }
+        return JsonUtil.fromJsonSafe(stored.value, Array<String>::class.java)?.toMutableList()
+            ?: throw ProfileStorageException("Failed to decode subscription index")
     }
 
     private fun serverListKey(subscriptionId: String): String {
@@ -126,6 +260,49 @@ object MmkvManager {
             referencedServers.addAll(serverIds)
         }
         return referencedServers
+    }
+
+    private fun StorageMutationTransaction.removeProfilesFromGroup(
+        subscriptionId: String,
+        requestedGuids: Set<String>?,
+    ): Set<String> {
+        val serverList = decodeServerListForWrite(subscriptionId)
+        val removedServers = if (requestedGuids == null) {
+            serverList.toSet()
+        } else {
+            serverList.filterTo(linkedSetOf()) { it in requestedGuids }
+        }
+        if (removedServers.isEmpty()) return emptySet()
+
+        val referencedByOtherGroups = decodeServersReferencedByOtherGroups(subscriptionId)
+        val removablePayloads = ProfileReplacement.findRemovablePayloads(
+            replacedServers = removedServers,
+            replacementServers = emptySet(),
+            protectedServer = null,
+            serversReferencedByOtherGroups = referencedByOtherGroups,
+        )
+        return prepareThenPublish(
+            prepare = {
+                val selectedServer = readStoredString(
+                    storage = mainStorage,
+                    key = KEY_SELECTED_SERVER,
+                    description = "selected profile",
+                )
+                if (selectedServer.value in removablePayloads) {
+                    removeString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
+                }
+                removablePayloads
+            },
+            publish = {
+                serverList.removeAll(removedServers)
+                writeString(
+                    storage = mainStorage,
+                    key = serverListKey(subscriptionId),
+                    value = JsonUtil.toJson(serverList),
+                    description = "profile index",
+                )
+            },
+        )
     }
 
     //endregion
@@ -193,9 +370,22 @@ object MmkvManager {
      * @param serverList The list of server GUIDs.
      * @param subscriptionId The subscription ID.
      */
-    fun encodeServerList(serverList: MutableList<String>, subscriptionId: String) {
-        withProfileIndexLock {
-            persistServerList(serverList, subscriptionId)
+    fun encodeServerList(serverList: MutableList<String>, subscriptionId: String): Boolean {
+        return try {
+            withProfileIndexLock {
+                runStorageMutationTransaction {
+                    writeString(
+                        storage = mainStorage,
+                        key = serverListKey(subscriptionId),
+                        value = JsonUtil.toJson(serverList),
+                        description = "profile index",
+                    )
+                }
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to persist profile order for group $subscriptionId", e)
+            false
         }
     }
 
@@ -266,34 +456,74 @@ object MmkvManager {
      * @param config The server configuration.
      * @return The server GUID.
      */
-    fun encodeServerConfig(guid: String, config: ProfileItem): String {
+    fun encodeServerConfig(
+        guid: String,
+        config: ProfileItem,
+        rawConfig: String? = null,
+    ): String? {
         val key = guid.ifBlank { Utils.getUuid() }
-        withProfileIndexLock {
-            requireStorageWrite(
-                profileFullStorage.encode(key, JsonUtil.toJson(config)),
-                "Failed to save profile payload",
-            )
+        return try {
+            withProfileIndexLock {
+                // Decode every index before changing a payload so unreadable state fails closed.
+                val subId = getSubscriptionId(config.subscriptionId)
+                val serverList = decodeServerListForWrite(subId)
+                val needsIndexWrite = !serverList.contains(key)
+                val selectedServer = if (needsIndexWrite) {
+                    readStoredString(
+                        storage = mainStorage,
+                        key = KEY_SELECTED_SERVER,
+                        description = "selected profile",
+                    )
+                } else {
+                    null
+                }
 
-            // Use default subscription for servers without subscription
-            val subId = getSubscriptionId(config.subscriptionId)
-            val serverList = decodeServerList(subId)
+                runStorageMutationTransaction {
+                    prepareThenPublish(
+                        prepare = {
+                            rawConfig?.let { raw ->
+                                writeString(
+                                    storage = serverRawStorage,
+                                    key = key,
+                                    value = raw,
+                                    description = "raw profile payload",
+                                )
+                            }
+                            writeString(
+                                storage = profileFullStorage,
+                                key = key,
+                                value = JsonUtil.toJson(config),
+                                description = "profile payload",
+                            )
 
-            if (!serverList.contains(key)) {
-                serverList.add(0, key)
-                requireStorageWrite(
-                    persistServerList(serverList, subId),
-                    "Failed to publish profile index",
-                )
-                if (getSelectServer().isNullOrBlank()) {
-                    requireStorageWrite(
-                        mainStorage.encode(KEY_SELECTED_SERVER, key),
-                        "Failed to update selected profile",
+                            if (needsIndexWrite && selectedServer?.value.isNullOrBlank()) {
+                                writeString(
+                                    storage = mainStorage,
+                                    key = KEY_SELECTED_SERVER,
+                                    value = key,
+                                    description = "selected profile",
+                                )
+                            }
+                        },
+                        publish = {
+                            if (needsIndexWrite) {
+                                serverList.add(0, key)
+                                writeString(
+                                    storage = mainStorage,
+                                    key = serverListKey(subId),
+                                    value = JsonUtil.toJson(serverList),
+                                    description = "profile index",
+                                )
+                            }
+                        },
                     )
                 }
             }
+            key
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to persist profile $key", e)
+            null
         }
-
-        return key
     }
 
     /**
@@ -309,16 +539,33 @@ object MmkvManager {
         rawConfigs: Map<String, String>,
         subscriptionId: String,
         append: Boolean,
+        subscriptionUpdate: SubscriptionUpdateCommit? = null,
     ) {
         if (profiles.isEmpty()) return
 
         withProfileIndexLock {
+            subscriptionUpdate?.let { update ->
+                val subscriptionIds = decodeSubsListForWrite()
+                val currentSubscription = decodeSubscription(subscriptionId)
+                if (!SubscriptionUpdateGuard.canCommit(
+                        isIndexed = subscriptionId in subscriptionIds,
+                        current = currentSubscription,
+                        expected = update.expected,
+                    )
+                ) {
+                    throw SubscriptionUpdateAbortedException()
+                }
+            }
             val replacedServers = if (append) {
                 emptyList()
             } else {
-                decodeServerList(subscriptionId).toList()
+                decodeServerListForWrite(subscriptionId).toList()
             }
-            val previousSelection = getSelectServer()
+            val previousSelection = readStoredString(
+                storage = mainStorage,
+                key = KEY_SELECTED_SERVER,
+                description = "selected profile",
+            ).value
             val selectedProfile = if (!append &&
                 previousSelection != null &&
                 previousSelection in replacedServers
@@ -333,21 +580,8 @@ object MmkvManager {
                 selectedProfile = selectedProfile,
             )
 
-            profiles.forEach { (guid, profile) ->
-                requireStorageWrite(
-                    profileFullStorage.encode(guid, JsonUtil.toJson(profile)),
-                    "Failed to save profile payload",
-                )
-                rawConfigs[guid]?.let { raw ->
-                    requireStorageWrite(
-                        serverRawStorage.encode(guid, raw),
-                        "Failed to save raw profile payload",
-                    )
-                }
-            }
-
             val serverList = if (append) {
-                decodeServerList(subscriptionId)
+                decodeServerListForWrite(subscriptionId)
             } else {
                 mutableListOf()
             }
@@ -357,26 +591,63 @@ object MmkvManager {
                     serverList.add(0, guid)
                 }
             }
-            requireStorageWrite(
-                persistServerList(serverList, subscriptionId),
-                "Failed to publish profile index",
-            )
-            replacementSelection?.let { guid ->
-                requireStorageWrite(
-                    mainStorage.encode(KEY_SELECTED_SERVER, guid),
-                    "Failed to update selected profile",
+
+            val removablePayloads = runStorageMutationTransaction {
+                prepareThenPublish(
+                    prepare = {
+                        rawConfigs.forEach { (guid, raw) ->
+                            writeString(
+                                storage = serverRawStorage,
+                                key = guid,
+                                value = raw,
+                                description = "raw profile payload",
+                            )
+                        }
+                        profiles.forEach { (guid, profile) ->
+                            writeString(
+                                storage = profileFullStorage,
+                                key = guid,
+                                value = JsonUtil.toJson(profile),
+                                description = "profile payload",
+                            )
+                        }
+                        subscriptionUpdate?.let { update ->
+                            writeString(
+                                storage = subStorage,
+                                key = subscriptionId,
+                                value = JsonUtil.toJson(update.replacement),
+                                description = "subscription payload",
+                            )
+                        }
+                        replacementSelection?.let { guid ->
+                            writeString(
+                                storage = mainStorage,
+                                key = KEY_SELECTED_SERVER,
+                                value = guid,
+                                description = "selected profile",
+                            )
+                        }
+
+                        if (replacedServers.isEmpty()) return@prepareThenPublish emptySet()
+                        val protectedServer = replacementSelection ?: previousSelection
+                        val referencedByOtherGroups = decodeServersReferencedByOtherGroups(subscriptionId)
+                        ProfileReplacement.findRemovablePayloads(
+                            replacedServers = replacedServers,
+                            replacementServers = profiles.keys,
+                            protectedServer = protectedServer,
+                            serversReferencedByOtherGroups = referencedByOtherGroups,
+                        )
+                    },
+                    publish = {
+                        writeString(
+                            storage = mainStorage,
+                            key = serverListKey(subscriptionId),
+                            value = JsonUtil.toJson(serverList),
+                            description = "profile index",
+                        )
+                    },
                 )
             }
-            if (replacedServers.isEmpty()) return@withProfileIndexLock
-
-            val protectedServer = replacementSelection ?: previousSelection
-            val referencedByOtherGroups = decodeServersReferencedByOtherGroups(subscriptionId)
-            val removablePayloads = ProfileReplacement.findRemovablePayloads(
-                replacedServers = replacedServers,
-                replacementServers = profiles.keys,
-                protectedServer = protectedServer,
-                serversReferencedByOtherGroups = referencedByOtherGroups,
-            )
             removeProfilePayloads(removablePayloads)
         }
     }
@@ -386,26 +657,26 @@ object MmkvManager {
      *
      * @param guid The server GUID.
      */
-    fun removeServer(guid: String) {
+    fun removeServer(guid: String): Boolean {
         if (guid.isBlank()) {
-            return
+            return false
         }
 
-        // Get config to determine which subscription to update
-        val config = decodeServerConfig(guid)
-        val subId = getSubscriptionId(config?.subscriptionId)
-
-        // Remove from appropriate server list
-        val serverList = decodeServerList(subId)
-        serverList.remove(guid)
-        encodeServerList(serverList, subId)
-
-        // Clean up storage
-        if (getSelectServer() == guid) {
-            mainStorage.remove(KEY_SELECTED_SERVER)
+        return try {
+            withProfileIndexLock {
+                // Get config to determine which subscription to update
+                val config = decodeServerConfig(guid)
+                val subId = getSubscriptionId(config?.subscriptionId)
+                val removablePayloads = runStorageMutationTransaction {
+                    removeProfilesFromGroup(subId, setOf(guid))
+                }
+                removeProfilePayloads(removablePayloads)
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to remove profile $guid", e)
+            false
         }
-        profileFullStorage.remove(guid)
-        serverAffStorage.remove(guid)
     }
 
     /**
@@ -413,21 +684,20 @@ object MmkvManager {
      *
      * @param subscriptionId The subscription ID.
      */
-    fun removeServerViaSubid(subscriptionId: String?) {
+    fun removeServerViaSubid(subscriptionId: String?): Boolean {
         val subId = getSubscriptionId(subscriptionId)
-        val serverList = decodeServerList(subId)
-
-        // Remove all servers in the list
-        serverList.forEach { guid ->
-            if (getSelectServer() == guid) {
-                mainStorage.remove(KEY_SELECTED_SERVER)
+        return try {
+            withProfileIndexLock {
+                val removablePayloads = runStorageMutationTransaction {
+                    removeProfilesFromGroup(subId, requestedGuids = null)
+                }
+                removeProfilePayloads(removablePayloads)
             }
-            profileFullStorage.remove(guid)
-            serverAffStorage.remove(guid)
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to remove profiles for group $subId", e)
+            false
         }
-
-        serverList.clear()
-        encodeServerList(serverList, subId)
     }
 
     /**
@@ -436,22 +706,20 @@ object MmkvManager {
      * @param guids The list of server GUIDs.
      * @param subscriptionId The subscription ID.
      */
-    fun removeServers(guids: List<String>, subscriptionId: String) {
-        if (guids.isEmpty()) return
+    fun removeServers(guids: List<String>, subscriptionId: String): Boolean {
+        if (guids.isEmpty()) return true
         val subId = getSubscriptionId(subscriptionId)
-        val serverList = decodeServerList(subId)
-        if (serverList.removeAll(guids)) {
-            encodeServerList(serverList, subId)
-        }
-
-        val selectedServer = getSelectServer()
-        guids.forEach { guid ->
-            if (selectedServer == guid) {
-                mainStorage.remove(KEY_SELECTED_SERVER)
+        return try {
+            withProfileIndexLock {
+                val removablePayloads = runStorageMutationTransaction {
+                    removeProfilesFromGroup(subId, guids.toSet())
+                }
+                removeProfilePayloads(removablePayloads)
             }
-            profileFullStorage.remove(guid)
-            serverAffStorage.remove(guid)
-            serverRawStorage.remove(guid)
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to remove profiles for group $subId", e)
+            false
         }
     }
 
@@ -507,15 +775,27 @@ object MmkvManager {
      * @return The number of server configurations removed.
      */
     fun removeAllServer(): Int {
-        val count = profileFullStorage.allKeys()?.count() ?: 0
-        profileFullStorage.clearAll()
-        serverAffStorage.clearAll()
-        serverRawStorage.clearAll()
+        return withProfileIndexLock {
+            val count = profileFullStorage.allKeys()?.count() ?: 0
+            val profileIndexKeys = mainStorage.allKeys().orEmpty()
+                .filter { key -> key.startsWith(KEY_SUB_SERVER_PREFIX) }
+            runStorageMutationTransaction {
+                profileIndexKeys.forEach { key ->
+                    writeString(
+                        storage = mainStorage,
+                        key = key,
+                        value = JsonUtil.toJson(emptyList<String>()),
+                        description = "profile index",
+                    )
+                }
+                removeString(mainStorage, KEY_SELECTED_SERVER, "selected profile")
+            }
 
-        decodeSubscriptions().forEach { sub ->
-            encodeServerList(mutableListOf(), sub.guid)
+            profileFullStorage.clearAll()
+            serverAffStorage.clearAll()
+            serverRawStorage.clearAll()
+            count
         }
-        return count
     }
 
     /**
@@ -529,31 +809,19 @@ object MmkvManager {
         if (guid.isNotEmpty()) {
             decodeServerAffiliationInfo(guid)?.let { aff ->
                 if (aff.testDelayMillis < 0L) {
-                    removeServer(guid)
-                    count++
+                    if (removeServer(guid)) count++
                 }
             }
         } else {
             serverAffStorage.allKeys()?.forEach { key ->
                 decodeServerAffiliationInfo(key)?.let { aff ->
                     if (aff.testDelayMillis < 0L) {
-                        removeServer(key)
-                        count++
+                        if (removeServer(key)) count++
                     }
                 }
             }
         }
         return count
-    }
-
-    /**
-     * Encodes the raw server configuration.
-     *
-     * @param guid The server GUID.
-     * @param config The raw server configuration.
-     */
-    fun encodeServerRaw(guid: String, config: String) {
-        serverRawStorage.encode(guid, config)
     }
 
     /**
@@ -662,13 +930,50 @@ object MmkvManager {
      *
      * @param subid The subscription ID.
      */
-    fun removeSubscription(subid: String) {
-        subStorage.remove(subid)
-        val subsList = decodeSubsList()
-        subsList.remove(subid)
-        encodeSubsList(subsList)
+    fun removeSubscription(subid: String): Boolean {
+        return try {
+            withProfileIndexLock {
+                val subsList = decodeSubsListForWrite()
+                runStorageMutationTransaction {
+                    if (subsList.remove(subid)) {
+                        // Unpublish first. A process stop after this write can leave only an
+                        // unreachable payload, and every in-flight update guard rejects the ID.
+                        writeString(
+                            storage = mainStorage,
+                            key = KEY_SUB_IDS,
+                            value = JsonUtil.toJson(subsList),
+                            description = "subscription index",
+                        )
+                    }
+                }
 
-        removeServerViaSubid(subid)
+                try {
+                    subStorage.remove(subid)
+                    if (subStorage.containsKey(subid)) {
+                        LogUtil.e(TAG, "Failed to clean payload for deleted subscription $subid")
+                    }
+                } catch (e: Exception) {
+                    // The authoritative index no longer exposes this payload. Retain the orphan
+                    // for later cleanup instead of making a completed deletion appear to fail.
+                    LogUtil.e(TAG, "Failed to clean payload for deleted subscription $subid", e)
+                }
+
+                try {
+                    val removablePayloads = runStorageMutationTransaction {
+                        removeProfilesFromGroup(subid, requestedGuids = null)
+                    }
+                    removeProfilePayloads(removablePayloads)
+                } catch (e: Exception) {
+                    // The subscription is already unpublished. Retaining orphaned payloads is
+                    // safer than reporting the user-requested deletion as if it never happened.
+                    LogUtil.e(TAG, "Failed to clean profiles for deleted subscription $subid", e)
+                }
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to remove subscription $subid", e)
+            false
+        }
     }
 
     /**
@@ -677,14 +982,81 @@ object MmkvManager {
      * @param guid The subscription GUID.
      * @param subItem The subscription item.
      */
-    fun encodeSubscription(guid: String, subItem: SubscriptionItem) {
+    fun encodeSubscription(guid: String, subItem: SubscriptionItem): String? {
         val key = guid.ifBlank { Utils.getUuid() }
-        subStorage.encode(key, JsonUtil.toJson(subItem))
+        return try {
+            withProfileIndexLock {
+                val subsList = decodeSubsListForWrite()
+                val needsIndexWrite = !subsList.contains(key)
+                if (needsIndexWrite) subsList.add(key)
 
-        val subsList = decodeSubsList()
-        if (!subsList.contains(key)) {
-            subsList.add(key)
-            encodeSubsList(subsList)
+                runStorageMutationTransaction {
+                    prepareThenPublish(
+                        prepare = {
+                            writeString(
+                                storage = subStorage,
+                                key = key,
+                                value = JsonUtil.toJson(subItem),
+                                description = "subscription payload",
+                            )
+                        },
+                        publish = {
+                            if (needsIndexWrite) {
+                                writeString(
+                                    storage = mainStorage,
+                                    key = KEY_SUB_IDS,
+                                    value = JsonUtil.toJson(subsList),
+                                    description = "subscription index",
+                                )
+                            }
+                        },
+                    )
+                }
+            }
+            key
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to persist subscription $key", e)
+            null
+        }
+    }
+
+    /**
+     * Replaces an existing subscription only if it has not changed since the caller read it.
+     */
+    fun updateSubscription(
+        guid: String,
+        expected: SubscriptionItem,
+        replacement: SubscriptionItem,
+    ): Boolean {
+        return try {
+            withProfileIndexLock {
+                val subscriptionIds = decodeSubsListForWrite()
+                val current = decodeSubscription(guid)
+                if (!SubscriptionUpdateGuard.canCommit(
+                        isIndexed = guid in subscriptionIds,
+                        current = current,
+                        expected = expected,
+                    )
+                ) {
+                    throw SubscriptionUpdateAbortedException()
+                }
+
+                runStorageMutationTransaction {
+                    writeString(
+                        storage = subStorage,
+                        key = guid,
+                        value = JsonUtil.toJson(replacement),
+                        description = "subscription payload",
+                    )
+                }
+            }
+            true
+        } catch (e: SubscriptionUpdateAbortedException) {
+            LogUtil.i(TAG, "Skipped stale subscription update for $guid")
+            false
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to update subscription $guid", e)
+            false
         }
     }
 
@@ -704,8 +1076,23 @@ object MmkvManager {
      *
      * @param subsList The list of subscription IDs.
      */
-    fun encodeSubsList(subsList: MutableList<String>) {
-        mainStorage.encode(KEY_SUB_IDS, JsonUtil.toJson(subsList))
+    fun encodeSubsList(subsList: MutableList<String>): Boolean {
+        return try {
+            withProfileIndexLock {
+                runStorageMutationTransaction {
+                    writeString(
+                        storage = mainStorage,
+                        key = KEY_SUB_IDS,
+                        value = JsonUtil.toJson(subsList),
+                        description = "subscription index",
+                    )
+                }
+            }
+            true
+        } catch (e: Exception) {
+            LogUtil.e(TAG, "Failed to persist subscription order", e)
+            false
+        }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -34,6 +34,11 @@ import kotlin.random.Random
 
 object SettingsManager {
 
+    data class SubscriptionRemovalResult(
+        val removed: Boolean,
+        val defaultCreated: Boolean,
+    )
+
     @Volatile
     private var runtimeSocksPort: Int? = null
 
@@ -234,22 +239,27 @@ object SettingsManager {
      * Removes the subscription.
      * If there are no remaining subscriptions,
      * it creates a new default subscription to ensure that ungroup
-     **/
-    fun removeSubscriptionWithDefault(subid: String) {
-        SubscriptionUpdater.cancelOne(subId = subid)
+    **/
+    fun removeSubscriptionWithDefault(subid: String): SubscriptionRemovalResult {
         // Remove the subscription
-        removeSubscription(subid)
+        if (!removeSubscription(subid)) {
+            return SubscriptionRemovalResult(removed = false, defaultCreated = true)
+        }
+        SubscriptionUpdater.cancelOne(subId = subid)
 
         // After removal, check if there are any subscriptions left. If not, create a default subscription.
         val subsList2 = decodeSubsList()
         if (subsList2.isNotEmpty()) {
-            return
+            return SubscriptionRemovalResult(removed = true, defaultCreated = true)
         }
 
         val defaultSub = SubscriptionItem(
             remarks = "Default",
         )
-        encodeSubscription(DEFAULT_SUBSCRIPTION_ID, defaultSub)
+        return SubscriptionRemovalResult(
+            removed = true,
+            defaultCreated = encodeSubscription(DEFAULT_SUBSCRIPTION_ID, defaultSub) != null,
+        )
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -47,7 +47,7 @@ object SettingsManager {
         ensureDefaultSettings()
         //ensureDefaultSubscription()
         initRoutingRulesets(context)
-        migrateServerListToSubscriptions()
+        if (!migrateServerListToSubscriptions()) return
         migrateHysteria2PinSHA256()
     }
 
@@ -503,10 +503,9 @@ object SettingsManager {
             return
         }
 
-        val serverList = decodeAllServerList()
+        val profiles = readMigrationProfiles() ?: return
 
-        for (guid in serverList) {
-            val profile = decodeServerConfig(guid) ?: continue
+        for ((guid, profile) in profiles) {
             if (profile.configType != EConfigType.HYSTERIA2) {
                 continue
             }
@@ -515,7 +514,8 @@ object SettingsManager {
             }
             profile.pinnedCA256 = profile.pinSHA256
             profile.pinSHA256 = null
-            MmkvManager.encodeServerConfig(guid, profile)
+            // Leave the migration pending if even one profile could not be saved.
+            if (MmkvManager.encodeServerConfig(guid, profile) == null) return
         }
 
         MmkvManager.encodeSettings(migrationKey, true)
@@ -526,36 +526,24 @@ object SettingsManager {
      * This method should be called once during app initialization after the storage structure change.
      * Servers are grouped by their subscriptionId into respective subscription's serverList.
      * Servers without subscription are moved to the default subscription.
-     * After migration, KEY_ANG_CONFIGS is removed.
+     * Retains the legacy index; the completion flag prevents repeating a successful migration.
      */
-    private fun migrateServerListToSubscriptions() {
+    private fun migrateServerListToSubscriptions(): Boolean {
+        if (!MmkvManager.migrateSubscriptionIndex()) return false
         // Check if migration has already been done
         val migrationKey = "server_list_to_subscriptions_migrated"
         if (MmkvManager.decodeSettingsBool(migrationKey, false)) {
-            return
+            return true
         }
 
         // Ensure default subscription exists before migration
-        ensureDefaultSubscription()
+        if (!ensureDefaultSubscription()) return false
 
-        // Read existing server list from legacy KEY_ANG_CONFIGS
-        val oldJson = MmkvManager.readLegacyServerList()
-        if (oldJson.isNullOrBlank()) {
-            // No data to migrate, mark as done
-            MmkvManager.encodeSettings(migrationKey, true)
-            return
-        }
-
-        val guids = JsonUtil.fromJsonSafe(oldJson, Array<String>::class.java) ?: run {
-            MmkvManager.encodeSettings(migrationKey, true)
-            return
-        }
-
+        val profiles = readMigrationProfiles(legacy = true) ?: return false
         val subscriptionServerMap = mutableMapOf<String, MutableList<String>>()
 
         // Group servers by subscription (use default subscription for empty subscriptionId)
-        guids.forEach { guid ->
-            val config = decodeServerConfig(guid) ?: return@forEach
+        profiles.forEach { (guid, config) ->
             val subId = config.subscriptionId.ifEmpty { DEFAULT_SUBSCRIPTION_ID }
 
             subscriptionServerMap.getOrPut(subId) { mutableListOf() }.add(guid)
@@ -563,32 +551,41 @@ object SettingsManager {
 
         // Update each subscription's serverList (including default subscription)
         subscriptionServerMap.forEach { (subId, serverGuids) ->
-            MmkvManager.encodeServerList(serverGuids, subId)
+            if (!MmkvManager.migrateServerList(serverGuids, subId)) return false
         }
 
 
         // Mark migration as complete
-        MmkvManager.encodeSettings(migrationKey, true)
+        return MmkvManager.encodeSettings(migrationKey, true)
+    }
+
+    private fun readMigrationProfiles(legacy: Boolean = false): Map<String, ProfileItem>? {
+        return try {
+            MmkvManager.readProfilesForMigration(legacy)
+        } catch (e: ProfileStorageException) {
+            LogUtil.e(AppConfig.TAG, "Failed to read migration profiles (legacy=$legacy); migration remains pending", e)
+            null
+        }
     }
 
     /**
      * Ensures the default subscription exists for ungrouped servers.
      * This subscription is used internally to store servers without a subscription.
-     * Made public for migration in SettingsManager.
      */
-    private fun ensureDefaultSubscription() {
+    private fun ensureDefaultSubscription(): Boolean {
         if (decodeSubscription(DEFAULT_SUBSCRIPTION_ID) == null) {
             val defaultSub = SubscriptionItem(
                 remarks = "Default",
             )
-            encodeSubscription(DEFAULT_SUBSCRIPTION_ID, defaultSub)
+            if (encodeSubscription(DEFAULT_SUBSCRIPTION_ID, defaultSub) == null) return false
 
             // Move to the top
             val subsList = decodeSubsList()
             if (subsList.moveItem(subsList.lastIndex, 0)) {
-                MmkvManager.encodeSubsList(subsList)
+                return MmkvManager.reorderSubscriptions(subsList)
             }
         }
+        return true
     }
 
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -34,10 +34,11 @@ import kotlin.random.Random
 
 object SettingsManager {
 
-    data class SubscriptionRemovalResult(
-        val removed: Boolean,
-        val defaultCreated: Boolean,
-    )
+    enum class SubscriptionRemovalResult {
+        FAILED,
+        REMOVED,
+        REMOVED_WITHOUT_DEFAULT,
+    }
 
     @Volatile
     private var runtimeSocksPort: Int? = null
@@ -243,23 +244,24 @@ object SettingsManager {
     fun removeSubscriptionWithDefault(subid: String): SubscriptionRemovalResult {
         // Remove the subscription
         if (!removeSubscription(subid)) {
-            return SubscriptionRemovalResult(removed = false, defaultCreated = true)
+            return SubscriptionRemovalResult.FAILED
         }
         SubscriptionUpdater.cancelOne(subId = subid)
 
         // After removal, check if there are any subscriptions left. If not, create a default subscription.
         val subsList2 = decodeSubsList()
         if (subsList2.isNotEmpty()) {
-            return SubscriptionRemovalResult(removed = true, defaultCreated = true)
+            return SubscriptionRemovalResult.REMOVED
         }
 
         val defaultSub = SubscriptionItem(
             remarks = "Default",
         )
-        return SubscriptionRemovalResult(
-            removed = true,
-            defaultCreated = encodeSubscription(DEFAULT_SUBSCRIPTION_ID, defaultSub) != null,
-        )
+        return if (encodeSubscription(DEFAULT_SUBSCRIPTION_ID, defaultSub) != null) {
+            SubscriptionRemovalResult.REMOVED
+        } else {
+            SubscriptionRemovalResult.REMOVED_WITHOUT_DEFAULT
+        }
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/StorageMutationTransaction.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/StorageMutationTransaction.kt
@@ -1,0 +1,48 @@
+package com.v2ray.ang.handler
+
+internal open class ProfileStorageException(message: String) : IllegalStateException(message)
+
+/** Checked mutation/rollback mechanics only; callers own storage locks and publication order. */
+internal class StorageMutationTransaction {
+    private data class RollbackAction(
+        val restore: () -> Boolean,
+        val failureMessage: String,
+    )
+
+    private val rollbackActions = mutableListOf<RollbackAction>()
+
+    fun mutate(
+        change: () -> Boolean,
+        restore: () -> Boolean,
+        failureMessage: String,
+    ) {
+        rollbackActions.add(RollbackAction(restore, failureMessage))
+        if (!change()) throw ProfileStorageException(failureMessage)
+    }
+
+    fun rollback(failure: Throwable) {
+        rollbackActions.asReversed().forEach { action ->
+            try {
+                if (!action.restore()) {
+                    failure.addSuppressed(
+                        ProfileStorageException("Rollback failed: ${action.failureMessage}"),
+                    )
+                }
+            } catch (rollbackFailure: Throwable) {
+                failure.addSuppressed(rollbackFailure)
+            }
+        }
+    }
+}
+
+internal fun <T> runStorageMutationTransaction(
+    block: StorageMutationTransaction.() -> T,
+): T {
+    val transaction = StorageMutationTransaction()
+    return try {
+        transaction.block()
+    } catch (failure: Throwable) {
+        transaction.rollback(failure)
+        throw failure
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdateGuard.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdateGuard.kt
@@ -13,10 +13,6 @@ internal object SubscriptionUpdateGuard {
         current: SubscriptionItem?,
         expected: SubscriptionItem,
     ): Boolean {
-        return isIndexed && current != null && settingsOf(current) == settingsOf(expected)
-    }
-
-    private fun settingsOf(subscription: SubscriptionItem): SubscriptionItem {
-        return subscription.copy(lastUpdated = -1)
+        return isIndexed && current?.copy(lastUpdated = expected.lastUpdated) == expected
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdateGuard.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdateGuard.kt
@@ -1,0 +1,22 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.dto.entities.SubscriptionItem
+
+internal data class SubscriptionUpdateCommit(
+    val expected: SubscriptionItem,
+    val replacement: SubscriptionItem,
+)
+
+internal object SubscriptionUpdateGuard {
+    fun canCommit(
+        isIndexed: Boolean,
+        current: SubscriptionItem?,
+        expected: SubscriptionItem,
+    ): Boolean {
+        return isIndexed && current != null && settingsOf(current) == settingsOf(expected)
+    }
+
+    private fun settingsOf(subscription: SubscriptionItem): SubscriptionItem {
+        return subscription.copy(lastUpdated = -1)
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdateGuard.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdateGuard.kt
@@ -2,17 +2,30 @@ package com.v2ray.ang.handler
 
 import com.v2ray.ang.dto.entities.SubscriptionItem
 
+internal class SubscriptionUpdateAbortedException :
+    ProfileStorageException("Subscription changed while its update was running")
+
 internal data class SubscriptionUpdateCommit(
     val expected: SubscriptionItem,
     val replacement: SubscriptionItem,
 )
 
 internal object SubscriptionUpdateGuard {
-    fun canCommit(
+    /**
+     * Returns the value to persist, or null if the subscription no longer matches the request.
+     * Settings edits preserve current refresh metadata. A refresh supplies [updatedAt] and must
+     * also match the initiating timestamp; a fresh timestamp may move backwards with the clock.
+     */
+    fun prepare(
         isIndexed: Boolean,
         current: SubscriptionItem?,
         expected: SubscriptionItem,
-    ): Boolean {
-        return isIndexed && current?.copy(lastUpdated = expected.lastUpdated) == expected
+        replacement: SubscriptionItem,
+        updatedAt: Long? = null,
+    ): SubscriptionItem? {
+        if (!isIndexed || current == null) return null
+        if (current.copy(lastUpdated = expected.lastUpdated) != expected) return null
+        if (updatedAt != null && current.lastUpdated != expected.lastUpdated) return null
+        return replacement.copy(lastUpdated = updatedAt ?: current.lastUpdated)
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -84,8 +84,7 @@ object SubscriptionUpdater {
      */
     fun updateLastUpdatedAndReschedule(context: Context = AngApplication.application, subId: String) {
         val subItem = MmkvManager.decodeSubscription(subId) ?: return
-        val updated = subItem.copy(lastUpdated = System.currentTimeMillis())
-        if (!MmkvManager.updateSubscription(subId, subItem, updated)) return
+        if (!MmkvManager.updateSubscription(subId, subItem, subItem, updatedAt = System.currentTimeMillis())) return
         syncOne(context, subId)
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SubscriptionUpdater.kt
@@ -84,8 +84,8 @@ object SubscriptionUpdater {
      */
     fun updateLastUpdatedAndReschedule(context: Context = AngApplication.application, subId: String) {
         val subItem = MmkvManager.decodeSubscription(subId) ?: return
-        subItem.lastUpdated = System.currentTimeMillis()
-        MmkvManager.encodeSubscription(subId, subItem)
+        val updated = subItem.copy(lastUpdated = System.currentTimeMillis())
+        if (!MmkvManager.updateSubscription(subId, subItem, updated)) return
         syncOne(context, subId)
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
@@ -32,9 +32,9 @@ interface MainDataSource : Closeable {
     fun decodeServerConfig(guid: String): ProfileItem?
     fun decodeAffiliationInfo(guid: String): ServerAffiliationInfo?
 
-    fun encodeServerList(guids: List<String>, groupId: String)
+    fun encodeServerList(guids: List<String>, groupId: String): Boolean
 
-    fun removeServer(guid: String)
+    fun removeServer(guid: String): Boolean
     fun removeAllServer(): Int
     fun removeInvalidServerByGuid(guid: String): Int
     fun removeInvalidServersInGroup(groupId: String): Int

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
@@ -32,7 +32,7 @@ interface MainDataSource : Closeable {
     fun decodeServerConfig(guid: String): ProfileItem?
     fun decodeAffiliationInfo(guid: String): ServerAffiliationInfo?
 
-    fun encodeServerList(guids: List<String>, groupId: String): Boolean
+    fun reorderServerList(guids: List<String>, groupId: String): Boolean
 
     fun removeServer(guid: String): Boolean
     fun removeAllServer(): Int

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -155,8 +155,8 @@ class MainRepository(
     override fun decodeAffiliationInfo(guid: String): ServerAffiliationInfo? =
         MmkvManager.decodeServerAffiliationInfo(guid)
 
-    override fun encodeServerList(guids: List<String>, groupId: String) =
-        MmkvManager.encodeServerList(ArrayList(guids), groupId)
+    override fun reorderServerList(guids: List<String>, groupId: String) =
+        MmkvManager.reorderServerList(guids, groupId)
 
     override fun removeServer(guid: String) = MmkvManager.removeServer(guid)
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -478,8 +478,7 @@ class MainViewModel(
                             dataSource.removeAllServer()
                         } else {
                             val guids = currentServers().map { it.guid }
-                            guids.forEach { dataSource.removeServer(it) }
-                            guids.size
+                            guids.count { dataSource.removeServer(it) }
                         }
                     viewModelScope.launch(ioDispatcher) {
                         cacheMutex.withLock { groupDataCache.clear() }
@@ -509,9 +508,13 @@ class MainViewModel(
                             if (!seen.add(identity)) duplicates += server.guid
                         }
                     }
-                    duplicates.forEach { dataSource.removeServer(it) }
+                    val removedCount = duplicates.count { dataSource.removeServer(it) }
                     setupGroupTab(forceRefresh = true)
-                    toast(dataSource.getString(R.string.title_del_duplicate_config_count, duplicates.size))
+                    if (removedCount == duplicates.size) {
+                        toast(dataSource.getString(R.string.title_del_duplicate_config_count, removedCount))
+                    } else {
+                        toastError(R.string.toast_failure)
+                    }
                 } catch (cancelled: CancellationException) {
                     throw cancelled
                 } catch (e: Exception) {
@@ -653,7 +656,10 @@ class MainViewModel(
             return
         }
         viewModelScope.launch(ioDispatcher) {
-            dataSource.removeServer(guid)
+            if (!dataSource.removeServer(guid)) {
+                toastError(R.string.toast_failure)
+                return@launch
+            }
             cacheMutex.withLock { groupDataCache.clear() }
             setupGroupTab(forceRefresh = true).join()
         }
@@ -668,8 +674,16 @@ class MainViewModel(
         val previousPersistenceJob = serverOrderPersistenceJobs[groupId]
         serverOrderPersistenceJobs[groupId] = viewModelScope.launch(ioDispatcher) {
             previousPersistenceJob?.join()
-            dataSource.encodeServerList(guids, groupId)
-            cacheMutex.withLock { groupDataCache[groupId] = servers }
+            if (dataSource.encodeServerList(guids, groupId)) {
+                cacheMutex.withLock { groupDataCache[groupId] = servers }
+                withContext(Dispatchers.Main) {
+                    mutableServersForGroup(groupId).value = servers
+                }
+            } else {
+                cacheMutex.withLock { groupDataCache.remove(groupId) }
+                setupGroupTab(forceRefresh = true).join()
+                toastError(R.string.toast_failure)
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -480,10 +480,7 @@ class MainViewModel(
                             val guids = currentServers().map { it.guid }
                             guids.count { dataSource.removeServer(it) }
                         }
-                    viewModelScope.launch(ioDispatcher) {
-                        cacheMutex.withLock { groupDataCache.clear() }
-                    }
-                    setupGroupTab(forceRefresh = true)
+                    setupGroupTab(forceRefresh = true).join()
                     toast(dataSource.getString(R.string.title_del_config_count, count))
                 } catch (cancelled: CancellationException) {
                     throw cancelled
@@ -509,7 +506,7 @@ class MainViewModel(
                         }
                     }
                     val removedCount = duplicates.count { dataSource.removeServer(it) }
-                    setupGroupTab(forceRefresh = true)
+                    setupGroupTab(forceRefresh = true).join()
                     if (removedCount == duplicates.size) {
                         toast(dataSource.getString(R.string.title_del_duplicate_config_count, removedCount))
                     } else {
@@ -530,10 +527,7 @@ class MainViewModel(
             withContext(ioDispatcher) {
                 try {
                     val count = removeInvalidServerInternal()
-                    viewModelScope.launch(ioDispatcher) {
-                        cacheMutex.withLock { groupDataCache.clear() }
-                        setupGroupTab(forceRefresh = true)
-                    }
+                    setupGroupTab(forceRefresh = true).join()
                     toast(dataSource.getString(R.string.title_del_config_count, count))
                 } catch (cancelled: CancellationException) {
                     throw cancelled
@@ -562,8 +556,7 @@ class MainViewModel(
             withContext(ioDispatcher) {
                 try {
                     sortByTestResultsInternal()
-                    cacheMutex.withLock { groupDataCache.clear() }
-                    setupGroupTab(forceRefresh = true)
+                    setupGroupTab(forceRefresh = true).join()
                 } catch (cancelled: CancellationException) {
                     throw cancelled
                 } catch (e: Exception) {
@@ -660,7 +653,6 @@ class MainViewModel(
                 toastError(R.string.toast_failure)
                 return@launch
             }
-            cacheMutex.withLock { groupDataCache.clear() }
             setupGroupTab(forceRefresh = true).join()
         }
     }
@@ -676,9 +668,6 @@ class MainViewModel(
             previousPersistenceJob?.join()
             if (dataSource.encodeServerList(guids, groupId)) {
                 cacheMutex.withLock { groupDataCache[groupId] = servers }
-                withContext(Dispatchers.Main) {
-                    mutableServersForGroup(groupId).value = servers
-                }
             } else {
                 cacheMutex.withLock { groupDataCache.remove(groupId) }
                 setupGroupTab(forceRefresh = true).join()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -42,12 +42,12 @@ import java.util.regex.PatternSyntaxException
 
 class MainViewModel(
     application: Application,
-    private val dataSource: MainDataSource
+    private val dataSource: MainDataSource,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : BaseViewModel(application) {
 
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
-    private val preloadDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(1)
+    private val preloadDispatcher: CoroutineDispatcher = ioDispatcher.limitedParallelism(1)
 
     // ---------- UI state ----------
     private val _uiState = MutableStateFlow(
@@ -274,14 +274,26 @@ class MainViewModel(
         groupId: String,
         forceRefresh: Boolean = false
     ): List<ServersCache> {
-        val loadMutex = groupLoadMutexes.computeIfAbsent(groupId) { Mutex() }
-        return loadMutex.withLock {
+        // Keep cache lookup, refresh and publication together: an older in-flight load must
+        // not repopulate an aggregate/shared-profile cache after it was invalidated.
+        return cacheMutex.withLock {
             if (!forceRefresh) {
-                cacheMutex.withLock { groupDataCache[groupId]?.let { return@withLock it } }
+                groupDataCache[groupId]?.let { return@withLock it }
             }
             val servers = buildServersCache(dataSource.getServerGuidList(groupId))
             currentCoroutineContext().ensureActive()
-            cacheMutex.withLock { groupDataCache[groupId] = servers }
+            if (forceRefresh) {
+                if (groupId.isEmpty()) {
+                    groupDataCache.clear()
+                } else {
+                    // The All tab contains every group. Other groups can share profile GUIDs.
+                    val affectedIds = (groupDataCache[groupId].orEmpty() + servers).mapTo(HashSet()) { it.guid }
+                    groupDataCache.entries.removeAll { (id, cached) ->
+                        id != groupId && (id.isEmpty() || cached.any { it.guid in affectedIds })
+                    }
+                }
+            }
+            groupDataCache[groupId] = servers
             servers
         }
     }
@@ -713,14 +725,20 @@ class MainViewModel(
         mutableServerGroupState(groupId).value = ServerGroupUiState(servers, rows)
         // A drag emits several moves; serialize writes so an older order cannot overwrite a newer one.
         val previousPersistenceJob = serverOrderPersistenceJobs[groupId]
-        serverOrderPersistenceJobs[groupId] = viewModelScope.launch(ioDispatcher) {
+        serverOrderPersistenceJobs[groupId] = viewModelScope.launch {
             previousPersistenceJob?.join()
-            if (dataSource.encodeServerList(guids, groupId)) {
-                cacheMutex.withLock { groupDataCache[groupId] = servers }
-            } else {
-                cacheMutex.withLock { groupDataCache.remove(groupId) }
-                setupGroupTab(forceRefresh = true).join()
+            if (!withContext(ioDispatcher) { dataSource.reorderServerList(guids, groupId) }) {
                 toastError(R.string.toast_failure)
+            }
+            // Only the final queued write reconciles the UI, on both success and failure.
+            // Read persisted membership/order instead of replaying a captured drag snapshot.
+            val thisJob = currentCoroutineContext()[Job]
+            if (serverOrderPersistenceJobs[groupId] === thisJob) {
+                val persisted = withContext(ioDispatcher) { loadGroup(groupId, forceRefresh = true) }
+                if (serverOrderPersistenceJobs[groupId] === thisJob) {
+                    updateGroupUi(groupId, persisted)
+                    serverOrderPersistenceJobs.remove(groupId)
+                }
             }
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -526,10 +526,7 @@ class MainViewModel(
                             val guids = currentServers().map { it.guid }
                             guids.count { dataSource.removeServer(it) }
                         }
-                    viewModelScope.launch(ioDispatcher) {
-                        cacheMutex.withLock { groupDataCache.clear() }
-                    }
-                    setupGroupTab(forceRefresh = true)
+                    setupGroupTab(forceRefresh = true).join()
                     toast(dataSource.getString(R.string.title_del_config_count, count))
                 } catch (cancelled: CancellationException) {
                     throw cancelled
@@ -555,7 +552,7 @@ class MainViewModel(
                         }
                     }
                     val removedCount = duplicates.count { dataSource.removeServer(it) }
-                    setupGroupTab(forceRefresh = true)
+                    setupGroupTab(forceRefresh = true).join()
                     if (removedCount == duplicates.size) {
                         toast(dataSource.getString(R.string.title_del_duplicate_config_count, removedCount))
                     } else {
@@ -576,10 +573,7 @@ class MainViewModel(
             withContext(ioDispatcher) {
                 try {
                     val count = removeInvalidServerInternal()
-                    viewModelScope.launch(ioDispatcher) {
-                        cacheMutex.withLock { groupDataCache.clear() }
-                        setupGroupTab(forceRefresh = true)
-                    }
+                    setupGroupTab(forceRefresh = true).join()
                     toast(dataSource.getString(R.string.title_del_config_count, count))
                 } catch (cancelled: CancellationException) {
                     throw cancelled
@@ -608,8 +602,7 @@ class MainViewModel(
             withContext(ioDispatcher) {
                 try {
                     sortByTestResultsInternal()
-                    cacheMutex.withLock { groupDataCache.clear() }
-                    setupGroupTab(forceRefresh = true)
+                    setupGroupTab(forceRefresh = true).join()
                 } catch (cancelled: CancellationException) {
                     throw cancelled
                 } catch (e: Exception) {
@@ -706,7 +699,6 @@ class MainViewModel(
                 toastError(R.string.toast_failure)
                 return@launch
             }
-            cacheMutex.withLock { groupDataCache.clear() }
             setupGroupTab(forceRefresh = true).join()
         }
     }
@@ -725,9 +717,6 @@ class MainViewModel(
             previousPersistenceJob?.join()
             if (dataSource.encodeServerList(guids, groupId)) {
                 cacheMutex.withLock { groupDataCache[groupId] = servers }
-                withContext(Dispatchers.Main) {
-                    mutableServersForGroup(groupId).value = servers
-                }
             } else {
                 cacheMutex.withLock { groupDataCache.remove(groupId) }
                 setupGroupTab(forceRefresh = true).join()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -524,8 +524,7 @@ class MainViewModel(
                             dataSource.removeAllServer()
                         } else {
                             val guids = currentServers().map { it.guid }
-                            guids.forEach { dataSource.removeServer(it) }
-                            guids.size
+                            guids.count { dataSource.removeServer(it) }
                         }
                     viewModelScope.launch(ioDispatcher) {
                         cacheMutex.withLock { groupDataCache.clear() }
@@ -555,9 +554,13 @@ class MainViewModel(
                             if (!seen.add(identity)) duplicates += server.guid
                         }
                     }
-                    duplicates.forEach { dataSource.removeServer(it) }
+                    val removedCount = duplicates.count { dataSource.removeServer(it) }
                     setupGroupTab(forceRefresh = true)
-                    toast(dataSource.getString(R.string.title_del_duplicate_config_count, duplicates.size))
+                    if (removedCount == duplicates.size) {
+                        toast(dataSource.getString(R.string.title_del_duplicate_config_count, removedCount))
+                    } else {
+                        toastError(R.string.toast_failure)
+                    }
                 } catch (cancelled: CancellationException) {
                     throw cancelled
                 } catch (e: Exception) {
@@ -699,7 +702,10 @@ class MainViewModel(
             return
         }
         viewModelScope.launch(ioDispatcher) {
-            dataSource.removeServer(guid)
+            if (!dataSource.removeServer(guid)) {
+                toastError(R.string.toast_failure)
+                return@launch
+            }
             cacheMutex.withLock { groupDataCache.clear() }
             setupGroupTab(forceRefresh = true).join()
         }
@@ -717,8 +723,16 @@ class MainViewModel(
         val previousPersistenceJob = serverOrderPersistenceJobs[groupId]
         serverOrderPersistenceJobs[groupId] = viewModelScope.launch(ioDispatcher) {
             previousPersistenceJob?.join()
-            dataSource.encodeServerList(guids, groupId)
-            cacheMutex.withLock { groupDataCache[groupId] = servers }
+            if (dataSource.encodeServerList(guids, groupId)) {
+                cacheMutex.withLock { groupDataCache[groupId] = servers }
+                withContext(Dispatchers.Main) {
+                    mutableServersForGroup(groupId).value = servers
+                }
+            } else {
+                cacheMutex.withLock { groupDataCache.remove(groupId) }
+                setupGroupTab(forceRefresh = true).join()
+                toastError(R.string.toast_failure)
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -70,7 +70,6 @@ class MainViewModel(
     private val groupDataCache = mutableMapOf<String, List<ServersCache>>()
     private val groupUiFlows = ConcurrentHashMap<String, MutableStateFlow<ServerGroupUiState>>()
     private val groupServerFlows = ConcurrentHashMap<String, StateFlow<List<ServersCache>>>()
-    private val groupLoadMutexes = ConcurrentHashMap<String, Mutex>()
     private val serverOrderPersistenceJobs = mutableMapOf<String, Job>()
 
     private var setupGroupJob: Job? = null
@@ -316,8 +315,12 @@ class MainViewModel(
     }
 
     private fun updateGroupUi(groupId: String, servers: List<ServersCache>) {
+        mutableServerGroupState(groupId).value = buildGroupUiState(groupId, servers)
+    }
+
+    private fun buildGroupUiState(groupId: String, servers: List<ServersCache>): ServerGroupUiState {
         val filteredServers = applyKeywordFilter(servers)
-        mutableServerGroupState(groupId).value = ServerGroupUiState(
+        return ServerGroupUiState(
             servers = filteredServers,
             rows = buildServerRows(groupId, filteredServers)
         )
@@ -387,7 +390,6 @@ class MainViewModel(
                 val validIds = groups.mapTo(HashSet()) { it.id }
                 groupUiFlows.keys.removeAll { it !in validIds }
                 groupServerFlows.keys.removeAll { it !in validIds }
-                groupLoadMutexes.keys.removeAll { it !in validIds }
 
                 _uiState.update {
                     it.copy(
@@ -734,9 +736,11 @@ class MainViewModel(
             // Read persisted membership/order instead of replaying a captured drag snapshot.
             val thisJob = currentCoroutineContext()[Job]
             if (serverOrderPersistenceJobs[groupId] === thisJob) {
-                val persisted = withContext(ioDispatcher) { loadGroup(groupId, forceRefresh = true) }
+                val persisted = withContext(ioDispatcher) {
+                    buildGroupUiState(groupId, loadGroup(groupId, forceRefresh = true))
+                }
                 if (serverOrderPersistenceJobs[groupId] === thisJob) {
-                    updateGroupUi(groupId, persisted)
+                    mutableServerGroupState(groupId).value = persisted
                     serverOrderPersistenceJobs.remove(groupId)
                 }
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -433,7 +433,10 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         if (config.subscriptionId.isEmpty() && !subscriptionId.isNullOrEmpty()) {
             config.subscriptionId = subscriptionId.orEmpty()
         }
-        val savedGuid = MmkvManager.encodeServerConfig(editGuid, config)
+        val savedGuid = MmkvManager.encodeServerConfig(editGuid, config) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
         toastSuccess(R.string.toast_success)
         ProfileEditorResult.run {
             finishSaved(savedGuid, isRunning)
@@ -506,7 +509,10 @@ abstract class BaseServerActivity : BaseComponentActivity() {
             toast(R.string.toast_action_not_allowed)
             return
         }
-        MmkvManager.removeServer(guid)
+        if (!MmkvManager.removeServer(guid)) {
+            toast(R.string.toast_failure)
+            return
+        }
         ProfileEditorResult.run {
             finishDeleted(guid)
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -423,11 +423,11 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         return true
     }
 
-    protected fun saveServer(state: ServerUiState): Boolean {
-        if (!validateBasicConfig(state)) return false
+    protected fun saveServer(state: ServerUiState) {
+        if (!validateBasicConfig(state)) return
         val config = state.toProfileItem(initialConfig)
-        if (!validateCommonConfig(config)) return false
-        if (!validateProtocolConfig(config)) return false
+        if (!validateCommonConfig(config)) return
+        if (!validateProtocolConfig(config)) return
 
         config.description = AngConfigManager.generateDescription(config)
         if (config.subscriptionId.isEmpty() && !subscriptionId.isNullOrEmpty()) {
@@ -435,13 +435,12 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         }
         val savedGuid = MmkvManager.encodeServerConfig(editGuid, config) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
         toastSuccess(R.string.toast_success)
         ProfileEditorResult.run {
             finishSaved(savedGuid, isRunning)
         }
-        return true
     }
 
     @Composable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -432,7 +432,10 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         if (config.subscriptionId.isEmpty() && !subscriptionId.isNullOrEmpty()) {
             config.subscriptionId = subscriptionId.orEmpty()
         }
-        val savedGuid = MmkvManager.encodeServerConfig(editGuid, config)
+        val savedGuid = MmkvManager.encodeServerConfig(editGuid, config) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
         toastSuccess(R.string.toast_success)
         ProfileEditorResult.run {
             finishSaved(savedGuid, isRunning)
@@ -505,7 +508,10 @@ abstract class BaseServerActivity : BaseComponentActivity() {
             toast(R.string.toast_action_not_allowed)
             return
         }
-        MmkvManager.removeServer(guid)
+        if (!MmkvManager.removeServer(guid)) {
+            toast(R.string.toast_failure)
+            return
+        }
         ProfileEditorResult.run {
             finishDeleted(guid)
         }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -422,11 +422,11 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         return true
     }
 
-    protected fun saveServer(state: ServerUiState): Boolean {
-        if (!validateBasicConfig(state)) return false
+    protected fun saveServer(state: ServerUiState) {
+        if (!validateBasicConfig(state)) return
         val config = state.toProfileItem(initialConfig)
-        if (!validateCommonConfig(config)) return false
-        if (!validateProtocolConfig(config)) return false
+        if (!validateCommonConfig(config)) return
+        if (!validateProtocolConfig(config)) return
 
         config.description = AngConfigManager.generateDescription(config)
         if (config.subscriptionId.isEmpty() && !subscriptionId.isNullOrEmpty()) {
@@ -434,13 +434,12 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         }
         val savedGuid = MmkvManager.encodeServerConfig(editGuid, config) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
         toastSuccess(R.string.toast_success)
         ProfileEditorResult.run {
             finishSaved(savedGuid, isRunning)
         }
-        return true
     }
 
     @Composable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
@@ -164,7 +164,10 @@ class ServerActivity : BaseComponentActivity() {
         val savedGuid = MmkvManager.encodeServerConfig(
             editGuid,
             config
-        )
+        ) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         toastSuccess(R.string.toast_success)
 
@@ -190,7 +193,10 @@ class ServerActivity : BaseComponentActivity() {
             return
         }
 
-        MmkvManager.removeServer(guid)
+        if (!MmkvManager.removeServer(guid)) {
+            toast(R.string.toast_failure)
+            return
+        }
 
         ProfileEditorResult.run {
             finishDeleted(guid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
@@ -87,20 +87,20 @@ class ServerActivity : BaseComponentActivity() {
             initialConfig = initialConfig,
             isRunning = isRunning,
             onBackClick = { finish() },
-            onSave = { saveServer(it) },
-            onDelete = { deleteServer(editGuid, isRunning) }
+            onSave = ::saveServer,
+            onDelete = { deleteServer(editGuid) },
         )
     }
 
-    private fun saveServer(config: ProfileItem): Boolean {
+    private fun saveServer(config: ProfileItem) {
         if (config.remarks.isBlank()) {
             toast(R.string.server_lab_remarks)
-            return false
+            return
         }
 
         if (config.server.isNullOrBlank()) {
             toast(R.string.server_lab_address)
-            return false
+            return
         }
 
         if (
@@ -108,7 +108,7 @@ class ServerActivity : BaseComponentActivity() {
             (config.serverPort?.toIntOrNull() ?: 0) <= 0
         ) {
             toast(R.string.server_lab_port)
-            return false
+            return
         }
 
         if (
@@ -124,7 +124,7 @@ class ServerActivity : BaseComponentActivity() {
                 else -> R.string.server_lab_id
             }
             toast(message)
-            return false
+            return
         }
 
         if (
@@ -132,7 +132,7 @@ class ServerActivity : BaseComponentActivity() {
             config.security.isNullOrBlank()
         ) {
             toast(R.string.server_lab_stream_security)
-            return false
+            return
         }
 
         if (
@@ -140,7 +140,7 @@ class ServerActivity : BaseComponentActivity() {
             JsonUtil.parseString(config.xhttpExtra) == null
         ) {
             toast(R.string.server_lab_xhttp_extra)
-            return false
+            return
         }
 
         if (
@@ -148,7 +148,7 @@ class ServerActivity : BaseComponentActivity() {
             JsonUtil.parseString(config.finalMask) == null
         ) {
             toast(R.string.server_lab_final_mask)
-            return false
+            return
         }
 
         config.description =
@@ -166,7 +166,7 @@ class ServerActivity : BaseComponentActivity() {
             config
         ) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         toastSuccess(R.string.toast_success)
@@ -177,14 +177,9 @@ class ServerActivity : BaseComponentActivity() {
                 restartService = isRunning
             )
         }
-
-        return true
     }
 
-    private fun deleteServer(
-        guid: String,
-        isRunning: Boolean
-    ) {
+    private fun deleteServer(guid: String) {
         if (
             guid.isEmpty() ||
             guid == MmkvManager.getSelectServer()
@@ -211,7 +206,7 @@ fun ServerScreen(
     initialConfig: ProfileItem,
     isRunning: Boolean,
     onBackClick: () -> Unit,
-    onSave: (ProfileItem) -> Boolean,
+    onSave: (ProfileItem) -> Unit,
     onDelete: () -> Unit
 ) {
     val context = LocalContext.current

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -148,13 +148,12 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
 
         val savedGuid = MmkvManager.encodeServerConfig(
             editGuid,
-            config
-        )
-
-        MmkvManager.encodeServerRaw(
-            savedGuid,
-            content
-        )
+            config,
+            rawConfig = content,
+        ) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         toastSuccess(R.string.toast_success)
 
@@ -178,7 +177,10 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.removeServer(editGuid)
+        if (!MmkvManager.removeServer(editGuid)) {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -100,18 +100,18 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
             initialRemarks = initialRemarks,
             initialContent = initialContent,
             onBackClick = { finish() },
-            onSave = { remarks, content -> saveServer(remarks, content) },
-            onDelete = { deleteServer() }
+            onSave = ::saveServer,
+            onDelete = ::deleteServer,
         )
     }
 
     private fun saveServer(
         remarks: String,
         content: String
-    ): Boolean {
+    ) {
         if (remarks.isBlank()) {
             toast(R.string.server_lab_remarks)
-            return false
+            return
         }
 
         val parsedProfile = try {
@@ -131,7 +131,7 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                     getString(R.string.toast_malformed_json_detail, detail)
                 }
             )
-            return false
+            return
         }
 
         val config =
@@ -139,10 +139,10 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                 ?: ProfileItem.create(EConfigType.CUSTOM)
 
         config.remarks =
-            remarks.ifEmpty { parsedProfile?.remarks.orEmpty() }
+            remarks.ifEmpty { parsedProfile.remarks }
 
-        config.server = parsedProfile?.server
-        config.serverPort = parsedProfile?.serverPort
+        config.server = parsedProfile.server
+        config.serverPort = parsedProfile.serverPort
         config.description =
             AngConfigManager.generateDescription(config)
 
@@ -152,7 +152,7 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
             rawConfig = content,
         ) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         toastSuccess(R.string.toast_success)
@@ -163,30 +163,26 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                 restartService = isRunning
             )
         }
-
-        return true
     }
 
-    private fun deleteServer(): Boolean {
+    private fun deleteServer() {
         if (editGuid.isEmpty()) {
-            return false
+            return
         }
 
         if (editGuid == MmkvManager.getSelectServer()) {
             toast(R.string.toast_action_not_allowed)
-            return false
+            return
         }
 
         if (!MmkvManager.removeServer(editGuid)) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)
         }
-
-        return true
     }
 }
 
@@ -206,7 +202,7 @@ fun ServerCustomConfigScreen(
     initialRemarks: String,
     initialContent: String,
     onBackClick: () -> Unit,
-    onSave: (String, String) -> Boolean,
+    onSave: (String, String) -> Unit,
     onDelete: () -> Unit
 ) {
     var remarks by rememberSaveable { mutableStateOf(initialRemarks) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -147,13 +147,12 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
 
         val savedGuid = MmkvManager.encodeServerConfig(
             editGuid,
-            config
-        )
-
-        MmkvManager.encodeServerRaw(
-            savedGuid,
-            content
-        )
+            config,
+            rawConfig = content,
+        ) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         toastSuccess(R.string.toast_success)
 
@@ -177,7 +176,10 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.removeServer(editGuid)
+        if (!MmkvManager.removeServer(editGuid)) {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -99,18 +99,18 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
             initialRemarks = initialRemarks,
             initialContent = initialContent,
             onBackClick = { finish() },
-            onSave = { remarks, content -> saveServer(remarks, content) },
-            onDelete = { deleteServer() }
+            onSave = ::saveServer,
+            onDelete = ::deleteServer,
         )
     }
 
     private fun saveServer(
         remarks: String,
         content: String
-    ): Boolean {
+    ) {
         if (remarks.isBlank()) {
             toast(R.string.server_lab_remarks)
-            return false
+            return
         }
 
         val parsedProfile = try {
@@ -130,7 +130,7 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                     getString(R.string.toast_malformed_json_detail, detail)
                 }
             )
-            return false
+            return
         }
 
         val config =
@@ -138,10 +138,10 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                 ?: ProfileItem.create(EConfigType.CUSTOM)
 
         config.remarks =
-            remarks.ifEmpty { parsedProfile?.remarks.orEmpty() }
+            remarks.ifEmpty { parsedProfile.remarks }
 
-        config.server = parsedProfile?.server
-        config.serverPort = parsedProfile?.serverPort
+        config.server = parsedProfile.server
+        config.serverPort = parsedProfile.serverPort
         config.description =
             AngConfigManager.generateDescription(config)
 
@@ -151,7 +151,7 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
             rawConfig = content,
         ) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         toastSuccess(R.string.toast_success)
@@ -162,30 +162,26 @@ class ServerCustomConfigActivity : BaseComponentActivity() {
                 restartService = isRunning
             )
         }
-
-        return true
     }
 
-    private fun deleteServer(): Boolean {
+    private fun deleteServer() {
         if (editGuid.isEmpty()) {
-            return false
+            return
         }
 
         if (editGuid == MmkvManager.getSelectServer()) {
             toast(R.string.toast_action_not_allowed)
-            return false
+            return
         }
 
         if (!MmkvManager.removeServer(editGuid)) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)
         }
-
-        return true
     }
 }
 
@@ -205,7 +201,7 @@ fun ServerCustomConfigScreen(
     initialRemarks: String,
     initialContent: String,
     onBackClick: () -> Unit,
-    onSave: (String, String) -> Boolean,
+    onSave: (String, String) -> Unit,
     onDelete: () -> Unit
 ) {
     var remarks by rememberSaveable { mutableStateOf(initialRemarks) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -101,10 +101,8 @@ class ServerGroupActivity : BaseComponentActivity() {
             initialFallbackTag = initialFallbackTag,
             fallbackSuggestions = fallbackSuggestions,
             onBackClick = { finish() },
-            onSave = { remarks, filter, typeIdx, subIdx, testOutbounds, fallbackTag ->
-                saveServer(remarks, filter, typeIdx, subIdx, testOutbounds, fallbackTag)
-            },
-            onDelete = { deleteServer() }
+            onSave = ::saveServer,
+            onDelete = ::deleteServer,
         )
     }
 
@@ -115,10 +113,10 @@ class ServerGroupActivity : BaseComponentActivity() {
         subIdx: Int,
         testOutbounds: Boolean,
         fallbackTag: String,
-    ): Boolean {
+    ) {
         if (remarks.isBlank()) {
             toast(R.string.server_lab_remarks)
-            return false
+            return
         }
 
         val config =
@@ -158,7 +156,7 @@ class ServerGroupActivity : BaseComponentActivity() {
             config
         ) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         toastSuccess(R.string.toast_success)
@@ -169,30 +167,26 @@ class ServerGroupActivity : BaseComponentActivity() {
                 restartService = isRunning
             )
         }
-
-        return true
     }
 
-    private fun deleteServer(): Boolean {
+    private fun deleteServer() {
         if (editGuid.isEmpty()) {
-            return false
+            return
         }
 
         if (editGuid == MmkvManager.getSelectServer()) {
             toast(R.string.toast_action_not_allowed)
-            return false
+            return
         }
 
         if (!MmkvManager.removeServer(editGuid)) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)
         }
-
-        return true
     }
 
     private fun populateSubscriptionSpinner() {
@@ -228,7 +222,7 @@ fun ServerGroupScreen(
     initialFallbackTag: String,
     fallbackSuggestions: List<String>,
     onBackClick: () -> Unit,
-    onSave: (String, String, Int, Int, Boolean, String) -> Boolean,
+    onSave: (String, String, Int, Int, Boolean, String) -> Unit,
     onDelete: () -> Unit
 ) {
     val typeEntries = stringArrayResource(R.array.policy_group_type).toList()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -156,7 +156,10 @@ class ServerGroupActivity : BaseComponentActivity() {
         val savedGuid = MmkvManager.encodeServerConfig(
             editGuid,
             config
-        )
+        ) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         toastSuccess(R.string.toast_success)
 
@@ -180,7 +183,10 @@ class ServerGroupActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.removeServer(editGuid)
+        if (!MmkvManager.removeServer(editGuid)) {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -100,10 +100,8 @@ class ServerGroupActivity : BaseComponentActivity() {
             initialFallbackTag = initialFallbackTag,
             fallbackSuggestions = fallbackSuggestions,
             onBackClick = { finish() },
-            onSave = { remarks, filter, typeIdx, subIdx, testOutbounds, fallbackTag ->
-                saveServer(remarks, filter, typeIdx, subIdx, testOutbounds, fallbackTag)
-            },
-            onDelete = { deleteServer() }
+            onSave = ::saveServer,
+            onDelete = ::deleteServer,
         )
     }
 
@@ -114,10 +112,10 @@ class ServerGroupActivity : BaseComponentActivity() {
         subIdx: Int,
         testOutbounds: Boolean,
         fallbackTag: String,
-    ): Boolean {
+    ) {
         if (remarks.isBlank()) {
             toast(R.string.server_lab_remarks)
-            return false
+            return
         }
 
         val config =
@@ -157,7 +155,7 @@ class ServerGroupActivity : BaseComponentActivity() {
             config
         ) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         toastSuccess(R.string.toast_success)
@@ -168,30 +166,26 @@ class ServerGroupActivity : BaseComponentActivity() {
                 restartService = isRunning
             )
         }
-
-        return true
     }
 
-    private fun deleteServer(): Boolean {
+    private fun deleteServer() {
         if (editGuid.isEmpty()) {
-            return false
+            return
         }
 
         if (editGuid == MmkvManager.getSelectServer()) {
             toast(R.string.toast_action_not_allowed)
-            return false
+            return
         }
 
         if (!MmkvManager.removeServer(editGuid)) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)
         }
-
-        return true
     }
 
     private fun populateSubscriptionSpinner() {
@@ -227,7 +221,7 @@ fun ServerGroupScreen(
     initialFallbackTag: String,
     fallbackSuggestions: List<String>,
     onBackClick: () -> Unit,
-    onSave: (String, String, Int, Int, Boolean, String) -> Boolean,
+    onSave: (String, String, Int, Int, Boolean, String) -> Unit,
     onDelete: () -> Unit
 ) {
     val typeEntries = stringArrayResource(R.array.policy_group_type).toList()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -155,7 +155,10 @@ class ServerGroupActivity : BaseComponentActivity() {
         val savedGuid = MmkvManager.encodeServerConfig(
             editGuid,
             config
-        )
+        ) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         toastSuccess(R.string.toast_success)
 
@@ -179,7 +182,10 @@ class ServerGroupActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.removeServer(editGuid)
+        if (!MmkvManager.removeServer(editGuid)) {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
@@ -90,18 +90,18 @@ class ServerProxyChainActivity : BaseComponentActivity() {
             initialMembers = initialMembers,
             allRemarks = allRemarks,
             onBackClick = { finish() },
-            onSave = { remarks, members -> saveServer(remarks, members) },
-            onDelete = { deleteServer() }
+            onSave = ::saveServer,
+            onDelete = ::deleteServer,
         )
     }
 
     private fun saveServer(
         remarks: String,
         members: List<String>
-    ): Boolean {
+    ) {
         if (remarks.isBlank()) {
             toast(R.string.server_lab_remarks)
-            return false
+            return
         }
 
         val chainMembers = members
@@ -110,12 +110,12 @@ class ServerProxyChainActivity : BaseComponentActivity() {
 
         if (chainMembers.size != members.size) {
             toast(R.string.server_proxy_chain_members_unselected)
-            return false
+            return
         }
 
         if (chainMembers.size < 2) {
             toast(R.string.server_proxy_chain_members_insufficient)
-            return false
+            return
         }
 
         val invalidMembers = chainMembers.filter { member ->
@@ -130,7 +130,7 @@ class ServerProxyChainActivity : BaseComponentActivity() {
                     invalidMembers.joinToString(", ")
                 )
             )
-            return false
+            return
         }
 
         val config =
@@ -156,7 +156,7 @@ class ServerProxyChainActivity : BaseComponentActivity() {
             config
         ) ?: run {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         toastSuccess(R.string.toast_success)
@@ -167,30 +167,26 @@ class ServerProxyChainActivity : BaseComponentActivity() {
                 restartService = isRunning
             )
         }
-
-        return true
     }
 
-    private fun deleteServer(): Boolean {
+    private fun deleteServer() {
         if (editGuid.isEmpty()) {
-            return false
+            return
         }
 
         if (editGuid == MmkvManager.getSelectServer()) {
             toast(R.string.toast_action_not_allowed)
-            return false
+            return
         }
 
         if (!MmkvManager.removeServer(editGuid)) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)
         }
-
-        return true
     }
 }
 
@@ -202,7 +198,7 @@ fun ProxyChainScreen(
     initialMembers: List<String>,
     allRemarks: List<String>,
     onBackClick: () -> Unit,
-    onSave: (String, List<String>) -> Boolean,
+    onSave: (String, List<String>) -> Unit,
     onDelete: () -> Unit
 ) {
     var remarks by rememberSaveable { mutableStateOf(initialRemarks) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
@@ -154,7 +154,10 @@ class ServerProxyChainActivity : BaseComponentActivity() {
         val savedGuid = MmkvManager.encodeServerConfig(
             editGuid,
             config
-        )
+        ) ?: run {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         toastSuccess(R.string.toast_success)
 
@@ -178,7 +181,10 @@ class ServerProxyChainActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.removeServer(editGuid)
+        if (!MmkvManager.removeServer(editGuid)) {
+            toast(R.string.toast_failure)
+            return false
+        }
 
         ProfileEditorResult.run {
             finishDeleted(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -74,33 +74,32 @@ class SubEditActivity : BaseComponentActivity() {
             initial = subItem,
             profileSuggestions = suggestions,
             onBackClick = { finish() },
-            onSave = { saveServer(it) },
-            onDelete = { deleteServer() }
+            onSave = ::saveSubscription,
+            onDelete = ::deleteSubscription,
         )
     }
 
-    private fun saveServer(subItem: SubscriptionItem): Boolean {
-
+    private fun saveSubscription(subItem: SubscriptionItem) {
         if (TextUtils.isEmpty(subItem.remarks)) {
             toast(R.string.sub_setting_remarks)
-            return false
+            return
         }
         if (subItem.url.isNotEmpty()) {
             if (!Utils.isValidUrl(subItem.url)) {
                 toast(R.string.toast_invalid_url)
-                return false
+                return
             }
             if (!Utils.isValidSubUrl(subItem.url)) {
                 toast(R.string.toast_insecure_url_protocol)
                 if (!subItem.allowInsecureUrl) {
-                    return false
+                    return
                 }
             }
         }
 
         if (subItem.autoUpdate && subItem.updateInterval < AppConfig.SUBSCRIPTION_MIN_INTERVAL_MINUTES) {
             toast(R.string.toast_invalid_update_interval)
-            return false
+            return
         }
 
         val savedSubId = if (editSubId.isEmpty()) {
@@ -112,34 +111,32 @@ class SubEditActivity : BaseComponentActivity() {
         }
         if (savedSubId == null) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         SubscriptionUpdater.syncOne(subId = savedSubId)
         SettingsChangeManager.makeSetupGroupTab()
         toastSuccess(R.string.toast_success)
         finish()
-        return true
     }
 
-    private fun deleteServer(): Boolean {
-        if (editSubId.isNotEmpty()) {
-            lifecycleScope.launch {
-                val result = withContext(Dispatchers.IO) {
-                    SettingsManager.removeSubscriptionWithDefault(editSubId)
-                }
-                if (!result.removed) {
-                    toast(R.string.toast_failure)
-                    return@launch
-                }
-                SettingsChangeManager.makeSetupGroupTab()
-                if (!result.defaultCreated) {
-                    toast(R.string.toast_failure)
-                }
-                finish()
+    private fun deleteSubscription() {
+        if (editSubId.isEmpty()) return
+
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                SettingsManager.removeSubscriptionWithDefault(editSubId)
             }
+            if (result == SettingsManager.SubscriptionRemovalResult.FAILED) {
+                toast(R.string.toast_failure)
+                return@launch
+            }
+            SettingsChangeManager.makeSetupGroupTab()
+            if (result == SettingsManager.SubscriptionRemovalResult.REMOVED_WITHOUT_DEFAULT) {
+                toast(R.string.toast_failure)
+            }
+            finish()
         }
-        return true
     }
 }
 
@@ -149,7 +146,7 @@ fun SubEditScreen(
     initial: SubscriptionItem,
     profileSuggestions: List<String>,
     onBackClick: () -> Unit,
-    onSave: (SubscriptionItem) -> Boolean,
+    onSave: (SubscriptionItem) -> Unit,
     onDelete: () -> Unit
 ) {
     //val context = LocalContext.current
@@ -199,7 +196,7 @@ fun SubEditScreen(
                             Icon(painterResource(R.drawable.ic_delete_24dp), contentDescription = stringResource(R.string.acc_delete))
                         }
                     }
-                    IconButton(onClick = { buildSubItem()?.let { onSave(it) } }) {
+                    IconButton(onClick = { onSave(buildSubItem()) }) {
                         Icon(painterResource(R.drawable.ic_fab_check), contentDescription = stringResource(R.string.acc_save))
                     }
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -47,6 +47,7 @@ import com.v2ray.ang.ui.compose.verticalScrollbar
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SubEditActivity : BaseComponentActivity() {
     private val editSubId by lazy { intent.getStringExtra("subId").orEmpty() }
@@ -102,8 +103,19 @@ class SubEditActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.encodeSubscription(editSubId, subItem)
-        SubscriptionUpdater.syncOne(subId = editSubId)
+        val savedSubId = if (editSubId.isEmpty()) {
+            MmkvManager.encodeSubscription(editSubId, subItem)
+        } else if (MmkvManager.updateSubscription(editSubId, this.subItem, subItem)) {
+            editSubId
+        } else {
+            null
+        }
+        if (savedSubId == null) {
+            toast(R.string.toast_failure)
+            return false
+        }
+
+        SubscriptionUpdater.syncOne(subId = savedSubId)
         SettingsChangeManager.makeSetupGroupTab()
         toastSuccess(R.string.toast_success)
         finish()
@@ -112,10 +124,19 @@ class SubEditActivity : BaseComponentActivity() {
 
     private fun deleteServer(): Boolean {
         if (editSubId.isNotEmpty()) {
-            lifecycleScope.launch(Dispatchers.IO) {
-                SettingsManager.removeSubscriptionWithDefault(editSubId)
+            lifecycleScope.launch {
+                val result = withContext(Dispatchers.IO) {
+                    SettingsManager.removeSubscriptionWithDefault(editSubId)
+                }
+                if (!result.removed) {
+                    toast(R.string.toast_failure)
+                    return@launch
+                }
                 SettingsChangeManager.makeSetupGroupTab()
-                launch(Dispatchers.Main) { finish() }
+                if (!result.defaultCreated) {
+                    toast(R.string.toast_failure)
+                }
+                finish()
             }
         }
         return true

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -46,6 +46,7 @@ import com.v2ray.ang.ui.compose.verticalScrollbar
 import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SubEditActivity : BaseComponentActivity() {
     private val editSubId by lazy { intent.getStringExtra("subId").orEmpty() }
@@ -101,8 +102,19 @@ class SubEditActivity : BaseComponentActivity() {
             return false
         }
 
-        MmkvManager.encodeSubscription(editSubId, subItem)
-        SubscriptionUpdater.syncOne(subId = editSubId)
+        val savedSubId = if (editSubId.isEmpty()) {
+            MmkvManager.encodeSubscription(editSubId, subItem)
+        } else if (MmkvManager.updateSubscription(editSubId, this.subItem, subItem)) {
+            editSubId
+        } else {
+            null
+        }
+        if (savedSubId == null) {
+            toast(R.string.toast_failure)
+            return false
+        }
+
+        SubscriptionUpdater.syncOne(subId = savedSubId)
         SettingsChangeManager.makeSetupGroupTab()
         toastSuccess(R.string.toast_success)
         finish()
@@ -111,10 +123,19 @@ class SubEditActivity : BaseComponentActivity() {
 
     private fun deleteServer(): Boolean {
         if (editSubId.isNotEmpty()) {
-            lifecycleScope.launch(Dispatchers.IO) {
-                SettingsManager.removeSubscriptionWithDefault(editSubId)
+            lifecycleScope.launch {
+                val result = withContext(Dispatchers.IO) {
+                    SettingsManager.removeSubscriptionWithDefault(editSubId)
+                }
+                if (!result.removed) {
+                    toast(R.string.toast_failure)
+                    return@launch
+                }
                 SettingsChangeManager.makeSetupGroupTab()
-                launch(Dispatchers.Main) { finish() }
+                if (!result.defaultCreated) {
+                    toast(R.string.toast_failure)
+                }
+                finish()
             }
         }
         return true

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubEditActivity.kt
@@ -73,33 +73,32 @@ class SubEditActivity : BaseComponentActivity() {
             initial = subItem,
             profileSuggestions = suggestions,
             onBackClick = { finish() },
-            onSave = { saveServer(it) },
-            onDelete = { deleteServer() }
+            onSave = ::saveSubscription,
+            onDelete = ::deleteSubscription,
         )
     }
 
-    private fun saveServer(subItem: SubscriptionItem): Boolean {
-
+    private fun saveSubscription(subItem: SubscriptionItem) {
         if (TextUtils.isEmpty(subItem.remarks)) {
             toast(R.string.sub_setting_remarks)
-            return false
+            return
         }
         if (subItem.url.isNotEmpty()) {
             if (!Utils.isValidUrl(subItem.url)) {
                 toast(R.string.toast_invalid_url)
-                return false
+                return
             }
             if (!Utils.isValidSubUrl(subItem.url)) {
                 toast(R.string.toast_insecure_url_protocol)
                 if (!subItem.allowInsecureUrl) {
-                    return false
+                    return
                 }
             }
         }
 
         if (subItem.autoUpdate && subItem.updateInterval < AppConfig.SUBSCRIPTION_MIN_INTERVAL_MINUTES) {
             toast(R.string.toast_invalid_update_interval)
-            return false
+            return
         }
 
         val savedSubId = if (editSubId.isEmpty()) {
@@ -111,34 +110,32 @@ class SubEditActivity : BaseComponentActivity() {
         }
         if (savedSubId == null) {
             toast(R.string.toast_failure)
-            return false
+            return
         }
 
         SubscriptionUpdater.syncOne(subId = savedSubId)
         SettingsChangeManager.makeSetupGroupTab()
         toastSuccess(R.string.toast_success)
         finish()
-        return true
     }
 
-    private fun deleteServer(): Boolean {
-        if (editSubId.isNotEmpty()) {
-            lifecycleScope.launch {
-                val result = withContext(Dispatchers.IO) {
-                    SettingsManager.removeSubscriptionWithDefault(editSubId)
-                }
-                if (!result.removed) {
-                    toast(R.string.toast_failure)
-                    return@launch
-                }
-                SettingsChangeManager.makeSetupGroupTab()
-                if (!result.defaultCreated) {
-                    toast(R.string.toast_failure)
-                }
-                finish()
+    private fun deleteSubscription() {
+        if (editSubId.isEmpty()) return
+
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                SettingsManager.removeSubscriptionWithDefault(editSubId)
             }
+            if (result == SettingsManager.SubscriptionRemovalResult.FAILED) {
+                toast(R.string.toast_failure)
+                return@launch
+            }
+            SettingsChangeManager.makeSetupGroupTab()
+            if (result == SettingsManager.SubscriptionRemovalResult.REMOVED_WITHOUT_DEFAULT) {
+                toast(R.string.toast_failure)
+            }
+            finish()
         }
-        return true
     }
 }
 
@@ -148,7 +145,7 @@ fun SubEditScreen(
     initial: SubscriptionItem,
     profileSuggestions: List<String>,
     onBackClick: () -> Unit,
-    onSave: (SubscriptionItem) -> Boolean,
+    onSave: (SubscriptionItem) -> Unit,
     onDelete: () -> Unit
 ) {
     //val context = LocalContext.current
@@ -198,7 +195,7 @@ fun SubEditScreen(
                             Icon(painterResource(R.drawable.ic_delete_24dp), contentDescription = stringResource(R.string.acc_delete))
                         }
                     }
-                    IconButton(onClick = { buildSubItem()?.let { onSave(it) } }) {
+                    IconButton(onClick = { onSave(buildSubItem()) }) {
                         Icon(painterResource(R.drawable.ic_fab_check), contentDescription = stringResource(R.string.acc_save))
                     }
                 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -22,80 +22,69 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 
 class SubscriptionsViewModel(application: Application) : BaseViewModel(application) {
-    private val subscriptions: MutableList<SubscriptionCache> =
-        MmkvManager.decodeSubscriptions().toMutableList()
-
-    private val _subsFlow = MutableStateFlow(subscriptions.toList())
+    private val _subsFlow = MutableStateFlow(MmkvManager.decodeSubscriptions())
     val subsFlow: StateFlow<List<SubscriptionCache>> = _subsFlow.asStateFlow()
 
-    fun getAll(): List<SubscriptionCache> = subscriptions.toList()
-
     fun reload() {
-        subscriptions.clear()
-        subscriptions.addAll(MmkvManager.decodeSubscriptions())
-        _subsFlow.value = subscriptions.toList()
+        _subsFlow.value = MmkvManager.decodeSubscriptions()
     }
 
     fun remove(subId: String) {
         launchLoading {
             val (result, persistedSubscriptions) = withContext(Dispatchers.IO) {
                 val removal = SettingsManager.removeSubscriptionWithDefault(subId)
-                removal to if (removal.removed) {
+                removal to if (removal != SettingsManager.SubscriptionRemovalResult.FAILED) {
                     MmkvManager.decodeSubscriptions()
                 } else {
                     emptyList()
                 }
             }
-            if (!result.removed) {
+            if (result == SettingsManager.SubscriptionRemovalResult.FAILED) {
                 toastError(R.string.toast_failure)
                 return@launchLoading
             }
 
-            subscriptions.clear()
-            subscriptions.addAll(persistedSubscriptions)
+            _subsFlow.value = persistedSubscriptions
             SettingsChangeManager.makeSetupGroupTab()
-            _subsFlow.value = subscriptions.toList()
-            if (!result.defaultCreated) {
+            if (result == SettingsManager.SubscriptionRemovalResult.REMOVED_WITHOUT_DEFAULT) {
                 toastError(R.string.toast_failure)
             }
         }
     }
 
     fun update(subId: String, item: SubscriptionItem) {
-        val idx = subscriptions.indexOfFirst { it.guid == subId }
-        if (idx >= 0) {
-            val expected = subscriptions[idx].subscription.copy()
-            launchLoading {
-                val saved = withContext(Dispatchers.IO) {
-                    MmkvManager.updateSubscription(subId, expected, item)
-                }
-                if (!saved) {
-                    toastError(R.string.toast_failure)
-                    return@launchLoading
-                }
+        val expected = _subsFlow.value
+            .firstOrNull { it.guid == subId }
+            ?.subscription
+            ?.copy()
+            ?: return
+        launchLoading {
+            val saved = withContext(Dispatchers.IO) {
+                MmkvManager.updateSubscription(subId, expected, item)
+            }
+            if (!saved) {
+                toastError(R.string.toast_failure)
+                return@launchLoading
+            }
 
-                val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
-                if (currentIndex >= 0) {
-                    subscriptions[currentIndex] = SubscriptionCache(subId, item)
-                    _subsFlow.value = subscriptions.toList()
-                }
+            val subscriptions = _subsFlow.value.toMutableList()
+            val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
+            if (currentIndex >= 0) {
+                subscriptions[currentIndex] = SubscriptionCache(subId, item)
+                _subsFlow.value = subscriptions
             }
         }
     }
 
     fun move(fromPosition: Int, toPosition: Int) {
-        val previous = subscriptions.toList()
-        if (subscriptions.moveItem(fromPosition, toPosition)) {
-            val saved = MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })
-            if (saved) {
-                SettingsChangeManager.makeSetupGroupTab()
-                _subsFlow.value = subscriptions.toList()
-            } else {
-                subscriptions.clear()
-                subscriptions.addAll(previous)
-                _subsFlow.value = subscriptions.toList()
-                toastError(R.string.toast_failure)
-            }
+        val subscriptions = _subsFlow.value.toMutableList()
+        if (!subscriptions.moveItem(fromPosition, toPosition)) return
+
+        if (MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })) {
+            SettingsChangeManager.makeSetupGroupTab()
+            _subsFlow.value = subscriptions
+        } else {
+            toastError(R.string.toast_failure)
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -36,30 +36,66 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
         _subsFlow.value = subscriptions.toList()
     }
 
-    fun remove(subId: String): Boolean {
-        val changed = subscriptions.removeAll { it.guid == subId }
-        if (changed) {
-            SettingsManager.removeSubscriptionWithDefault(subId)
+    fun remove(subId: String) {
+        launchLoading {
+            val (result, persistedSubscriptions) = withContext(Dispatchers.IO) {
+                val removal = SettingsManager.removeSubscriptionWithDefault(subId)
+                removal to if (removal.removed) {
+                    MmkvManager.decodeSubscriptions()
+                } else {
+                    emptyList()
+                }
+            }
+            if (!result.removed) {
+                toastError(R.string.toast_failure)
+                return@launchLoading
+            }
+
+            subscriptions.clear()
+            subscriptions.addAll(persistedSubscriptions)
             SettingsChangeManager.makeSetupGroupTab()
+            _subsFlow.value = subscriptions.toList()
+            if (!result.defaultCreated) {
+                toastError(R.string.toast_failure)
+            }
         }
-        _subsFlow.value = subscriptions.toList()
-        return changed
     }
 
     fun update(subId: String, item: SubscriptionItem) {
         val idx = subscriptions.indexOfFirst { it.guid == subId }
         if (idx >= 0) {
-            subscriptions[idx] = SubscriptionCache(subId, item)
-            MmkvManager.encodeSubscription(subId, item)
+            val expected = subscriptions[idx].subscription.copy()
+            launchLoading {
+                val saved = withContext(Dispatchers.IO) {
+                    MmkvManager.updateSubscription(subId, expected, item)
+                }
+                if (!saved) {
+                    toastError(R.string.toast_failure)
+                    return@launchLoading
+                }
+
+                val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
+                if (currentIndex >= 0) {
+                    subscriptions[currentIndex] = SubscriptionCache(subId, item)
+                    _subsFlow.value = subscriptions.toList()
+                }
+            }
         }
-        _subsFlow.value = subscriptions.toList()
     }
 
     fun move(fromPosition: Int, toPosition: Int) {
+        val previous = subscriptions.toList()
         if (subscriptions.moveItem(fromPosition, toPosition)) {
-            MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })
-            SettingsChangeManager.makeSetupGroupTab()
-            _subsFlow.value = subscriptions.toList()
+            val saved = MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })
+            if (saved) {
+                SettingsChangeManager.makeSetupGroupTab()
+                _subsFlow.value = subscriptions.toList()
+            } else {
+                subscriptions.clear()
+                subscriptions.addAll(previous)
+                _subsFlow.value = subscriptions.toList()
+                toastError(R.string.toast_failure)
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -30,63 +30,56 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
     private var qrCodeJob: Job? = null
     private val _qrCode = MutableStateFlow<Bitmap?>(null)
     internal val qrCode = _qrCode.asStateFlow()
-    private val subscriptions: MutableList<SubscriptionCache> =
-        MmkvManager.decodeSubscriptions().toMutableList()
-
-    private val _subsFlow = MutableStateFlow(subscriptions.toList())
+    private val _subsFlow = MutableStateFlow(MmkvManager.decodeSubscriptions())
     val subsFlow: StateFlow<List<SubscriptionCache>> = _subsFlow.asStateFlow()
 
-    fun getAll(): List<SubscriptionCache> = subscriptions.toList()
-
     fun reload() {
-        subscriptions.clear()
-        subscriptions.addAll(MmkvManager.decodeSubscriptions())
-        _subsFlow.value = subscriptions.toList()
+        _subsFlow.value = MmkvManager.decodeSubscriptions()
     }
 
     fun remove(subId: String) {
         launchLoading {
             val (result, persistedSubscriptions) = withContext(Dispatchers.IO) {
                 val removal = SettingsManager.removeSubscriptionWithDefault(subId)
-                removal to if (removal.removed) {
+                removal to if (removal != SettingsManager.SubscriptionRemovalResult.FAILED) {
                     MmkvManager.decodeSubscriptions()
                 } else {
                     emptyList()
                 }
             }
-            if (!result.removed) {
+            if (result == SettingsManager.SubscriptionRemovalResult.FAILED) {
                 toastError(R.string.toast_failure)
                 return@launchLoading
             }
 
-            subscriptions.clear()
-            subscriptions.addAll(persistedSubscriptions)
+            _subsFlow.value = persistedSubscriptions
             SettingsChangeManager.makeSetupGroupTab()
-            _subsFlow.value = subscriptions.toList()
-            if (!result.defaultCreated) {
+            if (result == SettingsManager.SubscriptionRemovalResult.REMOVED_WITHOUT_DEFAULT) {
                 toastError(R.string.toast_failure)
             }
         }
     }
 
     fun update(subId: String, item: SubscriptionItem) {
-        val idx = subscriptions.indexOfFirst { it.guid == subId }
-        if (idx >= 0) {
-            val expected = subscriptions[idx].subscription.copy()
-            launchLoading {
-                val saved = withContext(Dispatchers.IO) {
-                    MmkvManager.updateSubscription(subId, expected, item)
-                }
-                if (!saved) {
-                    toastError(R.string.toast_failure)
-                    return@launchLoading
-                }
+        val expected = _subsFlow.value
+            .firstOrNull { it.guid == subId }
+            ?.subscription
+            ?.copy()
+            ?: return
+        launchLoading {
+            val saved = withContext(Dispatchers.IO) {
+                MmkvManager.updateSubscription(subId, expected, item)
+            }
+            if (!saved) {
+                toastError(R.string.toast_failure)
+                return@launchLoading
+            }
 
-                val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
-                if (currentIndex >= 0) {
-                    subscriptions[currentIndex] = SubscriptionCache(subId, item)
-                    _subsFlow.value = subscriptions.toList()
-                }
+            val subscriptions = _subsFlow.value.toMutableList()
+            val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
+            if (currentIndex >= 0) {
+                subscriptions[currentIndex] = SubscriptionCache(subId, item)
+                _subsFlow.value = subscriptions
             }
         }
     }
@@ -107,18 +100,14 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
     }
 
     fun move(fromPosition: Int, toPosition: Int) {
-        val previous = subscriptions.toList()
-        if (subscriptions.moveItem(fromPosition, toPosition)) {
-            val saved = MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })
-            if (saved) {
-                SettingsChangeManager.makeSetupGroupTab()
-                _subsFlow.value = subscriptions.toList()
-            } else {
-                subscriptions.clear()
-                subscriptions.addAll(previous)
-                _subsFlow.value = subscriptions.toList()
-                toastError(R.string.toast_failure)
-            }
+        val subscriptions = _subsFlow.value.toMutableList()
+        if (!subscriptions.moveItem(fromPosition, toPosition)) return
+
+        if (MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })) {
+            SettingsChangeManager.makeSetupGroupTab()
+            _subsFlow.value = subscriptions
+        } else {
+            toastError(R.string.toast_failure)
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -18,41 +18,53 @@ import com.v2ray.ang.ui.base.BaseViewModel
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.QRCodeDecoder
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class SubscriptionsViewModel(application: Application) : BaseViewModel(application) {
+class SubscriptionsViewModel @JvmOverloads constructor(
+    application: Application,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : BaseViewModel(application) {
     private var qrCodeJob: Job? = null
     private val _qrCode = MutableStateFlow<Bitmap?>(null)
     internal val qrCode = _qrCode.asStateFlow()
-    private val _subsFlow = MutableStateFlow(MmkvManager.decodeSubscriptions())
+    private val _subsFlow = MutableStateFlow<List<SubscriptionCache>>(emptyList())
     val subsFlow: StateFlow<List<SubscriptionCache>> = _subsFlow.asStateFlow()
+    private var orderPersistenceJob: Job? = null
+    private var reloadJob: Job? = null
+
+    init {
+        reload()
+    }
 
     fun reload() {
-        _subsFlow.value = MmkvManager.decodeSubscriptions()
+        reloadJob?.cancel()
+        reloadJob = viewModelScope.launch {
+            orderPersistenceJob?.join()
+            val observedOrderJob = orderPersistenceJob
+            val persisted = withContext(ioDispatcher) { MmkvManager.decodeSubscriptions() }
+            if (orderPersistenceJob === observedOrderJob) _subsFlow.value = persisted
+        }
     }
 
     fun remove(subId: String) {
         launchLoading {
-            val (result, persistedSubscriptions) = withContext(Dispatchers.IO) {
-                val removal = SettingsManager.removeSubscriptionWithDefault(subId)
-                removal to if (removal != SettingsManager.SubscriptionRemovalResult.FAILED) {
-                    MmkvManager.decodeSubscriptions()
-                } else {
-                    emptyList()
-                }
+            val result = withContext(ioDispatcher) {
+                SettingsManager.removeSubscriptionWithDefault(subId)
             }
             if (result == SettingsManager.SubscriptionRemovalResult.FAILED) {
                 toastError(R.string.toast_failure)
                 return@launchLoading
             }
 
-            _subsFlow.value = persistedSubscriptions
+            reload()
             SettingsChangeManager.makeSetupGroupTab()
             if (result == SettingsManager.SubscriptionRemovalResult.REMOVED_WITHOUT_DEFAULT) {
                 toastError(R.string.toast_failure)
@@ -67,20 +79,11 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
             ?.copy()
             ?: return
         launchLoading {
-            val saved = withContext(Dispatchers.IO) {
+            val saved = withContext(ioDispatcher) {
                 MmkvManager.updateSubscription(subId, expected, item)
             }
-            if (!saved) {
-                toastError(R.string.toast_failure)
-                return@launchLoading
-            }
-
-            val subscriptions = _subsFlow.value.toMutableList()
-            val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
-            if (currentIndex >= 0) {
-                subscriptions[currentIndex] = SubscriptionCache(subId, item)
-                _subsFlow.value = subscriptions
-            }
+            if (!saved) toastError(R.string.toast_failure)
+            reload()
         }
     }
 
@@ -103,11 +106,19 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
         val subscriptions = _subsFlow.value.toMutableList()
         if (!subscriptions.moveItem(fromPosition, toPosition)) return
 
-        if (MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })) {
-            SettingsChangeManager.makeSetupGroupTab()
-            _subsFlow.value = subscriptions
-        } else {
-            toastError(R.string.toast_failure)
+        _subsFlow.value = subscriptions
+        val previous = orderPersistenceJob
+        orderPersistenceJob = viewModelScope.launch {
+            previous?.join()
+            val saved = withContext(ioDispatcher) {
+                MmkvManager.reorderSubscriptions(subscriptions.map { it.guid })
+            }
+            if (saved) SettingsChangeManager.makeSetupGroupTab() else toastError(R.string.toast_failure)
+            val thisJob = currentCoroutineContext()[Job]
+            if (orderPersistenceJob === thisJob) {
+                orderPersistenceJob = null
+                reload()
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -44,23 +44,51 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
         _subsFlow.value = subscriptions.toList()
     }
 
-    fun remove(subId: String): Boolean {
-        val changed = subscriptions.removeAll { it.guid == subId }
-        if (changed) {
-            SettingsManager.removeSubscriptionWithDefault(subId)
+    fun remove(subId: String) {
+        launchLoading {
+            val (result, persistedSubscriptions) = withContext(Dispatchers.IO) {
+                val removal = SettingsManager.removeSubscriptionWithDefault(subId)
+                removal to if (removal.removed) {
+                    MmkvManager.decodeSubscriptions()
+                } else {
+                    emptyList()
+                }
+            }
+            if (!result.removed) {
+                toastError(R.string.toast_failure)
+                return@launchLoading
+            }
+
+            subscriptions.clear()
+            subscriptions.addAll(persistedSubscriptions)
             SettingsChangeManager.makeSetupGroupTab()
+            _subsFlow.value = subscriptions.toList()
+            if (!result.defaultCreated) {
+                toastError(R.string.toast_failure)
+            }
         }
-        _subsFlow.value = subscriptions.toList()
-        return changed
     }
 
     fun update(subId: String, item: SubscriptionItem) {
         val idx = subscriptions.indexOfFirst { it.guid == subId }
         if (idx >= 0) {
-            subscriptions[idx] = SubscriptionCache(subId, item)
-            MmkvManager.encodeSubscription(subId, item)
+            val expected = subscriptions[idx].subscription.copy()
+            launchLoading {
+                val saved = withContext(Dispatchers.IO) {
+                    MmkvManager.updateSubscription(subId, expected, item)
+                }
+                if (!saved) {
+                    toastError(R.string.toast_failure)
+                    return@launchLoading
+                }
+
+                val currentIndex = subscriptions.indexOfFirst { it.guid == subId }
+                if (currentIndex >= 0) {
+                    subscriptions[currentIndex] = SubscriptionCache(subId, item)
+                    _subsFlow.value = subscriptions.toList()
+                }
+            }
         }
-        _subsFlow.value = subscriptions.toList()
     }
 
     internal fun shareQRCode(url: String) {
@@ -79,10 +107,18 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
     }
 
     fun move(fromPosition: Int, toPosition: Int) {
+        val previous = subscriptions.toList()
         if (subscriptions.moveItem(fromPosition, toPosition)) {
-            MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })
-            SettingsChangeManager.makeSetupGroupTab()
-            _subsFlow.value = subscriptions.toList()
+            val saved = MmkvManager.encodeSubsList(subscriptions.mapTo(mutableListOf()) { it.guid })
+            if (saved) {
+                SettingsChangeManager.makeSetupGroupTab()
+                _subsFlow.value = subscriptions.toList()
+            } else {
+                subscriptions.clear()
+                subscriptions.addAll(previous)
+                _subsFlow.value = subscriptions.toList()
+                toastError(R.string.toast_failure)
+            }
         }
     }
 

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/MmkvPersistenceTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/MmkvPersistenceTest.kt
@@ -1,0 +1,207 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.dto.entities.ProfileItem
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.enums.EConfigType
+import com.v2ray.ang.util.JsonUtil
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class MmkvPersistenceTest {
+    private lateinit var stores: MmkvTestStore
+
+    @Before fun setUp() { stores = MmkvTestStore() }
+    @After fun tearDown() { stores.close() }
+
+    @Test fun `stale profile reorder preserves additions and excludes deleted IDs`() {
+        stores.main.values["SUB_SERVERS_s"] = "[\"new\",\"a\",\"c\"]"
+        assertTrue(MmkvManager.reorderServerList(listOf("c", "deleted", "a", "a"), "s"))
+        assertEquals(listOf("c", "a", "new"), MmkvManager.decodeServerList("s"))
+    }
+
+    @Test fun `stale subscription reorder preserves current membership`() {
+        stores.main.values["SUB_IDS"] = "[\"new\",\"a\",\"c\"]"
+        assertTrue(MmkvManager.reorderSubscriptions(listOf("c", "deleted", "a")))
+        assertEquals(listOf("c", "a", "new"), MmkvManager.decodeSubsList())
+    }
+
+    @Test fun `empty reorder cannot remove entries or create deleted entries`() {
+        stores.main.values["SUB_IDS"] = "[\"a\"]"
+        assertTrue(MmkvManager.reorderSubscriptions(emptyList()))
+        assertEquals(listOf("a"), MmkvManager.decodeSubsList())
+        stores.main.values["SUB_IDS"] = "[]"
+        assertTrue(MmkvManager.reorderSubscriptions(listOf("deleted")))
+        assertTrue(MmkvManager.decodeSubsList().isEmpty())
+    }
+
+    @Test fun `failed or unreadable reorder leaves the index untouched`() {
+        stores.main.values["SUB_IDS"] = "[\"a\",\"b\"]"
+        stores.main.failWrite = { true }
+        assertFalse(MmkvManager.reorderSubscriptions(listOf("b", "a")))
+        assertEquals(listOf("a", "b"), MmkvManager.decodeSubsList())
+        stores.main.failWrite = { false }
+        stores.main.values["SUB_IDS"] = "invalid"
+        assertFalse(MmkvManager.reorderSubscriptions(listOf("b", "a")))
+        assertEquals("invalid", stores.main.values["SUB_IDS"])
+    }
+
+    @Test fun `last subscription stays deleted when metadata cleanup fails`() {
+        val item = SubscriptionItem(remarks = "s")
+        assertEquals("s", MmkvManager.encodeSubscription("s", item))
+        stores.subscriptions.failRemove = true
+        assertTrue(MmkvManager.removeSubscription("s"))
+        assertTrue(stores.subscriptions.values.containsKey("s"))
+        assertTrue(MmkvManager.decodeSubscriptions().isEmpty())
+        assertTrue(MmkvManager.migrateSubscriptionIndex())
+        assertTrue(MmkvManager.decodeSubscriptions().isEmpty())
+        assertFalse(MmkvManager.updateSubscription("s", item, item.copy(enabled = false)))
+    }
+
+    @Test fun `legacy subscriptions are recovered only by explicit migration`() {
+        stores.subscriptions.values["s"] = JsonUtil.toJson(SubscriptionItem(remarks = "legacy"))
+        assertTrue(MmkvManager.decodeSubscriptions().isEmpty())
+        assertFalse(stores.main.values.containsKey("SUB_IDS"))
+        stores.main.failWrite = { true }
+        assertFalse(MmkvManager.migrateSubscriptionIndex())
+        stores.main.failWrite = { false }
+        assertTrue(MmkvManager.migrateSubscriptionIndex())
+        assertEquals(listOf("s"), MmkvManager.decodeSubsList())
+    }
+
+    @Test fun `settings edits and older refreshes preserve the latest timestamp`() {
+        val expected = SubscriptionItem(lastUpdated = 100)
+        MmkvManager.encodeSubscription("s", expected.copy(lastUpdated = 200))
+        assertTrue(MmkvManager.updateSubscription("s", expected, expected.copy(enabled = false)))
+        val edited = MmkvManager.decodeSubscription("s")!!
+        assertFalse(edited.enabled)
+        assertEquals(200L, edited.lastUpdated)
+        assertTrue(MmkvManager.updateSubscription("s", edited, edited, updatedAt = 300))
+        assertEquals(300L, MmkvManager.decodeSubscription("s")!!.lastUpdated)
+        assertFalse(MmkvManager.updateSubscription("s", edited, edited, updatedAt = 250))
+        assertEquals(300L, MmkvManager.decodeSubscription("s")!!.lastUpdated)
+    }
+
+    @Test fun `stale profile batch does not overwrite a completed refresh`() {
+        val expected = SubscriptionItem(lastUpdated = 100)
+        MmkvManager.encodeSubscription("s", expected.copy(lastUpdated = 300))
+        val profile = ProfileItem.create(EConfigType.VLESS).apply { subscriptionId = "s" }
+        assertThrows(SubscriptionUpdateAbortedException::class.java) {
+            MmkvManager.saveServerProfiles(mapOf("p" to profile), emptyMap(), "s", true,
+                SubscriptionUpdateCommit(expected, expected.copy(lastUpdated = 200)))
+        }
+        assertEquals(300L, MmkvManager.decodeSubscription("s")!!.lastUpdated)
+        assertTrue(MmkvManager.decodeServerList("s").isEmpty())
+        assertNull(MmkvManager.decodeServerConfig("p"))
+    }
+
+    @Test fun `fresh timestamp and batch updates accept a backward clock correction`() {
+        val future = SubscriptionItem(lastUpdated = 20000)
+        MmkvManager.encodeSubscription("s", future)
+        assertTrue(MmkvManager.updateSubscription("s", future, future, updatedAt = 10000))
+        val expected = MmkvManager.decodeSubscription("s")!!
+        assertEquals(10000L, expected.lastUpdated)
+        val profile = ProfileItem.create(EConfigType.VLESS).apply { subscriptionId = "s" }
+        MmkvManager.saveServerProfiles(mapOf("p" to profile), emptyMap(), "s", true,
+            SubscriptionUpdateCommit(expected, expected.copy(lastUpdated = 5000)))
+        assertEquals(5000L, MmkvManager.decodeSubscription("s")!!.lastUpdated)
+        assertEquals(listOf("p"), MmkvManager.decodeServerList("s"))
+        assertFalse(MmkvManager.updateSubscription("s", expected, expected, updatedAt = 15000))
+    }
+
+    @Test fun `settings edits never replace refresh metadata from their snapshot`() {
+        val expected = SubscriptionItem(lastUpdated = 100)
+        MmkvManager.encodeSubscription("s", expected)
+        assertTrue(MmkvManager.updateSubscription("s", expected, expected.copy(remarks = "edited", lastUpdated = 900)))
+        assertEquals(100L, MmkvManager.decodeSubscription("s")!!.lastUpdated)
+    }
+
+    @Test fun `unreadable migration payload remains pending until repaired`() {
+        MmkvManager.encodeSubscription("s", SubscriptionItem())
+        stores.main.values["SUB_SERVERS_s"] = "[\"p\",\"missing\"]"
+        stores.main.values["ANG_CONFIGS"] = "[\"p\",\"missing\"]"
+        for (unreadable in listOf("invalid-json", 123)) {
+            stores.profiles.values["p"] = unreadable
+            migratePins()
+            assertFalse(MmkvManager.decodeSettingsBool("hysteria2_pin_sha256_migrated", false))
+            assertFalse(migrateServerIndex())
+            assertFalse(MmkvManager.decodeSettingsBool("server_list_to_subscriptions_migrated", false))
+        }
+        stores.profiles.values["p"] = JsonUtil.toJson(ProfileItem.create(EConfigType.HYSTERIA2).apply {
+            subscriptionId = "s"
+            pinSHA256 = "old-pin"
+        })
+        assertTrue(migrateServerIndex())
+        migratePins()
+        assertTrue(MmkvManager.decodeSettingsBool("hysteria2_pin_sha256_migrated", false))
+        assertEquals("old-pin", MmkvManager.decodeServerConfig("p")!!.pinnedCA256)
+    }
+
+    @Test fun `unreadable migration indexes are not treated as empty`() {
+        for (key in listOf("SUB_IDS", "SUB_SERVERS_s")) {
+            stores.main.values["SUB_IDS"] = "[\"s\"]"
+            stores.main.values["SUB_SERVERS_s"] = "[]"
+            stores.main.values[key] = "invalid-json"
+            migratePins()
+            assertFalse(MmkvManager.decodeSettingsBool("hysteria2_pin_sha256_migrated", false))
+        }
+        stores.main.values["SUB_IDS"] = "[]"
+        stores.main.values["ANG_CONFIGS"] = 123
+        assertFalse(migrateServerIndex())
+        assertFalse(MmkvManager.decodeSettingsBool("server_list_to_subscriptions_migrated", false))
+    }
+
+    @Test fun `absent migration records do not prevent completion`() {
+        stores.main.values["SUB_IDS"] = "[\"s\"]"
+        stores.main.values["SUB_SERVERS_s"] = "[\"missing\"]"
+        stores.main.values["ANG_CONFIGS"] = "[\"missing\"]"
+        assertTrue(migrateServerIndex())
+        migratePins()
+        assertTrue(MmkvManager.decodeSettingsBool("hysteria2_pin_sha256_migrated", false))
+        assertTrue(MmkvManager.readProfilesForMigration().isEmpty())
+    }
+
+    @Test fun `failed pin migration is retried before its completion flag is set`() {
+        val profile = ProfileItem.create(EConfigType.HYSTERIA2).apply {
+            subscriptionId = "s"
+            pinSHA256 = "old-pin"
+        }
+        MmkvManager.encodeSubscription("s", SubscriptionItem())
+        MmkvManager.encodeServerConfig("p", profile)
+        stores.profiles.failWrite = { true }
+        migratePins()
+        assertFalse(MmkvManager.decodeSettingsBool("hysteria2_pin_sha256_migrated", false))
+        assertEquals("old-pin", MmkvManager.decodeServerConfig("p")!!.pinSHA256)
+        stores.profiles.failWrite = { false }
+        migratePins()
+        assertTrue(MmkvManager.decodeSettingsBool("hysteria2_pin_sha256_migrated", false))
+        assertEquals("old-pin", MmkvManager.decodeServerConfig("p")!!.pinnedCA256)
+        assertNull(MmkvManager.decodeServerConfig("p")!!.pinSHA256)
+    }
+
+    private fun migratePins() {
+        SettingsManager::class.java.getDeclaredMethod("migrateHysteria2PinSHA256")
+            .apply { isAccessible = true }.invoke(SettingsManager)
+    }
+
+    @Test fun `legacy profile index migration retries without hiding newer imports`() {
+        stores.main.values["SUB_IDS"] = "[\"s\"]"
+        stores.main.values["ANG_CONFIGS"] = "[\"legacy\"]"
+        stores.subscriptions.values["s"] = JsonUtil.toJson(SubscriptionItem())
+        stores.profiles.values["legacy"] = JsonUtil.toJson(
+            ProfileItem.create(EConfigType.VLESS).apply { subscriptionId = "s" })
+        stores.main.failWrite = { it == "SUB_SERVERS_s" }
+        assertFalse(migrateServerIndex())
+        assertFalse(MmkvManager.decodeSettingsBool("server_list_to_subscriptions_migrated", false))
+        stores.main.values["SUB_SERVERS_s"] = "[\"new\"]"
+        stores.main.failWrite = { false }
+        assertTrue(migrateServerIndex())
+        assertEquals(listOf("new", "legacy"), MmkvManager.decodeServerList("s"))
+        assertTrue(MmkvManager.decodeSettingsBool("server_list_to_subscriptions_migrated", false))
+    }
+
+    private fun migrateServerIndex(): Boolean =
+        SettingsManager::class.java.getDeclaredMethod("migrateServerListToSubscriptions")
+            .apply { isAccessible = true }.invoke(SettingsManager) as Boolean
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/MmkvTestStore.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/MmkvTestStore.kt
@@ -1,0 +1,84 @@
+package com.v2ray.ang.handler
+
+import com.tencent.mmkv.MMKV
+import com.v2ray.ang.util.LogUtil
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy
+import net.bytebuddy.implementation.StubMethod
+import net.bytebuddy.matcher.ElementMatchers
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.whenever
+
+/** In-memory MMKV boundary: production manager transactions and serialization still execute. */
+class MmkvTestStore : AutoCloseable {
+    class Store {
+        val values = linkedMapOf<String, Any>()
+        var failWrite: (String) -> Boolean = { false }
+        var failRemove = false
+        val mmkv: MMKV = Mockito.mock(mmkvClass)
+
+        init {
+            whenever(mmkv.containsKey(any())).thenAnswer { it.getArgument<String>(0) in values }
+            whenever(mmkv.decodeString(any())).thenAnswer { values[it.getArgument<String>(0)] as? String }
+            whenever(mmkv.decodeBool(any(), any())).thenAnswer {
+                values[it.getArgument<String>(0)] as? Boolean ?: it.getArgument<Boolean>(1)
+            }
+            whenever(mmkv.allKeys()).thenAnswer { values.keys.toTypedArray() }
+            whenever(mmkv.encode(any<String>(), any<String>())).thenAnswer {
+                val key = it.getArgument<String>(0)
+                if (failWrite(key)) false else { values[key] = it.getArgument<String>(1); true }
+            }
+            whenever(mmkv.encode(any<String>(), any<Boolean>())).thenAnswer {
+                val key = it.getArgument<String>(0)
+                if (failWrite(key)) false else { values[key] = it.getArgument<Boolean>(1); true }
+            }
+            doAnswer {
+                if (!failRemove) values.remove(it.getArgument<String>(0))
+                null
+            }.whenever(mmkv).remove(any())
+            doAnswer {
+                if (!failRemove) it.getArgument<Array<String>>(0).forEach(values::remove)
+                null
+            }.whenever(mmkv).removeValuesForKeys(any())
+        }
+    }
+
+    private val restore = mutableListOf<() -> Unit>()
+    val main = install("mainStorage")
+    val profiles = install("profileFullStorage")
+    val raw = install("serverRawStorage")
+    val affiliations = install("serverAffStorage")
+    val subscriptions = install("subStorage")
+    val settings = install("settingsStorage")
+
+    init {
+        val field = LogUtil::class.java.getDeclaredField("cachedMinPriority").apply { isAccessible = true }
+        val previous = field.get(null)
+        field.set(null, Int.MAX_VALUE)
+        restore += { field.set(null, previous) }
+    }
+
+    private fun install(name: String): Store {
+        val delegate = MmkvManager::class.java.getDeclaredField("${name}\$delegate")
+            .apply { isAccessible = true }.get(null)
+        val value = delegate.javaClass.getDeclaredField("_value").apply { isAccessible = true }
+        val previous = value.get(delegate)
+        val store = Store()
+        value.set(delegate, store.mmkv)
+        restore += { value.set(delegate, previous) }
+        return store
+    }
+
+    override fun close() = restore.asReversed().forEach { it() }
+
+    companion object {
+        // Mockito cannot intercept JNI methods. Override them before installing normal mock answers.
+        private val mmkvClass = ByteBuddy()
+            .subclass(MMKV::class.java, ConstructorStrategy.Default.NO_CONSTRUCTORS)
+            .method(ElementMatchers.isNative())
+            .intercept(StubMethod.INSTANCE)
+            .make().load(MMKV::class.java.classLoader).loaded
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/StorageMutationTransactionTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/StorageMutationTransactionTest.kt
@@ -1,0 +1,211 @@
+package com.v2ray.ang.handler
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class StorageMutationTransactionTest {
+
+    @Test
+    fun `restores every mutation when a write reports failure`() {
+        val values = mutableMapOf(
+            "first" to "before-first",
+            "second" to "before-second",
+        )
+
+        expectFailure<ProfileStorageException> {
+            runStorageMutationTransaction {
+                mutate(
+                    change = {
+                        values["first"] = "after-first"
+                        true
+                    },
+                    restore = {
+                        values["first"] = "before-first"
+                        true
+                    },
+                    failureMessage = "first write",
+                )
+                mutate(
+                    change = {
+                        values["second"] = "partial-second"
+                        false
+                    },
+                    restore = {
+                        values["second"] = "before-second"
+                        true
+                    },
+                    failureMessage = "second write",
+                )
+            }
+        }
+
+        assertEquals("before-first", values["first"])
+        assertEquals("before-second", values["second"])
+    }
+
+    @Test
+    fun `restores a mutation when the write throws`() {
+        val values = mutableMapOf("profile" to "before")
+
+        expectFailure<IllegalArgumentException> {
+            runStorageMutationTransaction {
+                mutate(
+                    change = {
+                        values["profile"] = "partial"
+                        throw IllegalArgumentException("write failed")
+                    },
+                    restore = {
+                        values["profile"] = "before"
+                        true
+                    },
+                    failureMessage = "profile write",
+                )
+            }
+        }
+
+        assertEquals("before", values["profile"])
+    }
+
+    @Test
+    fun `removes a newly created value when a later write fails`() {
+        val values = mutableMapOf<String, String>()
+
+        expectFailure<ProfileStorageException> {
+            runStorageMutationTransaction {
+                mutate(
+                    change = {
+                        values["profile"] = "new"
+                        true
+                    },
+                    restore = {
+                        values.remove("profile")
+                        true
+                    },
+                    failureMessage = "profile write",
+                )
+                mutate(
+                    change = { false },
+                    restore = { true },
+                    failureMessage = "index write",
+                )
+            }
+        }
+
+        assertFalse(values.containsKey("profile"))
+    }
+
+    @Test
+    fun `committed mutations are not restored`() {
+        val values = mutableMapOf("profile" to "before")
+
+        runStorageMutationTransaction {
+            mutate(
+                change = {
+                    values["profile"] = "after"
+                    true
+                },
+                restore = {
+                    values["profile"] = "before"
+                    true
+                },
+                failureMessage = "profile write",
+            )
+        }
+
+        assertEquals("after", values["profile"])
+    }
+
+    @Test
+    fun `reports rollback failures without hiding the original failure`() {
+        val failure = expectFailure<ProfileStorageException> {
+            runStorageMutationTransaction {
+                mutate(
+                    change = { true },
+                    restore = { false },
+                    failureMessage = "first write",
+                )
+                mutate(
+                    change = { false },
+                    restore = { true },
+                    failureMessage = "second write",
+                )
+            }
+        }
+
+        assertEquals("second write", failure.message)
+        assertEquals(1, failure.suppressed.size)
+        assertTrue(failure.suppressed.single().message.orEmpty().contains("first write"))
+    }
+
+    @Test
+    fun `publishes the authoritative index after every preparation step`() {
+        val writes = mutableListOf<String>()
+
+        runStorageMutationTransaction {
+            prepareThenPublish(
+                prepare = {
+                    writes += "raw payload"
+                    writes += "profile payload"
+                    writes += "selected profile"
+                },
+                publish = { writes += "profile index" },
+            )
+        }
+
+        assertEquals(
+            listOf("raw payload", "profile payload", "selected profile", "profile index"),
+            writes,
+        )
+    }
+
+    @Test
+    fun `does not publish the index when preparation fails and rollback also fails`() {
+        val values = mutableMapOf(
+            "payload" to "old payload",
+            "index" to "old index",
+        )
+
+        val failure = expectFailure<ProfileStorageException> {
+            runStorageMutationTransaction {
+                prepareThenPublish(
+                    prepare = {
+                        mutate(
+                            change = {
+                                values["payload"] = "extra payload"
+                                true
+                            },
+                            restore = { false },
+                            failureMessage = "payload write",
+                        )
+                        mutate(
+                            change = { false },
+                            restore = { true },
+                            failureMessage = "metadata write",
+                        )
+                    },
+                    publish = {
+                        values["index"] = "new index"
+                    },
+                )
+            }
+        }
+
+        assertEquals("metadata write", failure.message)
+        assertEquals("extra payload", values["payload"])
+        assertEquals("old index", values["index"])
+    }
+
+    private inline fun <reified T : Throwable> expectFailure(block: () -> Unit): T {
+        try {
+            block()
+            fail("Expected ${T::class.java.simpleName}")
+        } catch (failure: Throwable) {
+            if (failure !is T) throw failure
+            return failure
+        }
+        throw AssertionError("Unreachable")
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/StorageMutationTransactionTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/StorageMutationTransactionTest.kt
@@ -17,33 +17,15 @@ class StorageMutationTransactionTest {
 
         expectFailure<ProfileStorageException> {
             runStorageMutationTransaction {
-                mutate(
-                    change = {
-                        values["first"] = "after-first"
-                        true
-                    },
-                    restore = {
-                        values["first"] = "before-first"
-                        true
-                    },
-                    failureMessage = "first write",
-                )
-                mutate(
-                    change = {
-                        values["second"] = "partial-second"
-                        false
-                    },
-                    restore = {
-                        values["second"] = "before-second"
-                        true
-                    },
-                    failureMessage = "second write",
-                )
+                write(values, "first", "after-first")
+                write(values, "second", "partial-second", succeeds = false)
             }
         }
 
-        assertEquals("before-first", values["first"])
-        assertEquals("before-second", values["second"])
+        assertEquals(
+            mapOf("first" to "before-first", "second" to "before-second"),
+            values,
+        )
     }
 
     @Test
@@ -52,16 +34,11 @@ class StorageMutationTransactionTest {
 
         expectFailure<IllegalArgumentException> {
             runStorageMutationTransaction {
-                mutate(
-                    change = {
-                        values["profile"] = "partial"
-                        throw IllegalArgumentException("write failed")
-                    },
-                    restore = {
-                        values["profile"] = "before"
-                        true
-                    },
-                    failureMessage = "profile write",
+                write(
+                    values,
+                    "profile",
+                    "partial",
+                    changeFailure = IllegalArgumentException("write failed"),
                 )
             }
         }
@@ -75,22 +52,8 @@ class StorageMutationTransactionTest {
 
         expectFailure<ProfileStorageException> {
             runStorageMutationTransaction {
-                mutate(
-                    change = {
-                        values["profile"] = "new"
-                        true
-                    },
-                    restore = {
-                        values.remove("profile")
-                        true
-                    },
-                    failureMessage = "profile write",
-                )
-                mutate(
-                    change = { false },
-                    restore = { true },
-                    failureMessage = "index write",
-                )
+                write(values, "profile", "new")
+                write(values, "index", "new", succeeds = false)
             }
         }
 
@@ -102,17 +65,7 @@ class StorageMutationTransactionTest {
         val values = mutableMapOf("profile" to "before")
 
         runStorageMutationTransaction {
-            mutate(
-                change = {
-                    values["profile"] = "after"
-                    true
-                },
-                restore = {
-                    values["profile"] = "before"
-                    true
-                },
-                failureMessage = "profile write",
-            )
+            write(values, "profile", "after")
         }
 
         assertEquals("after", values["profile"])
@@ -120,82 +73,46 @@ class StorageMutationTransactionTest {
 
     @Test
     fun `reports rollback failures without hiding the original failure`() {
+        val values = mutableMapOf("first" to "before")
+
         val failure = expectFailure<ProfileStorageException> {
             runStorageMutationTransaction {
-                mutate(
-                    change = { true },
-                    restore = { false },
-                    failureMessage = "first write",
-                )
-                mutate(
-                    change = { false },
-                    restore = { true },
-                    failureMessage = "second write",
-                )
+                write(values, "first", "after", restoreSucceeds = false)
+                write(values, "second", "after", succeeds = false)
             }
         }
 
         assertEquals("second write", failure.message)
         assertEquals(1, failure.suppressed.size)
         assertTrue(failure.suppressed.single().message.orEmpty().contains("first write"))
+        assertEquals("after", values["first"])
     }
 
-    @Test
-    fun `publishes the authoritative index after every preparation step`() {
-        val writes = mutableListOf<String>()
-
-        runStorageMutationTransaction {
-            prepareThenPublish(
-                prepare = {
-                    writes += "raw payload"
-                    writes += "profile payload"
-                    writes += "selected profile"
-                },
-                publish = { writes += "profile index" },
-            )
-        }
-
-        assertEquals(
-            listOf("raw payload", "profile payload", "selected profile", "profile index"),
-            writes,
+    private fun StorageMutationTransaction.write(
+        values: MutableMap<String, String>,
+        key: String,
+        value: String,
+        succeeds: Boolean = true,
+        restoreSucceeds: Boolean = true,
+        changeFailure: Throwable? = null,
+    ) {
+        val previous = values[key]
+        mutate(
+            change = {
+                values[key] = value
+                changeFailure?.let { throw it }
+                succeeds
+            },
+            restore = {
+                if (!restoreSucceeds) {
+                    false
+                } else {
+                    if (previous == null) values.remove(key) else values[key] = previous
+                    true
+                }
+            },
+            failureMessage = "$key write",
         )
-    }
-
-    @Test
-    fun `does not publish the index when preparation fails and rollback also fails`() {
-        val values = mutableMapOf(
-            "payload" to "old payload",
-            "index" to "old index",
-        )
-
-        val failure = expectFailure<ProfileStorageException> {
-            runStorageMutationTransaction {
-                prepareThenPublish(
-                    prepare = {
-                        mutate(
-                            change = {
-                                values["payload"] = "extra payload"
-                                true
-                            },
-                            restore = { false },
-                            failureMessage = "payload write",
-                        )
-                        mutate(
-                            change = { false },
-                            restore = { true },
-                            failureMessage = "metadata write",
-                        )
-                    },
-                    publish = {
-                        values["index"] = "new index"
-                    },
-                )
-            }
-        }
-
-        assertEquals("metadata write", failure.message)
-        assertEquals("extra payload", values["payload"])
-        assertEquals("old index", values["index"])
     }
 
     private inline fun <reified T : Throwable> expectFailure(block: () -> Unit): T {

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionIndexTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionIndexTest.kt
@@ -1,36 +1,31 @@
 package com.v2ray.ang.handler
 
 import android.util.Log
-import com.tencent.mmkv.MMKV
 import com.v2ray.ang.dto.entities.SubscriptionItem
 import com.v2ray.ang.util.JsonUtil
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 class SubscriptionIndexTest {
-    private val mainValues = mutableMapOf<String, String>()
-    private val subValues = mutableMapOf<String, String>()
+    private lateinit var stores: MmkvTestStore
+    private val mainValues get() = stores.main.values
+    private val subValues get() = stores.subscriptions.values
 
     @Before
     fun prepareStorage() {
-        for ((storage, values) in listOf(main to mainValues, subs to subValues)) {
-            reset(storage)
-            whenever(storage.decodeString(any())).thenAnswer { values[it.getArgument<String>(0)] }
-            whenever(storage.encode(any<String>(), any<String>())).thenAnswer {
-                values[it.getArgument(0)] = it.getArgument(1)
-                true
-            }
-            whenever(storage.allKeys()).thenAnswer { values.keys.toTypedArray() }
-        }
+        stores = MmkvTestStore()
+    }
+
+    @After
+    fun restoreStorage() {
+        stores.close()
     }
 
     @Test
@@ -40,7 +35,7 @@ class SubscriptionIndexTest {
 
         assertEquals(listOf("second", "first", "third"), MmkvManager.decodeSubsList())
         assertEquals(stored, mainValues["SUB_IDS"])
-        verify(main, never()).encode(any<String>(), any<String>())
+        verify(stores.main.mmkv, never()).encode(any<String>(), any<String>())
     }
 
     @Test
@@ -66,15 +61,15 @@ class SubscriptionIndexTest {
     }
 
     @Test
-    fun decodedIndexRemainsMutableAndCanBeSavedInANewOrder() {
+    fun decodedIndexRemainsMutableAndReordersOnlyExistingMembership() {
         mainValues["SUB_IDS"] = """["a","b","a"]"""
         val ids = MmkvManager.decodeSubsList()
         ids.remove("a")
         ids.add(0, "c")
-        MmkvManager.encodeSubsList(ids)
+        assertTrue(MmkvManager.reorderSubscriptions(ids))
 
-        assertEquals("""["c","b"]""", mainValues["SUB_IDS"])
-        assertEquals(listOf("c", "b"), MmkvManager.decodeSubsList())
+        assertEquals("""["b","a"]""", mainValues["SUB_IDS"])
+        assertEquals(listOf("b", "a"), MmkvManager.decodeSubsList())
     }
 
     @Test
@@ -94,21 +89,4 @@ class SubscriptionIndexTest {
         }
     }
 
-    companion object {
-        private val main: MMKV = mock()
-        private val subs: MMKV = mock()
-        private val settings: MMKV = mock()
-
-        @BeforeClass
-        @JvmStatic
-        fun initializeHandles() {
-            mockStatic(MMKV::class.java).use {
-                it.`when`<MMKV> { MMKV.mmkvWithID("MAIN", MMKV.MULTI_PROCESS_MODE) }.thenReturn(main)
-                it.`when`<MMKV> { MMKV.mmkvWithID("SUB", MMKV.MULTI_PROCESS_MODE) }.thenReturn(subs)
-                it.`when`<MMKV> { MMKV.mmkvWithID("SETTING", MMKV.MULTI_PROCESS_MODE) }.thenReturn(settings)
-                MmkvManager.decodeSubscriptions()
-                MmkvManager.decodeSettingsString("test-initialize")
-            }
-        }
-    }
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionUpdateGuardTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionUpdateGuardTest.kt
@@ -1,8 +1,8 @@
 package com.v2ray.ang.handler
 
 import com.v2ray.ang.dto.entities.SubscriptionItem
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SubscriptionUpdateGuardTest {
@@ -16,36 +16,67 @@ class SubscriptionUpdateGuardTest {
 
     @Test
     fun `rejects an update after its subscription was deleted`() {
-        assertFalse(canCommit(current = null))
+        assertNull(prepare(current = null))
     }
 
     @Test
     fun `rejects an update after the subscription was unpublished`() {
-        assertFalse(canCommit(isIndexed = false))
+        assertNull(prepare(isIndexed = false))
     }
 
     @Test
     fun `rejects an update after subscription settings changed`() {
         val edited = expected.copy(url = "https://example.com/edited")
 
-        assertFalse(canCommit(current = edited))
+        assertNull(prepare(current = edited))
     }
 
     @Test
-    fun `allows an update when only last updated metadata changed`() {
+    fun `settings edit preserves current timestamp instead of the replacement snapshot`() {
         val current = expected.copy(lastUpdated = 200)
+        val replacement = expected.copy(enabled = false, lastUpdated = 900)
 
-        assertTrue(canCommit(current = current))
+        assertEquals(replacement.copy(lastUpdated = 200), prepare(current = current, replacement = replacement))
+        assertEquals(200L, current.lastUpdated)
+        assertEquals(900L, replacement.lastUpdated)
     }
 
-    private fun canCommit(
+    @Test
+    fun `refresh uses its explicit timestamp rather than replacement metadata`() {
+        val replacement = expected.copy(remarks = "Refreshed", lastUpdated = 999)
+
+        assertEquals(replacement.copy(lastUpdated = 200), prepare(replacement = replacement, updatedAt = 200))
+    }
+
+    @Test
+    fun `fresh refresh accepts backward clock corrections`() {
+        assertEquals(expected.copy(lastUpdated = 50), prepare(updatedAt = 50))
+    }
+
+    @Test
+    fun `refresh rejects a changed timestamp even if its proposed timestamp is later`() {
+        assertNull(prepare(current = expected.copy(lastUpdated = 200), updatedAt = 300))
+    }
+
+    @Test
+    fun `refresh rejects missing unpublished or edited subscriptions`() {
+        assertNull(prepare(current = null, updatedAt = 200))
+        assertNull(prepare(isIndexed = false, updatedAt = 200))
+        assertNull(prepare(current = expected.copy(enabled = false), updatedAt = 200))
+    }
+
+    private fun prepare(
         isIndexed: Boolean = true,
         current: SubscriptionItem? = expected,
-    ): Boolean {
-        return SubscriptionUpdateGuard.canCommit(
+        replacement: SubscriptionItem = expected,
+        updatedAt: Long? = null,
+    ): SubscriptionItem? {
+        return SubscriptionUpdateGuard.prepare(
             isIndexed = isIndexed,
             current = current,
             expected = expected,
+            replacement = replacement,
+            updatedAt = updatedAt,
         )
     }
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionUpdateGuardTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionUpdateGuardTest.kt
@@ -16,49 +16,36 @@ class SubscriptionUpdateGuardTest {
 
     @Test
     fun `rejects an update after its subscription was deleted`() {
-        assertFalse(
-            SubscriptionUpdateGuard.canCommit(
-                isIndexed = true,
-                current = null,
-                expected = expected,
-            )
-        )
+        assertFalse(canCommit(current = null))
     }
 
     @Test
     fun `rejects an update after the subscription was unpublished`() {
-        assertFalse(
-            SubscriptionUpdateGuard.canCommit(
-                isIndexed = false,
-                current = expected,
-                expected = expected,
-            )
-        )
+        assertFalse(canCommit(isIndexed = false))
     }
 
     @Test
     fun `rejects an update after subscription settings changed`() {
         val edited = expected.copy(url = "https://example.com/edited")
 
-        assertFalse(
-            SubscriptionUpdateGuard.canCommit(
-                isIndexed = true,
-                current = edited,
-                expected = expected,
-            )
-        )
+        assertFalse(canCommit(current = edited))
     }
 
     @Test
     fun `allows an update when only last updated metadata changed`() {
         val current = expected.copy(lastUpdated = 200)
 
-        assertTrue(
-            SubscriptionUpdateGuard.canCommit(
-                isIndexed = true,
-                current = current,
-                expected = expected,
-            )
+        assertTrue(canCommit(current = current))
+    }
+
+    private fun canCommit(
+        isIndexed: Boolean = true,
+        current: SubscriptionItem? = expected,
+    ): Boolean {
+        return SubscriptionUpdateGuard.canCommit(
+            isIndexed = isIndexed,
+            current = current,
+            expected = expected,
         )
     }
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionUpdateGuardTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionUpdateGuardTest.kt
@@ -1,0 +1,64 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubscriptionUpdateGuardTest {
+
+    private val expected = SubscriptionItem(
+        remarks = "Example",
+        url = "https://example.com/subscription",
+        lastUpdated = 100,
+        userAgent = "v2rayNG",
+    )
+
+    @Test
+    fun `rejects an update after its subscription was deleted`() {
+        assertFalse(
+            SubscriptionUpdateGuard.canCommit(
+                isIndexed = true,
+                current = null,
+                expected = expected,
+            )
+        )
+    }
+
+    @Test
+    fun `rejects an update after the subscription was unpublished`() {
+        assertFalse(
+            SubscriptionUpdateGuard.canCommit(
+                isIndexed = false,
+                current = expected,
+                expected = expected,
+            )
+        )
+    }
+
+    @Test
+    fun `rejects an update after subscription settings changed`() {
+        val edited = expected.copy(url = "https://example.com/edited")
+
+        assertFalse(
+            SubscriptionUpdateGuard.canCommit(
+                isIndexed = true,
+                current = edited,
+                expected = expected,
+            )
+        )
+    }
+
+    @Test
+    fun `allows an update when only last updated metadata changed`() {
+        val current = expected.copy(lastUpdated = 200)
+
+        assertTrue(
+            SubscriptionUpdateGuard.canCommit(
+                isIndexed = true,
+                current = current,
+                expected = expected,
+            )
+        )
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainReorderTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainReorderTest.kt
@@ -1,0 +1,180 @@
+package com.v2ray.ang.ui.main
+
+import androidx.lifecycle.viewModelScope
+import com.v2ray.ang.R
+import com.v2ray.ang.dto.entities.ProfileItem
+import com.v2ray.ang.dto.entities.SubscriptionCache
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.enums.EConfigType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainReorderTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val source = mock<MainDataSource>()
+    private var persisted = listOf("a", "b", "c")
+    private lateinit var viewModel: MainViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        whenever(source.mainServiceEvent).thenReturn(emptyFlow())
+        whenever(source.getSelectedSubscriptionId()).thenReturn("s")
+        whenever(source.getSelectServer()).thenReturn("")
+        whenever(source.getSubscriptions()).thenReturn(listOf(SubscriptionCache("s", SubscriptionItem())))
+        whenever(source.getServerGuidList("s")).thenAnswer { persisted }
+        whenever(source.decodeServerConfig(any())).thenAnswer {
+            ProfileItem.create(EConfigType.VLESS).apply { remarks = it.getArgument(0) }
+        }
+        whenever(source.reorderServerList(any(), eq("s"))).thenAnswer {
+            persisted = it.getArgument(0)
+            true
+        }
+        viewModel = spy(MainViewModel(mock(), source, dispatcher, dispatcher))
+        doNothing().whenever(viewModel).toastError(any<Int>())
+    }
+
+    @After fun tearDown() {
+        viewModel.viewModelScope.cancel()
+        Dispatchers.resetMain()
+    }
+
+    @Test fun `later successful drag reconciles UI after earlier failed write`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        assertEquals(persisted, visible())
+        var attempts = 0
+        whenever(source.reorderServerList(any(), eq("s"))).thenAnswer {
+            if (++attempts == 1) false else { persisted = it.getArgument(0); true }
+        }
+        viewModel.moveServer("s", 0, 1)
+        viewModel.moveServer("s", 1, 2)
+        assertEquals(listOf("b", "c", "a"), visible())
+        advanceUntilIdle()
+        assertEquals(2, attempts)
+        assertEquals(listOf("b", "c", "a"), persisted)
+        assertEquals(persisted, visible())
+        verify(viewModel).toastError(R.string.toast_failure)
+    }
+
+    @Test fun `failed final drag restores persisted order`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        whenever(source.reorderServerList(any(), any())).thenReturn(false)
+        viewModel.moveServer("s", 0, 2)
+        advanceUntilIdle()
+        assertEquals(listOf("a", "b", "c"), visible())
+    }
+
+    @Test fun `successful drag reloads storage instead of replaying stale membership`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        whenever(source.reorderServerList(any(), any())).thenAnswer {
+            persisted = listOf("c", "a", "new")
+            true
+        }
+        viewModel.moveServer("s", 2, 0)
+        advanceUntilIdle()
+        assertEquals(persisted, visible())
+    }
+
+    @Test fun `invalid and empty moves do not persist`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        viewModel.moveServer("s", -1, 0)
+        viewModel.moveServer("s", 0, 3)
+        viewModel.moveServer("empty", 0, 1)
+        advanceUntilIdle()
+        assertEquals(persisted, visible())
+        verify(source, never()).reorderServerList(any(), any())
+    }
+
+    private fun visible() = viewModel.serversForGroup("s").value.map { it.guid }
+
+    @Test fun `repeated group selection uses its populated cache`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        repeat(2) {
+            viewModel.subscriptionIdChanged("s")
+            advanceUntilIdle()
+        }
+        assertEquals(persisted, visible())
+        verify(source, times(1)).getServerGuidList("s")
+        verify(source, times(1)).decodeServerConfig("a")
+    }
+
+    @Test fun `empty groups are cached and explicit refresh bypasses cache`() = runTest(dispatcher) {
+        persisted = emptyList()
+        advanceUntilIdle()
+        viewModel.subscriptionIdChanged("s")
+        advanceUntilIdle()
+        verify(source, times(1)).getServerGuidList("s")
+        persisted = listOf("new")
+        viewModel.reloadServerList()
+        advanceUntilIdle()
+        assertEquals(persisted, visible())
+        verify(source, times(2)).getServerGuidList("s")
+    }
+
+    @Test fun `reorder invalidates All cache and caches the saved group order`() = runTest(dispatcher) {
+        whenever(source.getSubscriptions()).thenReturn(listOf("s", "").map { SubscriptionCache(it, SubscriptionItem()) })
+        whenever(source.getServerGuidList("")).thenAnswer { persisted }
+        viewModel.setupGroupTab()
+        advanceUntilIdle()
+        assertEquals(persisted, viewModel.serversForGroup("").value.map { it.guid })
+        viewModel.moveServer("s", 0, 2)
+        advanceUntilIdle()
+        viewModel.subscriptionIdChanged("")
+        advanceUntilIdle()
+        assertEquals(listOf("b", "c", "a"), viewModel.serversForGroup("").value.map { it.guid })
+        viewModel.subscriptionIdChanged("s")
+        advanceUntilIdle()
+        assertEquals(persisted, visible())
+        verify(source, times(2)).getServerGuidList("s")
+        verify(source, times(2)).getServerGuidList("")
+    }
+
+    @Test fun `refresh invalidates shared profiles but retains unrelated group caches`() = runTest(dispatcher) {
+        whenever(source.getSubscriptions()).thenReturn(listOf("s", "shared", "unrelated").map {
+            SubscriptionCache(it, SubscriptionItem())
+        })
+        whenever(source.getServerGuidList("shared")).thenReturn(listOf("b"))
+        whenever(source.getServerGuidList("unrelated")).thenReturn(listOf("x"))
+        viewModel.setupGroupTab()
+        advanceUntilIdle()
+        whenever(source.decodeServerConfig("b")).thenReturn(ProfileItem.create(EConfigType.VLESS).apply { remarks = "edited" })
+        viewModel.reloadServerList()
+        advanceUntilIdle()
+        viewModel.subscriptionIdChanged("shared")
+        advanceUntilIdle()
+        assertEquals("edited", viewModel.serversForGroup("shared").value.single().profile.remarks)
+        viewModel.subscriptionIdChanged("unrelated")
+        advanceUntilIdle()
+        verify(source, times(2)).getServerGuidList("shared")
+        verify(source, times(1)).getServerGuidList("unrelated")
+    }
+
+    @Test fun `All refresh invalidates individual group caches`() = runTest(dispatcher) {
+        whenever(source.getSubscriptions()).thenReturn(listOf("s", "").map { SubscriptionCache(it, SubscriptionItem()) })
+        whenever(source.getServerGuidList("")).thenAnswer { persisted }
+        viewModel.setupGroupTab()
+        advanceUntilIdle()
+        viewModel.subscriptionIdChanged("")
+        advanceUntilIdle()
+        assertEquals("", viewModel.uiState.value.selectedGroupId)
+        persisted = listOf("new")
+        viewModel.reloadServerList()
+        advanceUntilIdle()
+        viewModel.subscriptionIdChanged("s")
+        advanceUntilIdle()
+        assertEquals(listOf("new"), visible())
+        verify(source, times(2)).getServerGuidList("s")
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainReorderTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainReorderTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -97,7 +98,12 @@ class MainReorderTest {
         verify(source, never()).reorderServerList(any(), any())
     }
 
-    private fun visible() = viewModel.serversForGroup("s").value.map { it.guid }
+    private fun visible(groupId: String = "s"): List<String> {
+        val state = viewModel.serverGroupState(groupId).value
+        assertEquals(state.servers.map { it.guid }, state.rows.map { it.guid })
+        assertEquals(state.servers.map { it.profile.remarks }, state.rows.map { it.remarks })
+        return state.servers.map { it.guid }
+    }
 
     @Test fun `repeated group selection uses its populated cache`() = runTest(dispatcher) {
         advanceUntilIdle()
@@ -108,6 +114,22 @@ class MainReorderTest {
         assertEquals(persisted, visible())
         verify(source, times(1)).getServerGuidList("s")
         verify(source, times(1)).decodeServerConfig("a")
+    }
+
+    @Test fun `collected tab servers follow reconciled row state`() = runTest(dispatcher) {
+        val tabServers = viewModel.serversForGroup("s")
+        val collection = backgroundScope.launch { tabServers.collect {} }
+        advanceUntilIdle()
+        assertEquals(visible(), tabServers.value.map { it.guid })
+        whenever(source.reorderServerList(any(), any())).thenAnswer {
+            persisted = listOf("c", "a", "new")
+            true
+        }
+        viewModel.moveServer("s", 2, 0)
+        advanceUntilIdle()
+        assertEquals(persisted, visible())
+        assertEquals(visible(), tabServers.value.map { it.guid })
+        collection.cancel()
     }
 
     @Test fun `empty groups are cached and explicit refresh bypasses cache`() = runTest(dispatcher) {
@@ -128,12 +150,12 @@ class MainReorderTest {
         whenever(source.getServerGuidList("")).thenAnswer { persisted }
         viewModel.setupGroupTab()
         advanceUntilIdle()
-        assertEquals(persisted, viewModel.serversForGroup("").value.map { it.guid })
+        assertEquals(persisted, visible(""))
         viewModel.moveServer("s", 0, 2)
         advanceUntilIdle()
         viewModel.subscriptionIdChanged("")
         advanceUntilIdle()
-        assertEquals(listOf("b", "c", "a"), viewModel.serversForGroup("").value.map { it.guid })
+        assertEquals(listOf("b", "c", "a"), visible(""))
         viewModel.subscriptionIdChanged("s")
         advanceUntilIdle()
         assertEquals(persisted, visible())
@@ -154,7 +176,8 @@ class MainReorderTest {
         advanceUntilIdle()
         viewModel.subscriptionIdChanged("shared")
         advanceUntilIdle()
-        assertEquals("edited", viewModel.serversForGroup("shared").value.single().profile.remarks)
+        assertEquals(listOf("b"), visible("shared"))
+        assertEquals("edited", viewModel.serverGroupState("shared").value.rows.single().remarks)
         viewModel.subscriptionIdChanged("unrelated")
         advanceUntilIdle()
         verify(source, times(2)).getServerGuidList("shared")

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/subscription/SubscriptionsPersistenceTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/subscription/SubscriptionsPersistenceTest.kt
@@ -1,0 +1,104 @@
+package com.v2ray.ang.ui.subscription
+
+import androidx.lifecycle.viewModelScope
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.handler.MmkvTestStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SubscriptionsPersistenceTest {
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var stores: MmkvTestStore
+    private lateinit var viewModel: SubscriptionsViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        stores = MmkvTestStore()
+        listOf("a", "b", "c").forEach {
+            MmkvManager.encodeSubscription(it, SubscriptionItem(remarks = it, lastUpdated = 100))
+        }
+        viewModel = spy(SubscriptionsViewModel(mock(), dispatcher))
+        doNothing().whenever(viewModel).toastError(any<Int>())
+    }
+
+    @After fun tearDown() {
+        viewModel.viewModelScope.cancel()
+        stores.close()
+        Dispatchers.resetMain()
+    }
+
+    @Test fun `queued drag recovers from failed write and keeps new subscriptions`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        viewModel.move(0, 1)
+        viewModel.move(1, 2)
+        MmkvManager.encodeSubscription("new", SubscriptionItem())
+        var writes = 0
+        stores.main.failWrite = { it == "SUB_IDS" && ++writes == 1 }
+        advanceUntilIdle()
+        assertEquals(listOf("b", "c", "a", "new"), visible())
+        assertEquals(MmkvManager.decodeSubsList(), visible())
+    }
+
+    @Test fun `failed drag restores persisted state and invalid moves do nothing`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        viewModel.move(-1, 0)
+        viewModel.move(0, 99)
+        assertEquals(listOf("a", "b", "c"), visible())
+        stores.main.failWrite = { true }
+        viewModel.move(0, 2)
+        advanceUntilIdle()
+        assertEquals(listOf("a", "b", "c"), visible())
+    }
+
+    @Test fun `toggle reloads merged timestamp from storage`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        val old = viewModel.subsFlow.value.first().subscription
+        MmkvManager.updateSubscription("a", old, old, updatedAt = 200)
+        viewModel.update("a", old.copy(enabled = false))
+        advanceUntilIdle()
+        val displayed = viewModel.subsFlow.value.first().subscription
+        assertFalse(displayed.enabled)
+        assertEquals(200L, displayed.lastUpdated)
+        viewModel.reload()
+        advanceUntilIdle()
+        assertEquals(displayed, viewModel.subsFlow.value.first().subscription)
+    }
+
+    @Test fun `stale settings edit reloads current settings without overwriting them`() = runTest(dispatcher) {
+        advanceUntilIdle()
+        val old = viewModel.subsFlow.value.first().subscription
+        val changed = old.copy(remarks = "updated elsewhere")
+        MmkvManager.updateSubscription("a", old, changed)
+        viewModel.update("a", old.copy(enabled = false))
+        advanceUntilIdle()
+        assertEquals(changed, viewModel.subsFlow.value.first().subscription)
+    }
+
+    @Test fun `empty subscriptions load and ignore move and update`() = runTest(dispatcher) {
+        stores.main.values["SUB_IDS"] = "[]"
+        advanceUntilIdle()
+        viewModel.move(0, 1)
+        viewModel.update("missing", SubscriptionItem())
+        advanceUntilIdle()
+        assertTrue(viewModel.subsFlow.value.isEmpty())
+    }
+
+    private fun visible() = viewModel.subsFlow.value.map { it.guid }
+
+    @Test fun `default Android factory can construct the ViewModel`() {
+        assertNotNull(SubscriptionsViewModel::class.java.getConstructor(android.app.Application::class.java))
+    }
+}

--- a/V2rayNG/gradle/libs.versions.toml
+++ b/V2rayNG/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 core = { module = "com.google.zxing:core", version.ref = "core" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 work-multiprocess = { module = "androidx.work:work-multiprocess", version.ref = "workRuntimeKtx" }


### PR DESCRIPTION
## Summary

Make checked profile/subscription writes rollback-safe, reject stale updates, and preserve current membership during reorders. Share storage policy across callers without changing the persisted schema or native dependencies.

### Context: #6084 was only partially fixed

Related to #6084, not a claim to close it. Earlier changes improved integrity recovery (#6085), removed delete-before-save replacement (#6093), and added orphan cleanup (#6094). Multi-store operations could still publish inconsistent payloads, indexes, or selection after a failed write; deletion could leave secret-bearing raw configurations behind.

This PR addresses application-level failure windows. It neither establishes the original random `SUB_IDS`/`SUB` loss mechanism nor provides crash-durable transactions across MMKV files. Rollback is attempted after a reported failure; persistent write failure can also prevent restoration.

## Guarantees and structure

- **Checked mutations:** under the `MAIN` multi-process lock, snapshot affected strings and register restoration before mutation. On failure, restore in reverse order and attach rollback failures to the original exception. Prepare profile payloads, subscription metadata, and selection before publishing the authoritative profile index.
- **Deletion:** unpublish IDs before cleaning full-profile, raw-config, and affinity payloads. Interrupted cleanup may leave orphans; an explicitly empty subscription index remains authoritative and does not republish them.
- **Subscription updates:** one pure function validates the expected settings and prepares the value to persist; the manager owns locking and storage access. Settings edits preserve the current `lastUpdated`. Refreshes also require the initiating timestamp to remain unchanged, but may commit an earlier time after a clock correction. Deleted or unpublished subscriptions are rejected.
- **Reorders and migrations:** reorder only current members, retaining additions missing from stale snapshots. Discover legacy subscriptions only when `SUB_IDS` is absent. Merge legacy profile indexes with existing membership; unreadable records and failed required writes leave migrations pending for retry.
- **Callers and caches:** failed saves retain the editor and show existing localized feedback. Serialize drag writes and reconcile visible state after the final queued result. Share cache locking/loading, reuse cached empty groups, and invalidate related group/All caches on refresh.

The standalone transaction helper owns rollback mechanics, not MMKV locking or publication order. No runtime dependency, Android API, or serialized field changes; `kotlinx-coroutines-test` is test-only. Local agent customizations and temporary QA hooks/artifacts are excluded.

## Suggested reading order

1. `StorageMutationTransaction.kt` and its test: checked mutation and rollback mechanics.
2. `SubscriptionUpdateGuard.kt` and its test: eligibility and timestamp ownership.
3. `MmkvManager.kt` and `MmkvPersistenceTest.kt`: locked publication, deletion, and integration regressions.
4. `SettingsManager.kt` / `AngConfigManager.kt`, then repository, ViewModel, and editor changes: migration retries and failure propagation.

## Current validation — `3c0641218`

- Focused subscription-policy, transaction, and manager persistence tests passed.
- `:app:testPlaystoreDebugUnitTest`: 114 tests, no failures/errors/skips.
- `:app:compilePlaystoreDebugKotlin`, `:app:assemblePlaystoreDebug`, and `git diff --check`: passed.
- Regression coverage includes rollback, stale reorders/refreshes, metadata ownership, backward clock changes, authoritative empty indexes, migration retries, queued UI reconciliation, and group caches.
- The MMKV JVM fixture replaces JNI, while executing production transaction/serialization code; it does not prove native durability.

**Not run:** fresh emulator/fault-injection testing for this policy/helper extraction; full keyboard/D-pad/TalkBack coverage; power-loss, mid-operation process termination, or real MMKV/CRC corruption testing.

<details>
<summary>Earlier validation and upstream synchronization</summary>

`744965e0f` merged upstream `2020807c2` (2.3.7), retaining prepared row models alongside cache locking and final-write reconciliation. Its 110 JVM tests, Kotlin compilation, and debug assembly passed.

That merged APK passed Pixel 6a / Android 13 checks for empty/populated/All tabs, profile reorder persistence across restart, and restored order consistency, without an app ANR/crash in captured logs. The previous APK and user state were restored and the emulator stopped. An earlier `40e075d56` cold-boot run had one unexplained Compose-initialization ANR; subsequent launches and the merged run did not repeat it.

Earlier real-MMKV instrumentation exercised payload/index/selection rollback, deletion cleanup and rollback, and delayed refresh after subscription deletion. Temporary fault-injection sources/hooks were removed before publication. These are historical results, not a fresh native-failure run of the current commit.

</details>
