### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         out-file-path: V2rayNG/app/libs/
 
     - name: Setup Java
-      uses: actions/setup-java@v5.7.0
+      uses: actions/setup-java@v6
       with:
         distribution: 'temurin'
         java-version: '21'


### PR DESCRIPTION
Upgrade the active build workflow from `actions/setup-java@v5.7.0` to `actions/setup-java@v6`.

Tests were not run (workflow-only change).