### PR TITLE
Service: wait for core shutdown before restart

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -30,8 +30,12 @@ import com.v2ray.ang.service.DialerWebviewService
 import com.v2ray.ang.service.NetworkMonitor
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
@@ -40,6 +44,9 @@ import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
 
 object CoreServiceManager {
+
+    private const val RESTART_STOP_TIMEOUT_MS = 5_000
+    private const val RESTART_STOP_POLL_INTERVAL_MS = 50
 
     private val coreController: CoreController = CoreNativeManager.newCoreController(CoreCallback())
     private val mMsgReceive = ReceiveMessageHandler()
@@ -50,6 +57,11 @@ object CoreServiceManager {
 
     @Volatile
     private var isReloading = false
+
+    // The owner survives destruction of the old service instance; the lock makes Stop and the
+    // replacement start mutually ordered.
+    private val restartLock = Any()
+    private var restartJob: Job? = null
 
     /** Tun descriptor the core was started with, null in the proxy only and root run modes. */
     private var currentVpnInterface: ParcelFileDescriptor? = null
@@ -352,6 +364,20 @@ object CoreServiceManager {
         return serviceControl?.get()?.getService()
     }
 
+    private fun cancelPendingRestart() {
+        val owner = synchronized(restartLock) {
+            restartJob.also { restartJob = null }
+        }
+        owner?.cancel()
+    }
+
+    private suspend fun waitForCoreToStop(): Boolean = waitForCoreToStop(
+        timeoutMillis = RESTART_STOP_TIMEOUT_MS,
+        pollIntervalMillis = RESTART_STOP_POLL_INTERVAL_MS,
+        isRunning = ::isRunning,
+        wait = ::delay,
+    )
+
     /**
      * Core callback handler implementation for handling V2Ray core events.
      * Handles startup, shutdown, socket protection, and status emission.
@@ -456,6 +482,7 @@ object CoreServiceManager {
 
                 AppConfig.MSG_STATE_STOP -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Stop service")
+                    cancelPendingRestart()
                     serviceControl.stopService()
                 }
 
@@ -466,13 +493,53 @@ object CoreServiceManager {
                     if (isOrderedBroadcast) resultCode = Activity.RESULT_OK
 
                     val pendingResult = goAsync()
-                    CoroutineScope(Dispatchers.Default).launch {
-                        try {
-                            serviceControl.stopService()
-                            delay(500L)
-                            LauncherManager.startService(serviceControl.getService())
-                        } finally {
-                            pendingResult.finish()
+                    val owner = synchronized(restartLock) {
+                        if (hasActiveRestart(restartJob)) null
+                        else SupervisorJob().also { restartJob = it }
+                    }
+                    if (owner == null) {
+                        LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart already in progress")
+                        pendingResult.finish()
+                    } else {
+                        CoroutineScope(
+                            owner + Dispatchers.Default + CoroutineName("CoreServiceRestart")
+                        ).launch {
+                            try {
+                                val service = serviceControl.getService()
+                                serviceControl.stopService()
+                                if (!waitForCoreToStop()) {
+                                    LogUtil.e(
+                                        AppConfig.TAG,
+                                        "StartCore-Manager: Restart timed out waiting for core to stop, " +
+                                            "mode=${service::class.java.simpleName}, " +
+                                            "profile=${MmkvManager.getSelectServer().orEmpty()}",
+                                    )
+                                } else {
+                                    synchronized(restartLock) {
+                                        if (canStartReplacement(restartJob, owner)) {
+                                            LauncherManager.startService(service)
+                                        }
+                                    }
+                                }
+                            } catch (e: CancellationException) {
+                                LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart canceled")
+                                throw e
+                            } catch (e: Exception) {
+                                val service = serviceControl.getService()
+                                LogUtil.e(
+                                    AppConfig.TAG,
+                                    "StartCore-Manager: Restart failed, " +
+                                        "mode=${service::class.java.simpleName}, " +
+                                        "profile=${MmkvManager.getSelectServer().orEmpty()}",
+                                    e,
+                                )
+                            } finally {
+                                synchronized(restartLock) {
+                                    if (restartJob === owner) restartJob = null
+                                }
+                                owner.cancel()
+                                pendingResult.finish()
+                            }
                         }
                     }
                 }
@@ -495,4 +562,27 @@ object CoreServiceManager {
             }
         }
     }
+}
+
+internal fun hasActiveRestart(job: Job?): Boolean = job?.isActive == true
+
+internal fun canStartReplacement(currentJob: Job?, candidateJob: Job): Boolean =
+    currentJob === candidateJob && candidateJob.isActive
+
+internal suspend fun waitForCoreToStop(
+    timeoutMillis: Int,
+    pollIntervalMillis: Int,
+    isRunning: () -> Boolean,
+    wait: suspend (Int) -> Unit,
+): Boolean {
+    require(timeoutMillis >= 0)
+    require(pollIntervalMillis > 0)
+
+    var waitedMillis = 0
+    while (isRunning() && waitedMillis < timeoutMillis) {
+        val nextWait = minOf(pollIntervalMillis, timeoutMillis - waitedMillis)
+        wait(nextWait)
+        waitedMillis += nextWait
+    }
+    return !isRunning()
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/CoreServiceRestartTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/CoreServiceRestartTest.kt
@@ -1,0 +1,82 @@
+package com.v2ray.ang.core
+
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CoreServiceRestartTest {
+
+    @Test
+    fun activeRestartIsDetectedUntilCancellation() {
+        val restartJob = SupervisorJob()
+
+        assertTrue(hasActiveRestart(restartJob))
+        restartJob.cancel()
+        assertFalse(hasActiveRestart(restartJob))
+    }
+
+    @Test
+    fun onlyCurrentActiveRestartCanStartReplacement() {
+        val currentJob = SupervisorJob()
+        val staleJob = SupervisorJob()
+
+        assertFalse(canStartReplacement(currentJob, staleJob))
+        assertTrue(canStartReplacement(currentJob, currentJob))
+
+        currentJob.cancel()
+        assertFalse(canStartReplacement(currentJob, currentJob))
+        staleJob.cancel()
+    }
+
+    @Test
+    fun waitsUntilCoreReportsStopped() = runBlocking {
+        var running = true
+        val waits = mutableListOf<Int>()
+
+        val stopped = waitForCoreToStop(
+            timeoutMillis = 500,
+            pollIntervalMillis = 50,
+            isRunning = { running },
+            wait = {
+                waits += it
+                if (waits.size == 3) running = false
+            },
+        )
+
+        assertTrue(stopped)
+        assertEquals(listOf(50, 50, 50), waits)
+    }
+
+    @Test
+    fun timeoutUsesOnlyTheRemainingInterval() = runBlocking {
+        val waits = mutableListOf<Int>()
+
+        val stopped = waitForCoreToStop(
+            timeoutMillis = 120,
+            pollIntervalMillis = 50,
+            isRunning = { true },
+            wait = { waits += it },
+        )
+
+        assertFalse(stopped)
+        assertEquals(listOf(50, 50, 20), waits)
+    }
+
+    @Test
+    fun alreadyStoppedCoreDoesNotWait() = runBlocking {
+        var waited = false
+
+        val stopped = waitForCoreToStop(
+            timeoutMillis = 500,
+            pollIntervalMillis = 50,
+            isRunning = { false },
+            wait = { waited = true },
+        )
+
+        assertTrue(stopped)
+        assertFalse(waited)
+    }
+}


### PR DESCRIPTION
## Summary

- replace the fixed restart delay with bounded polling of the daemon's actual core state
- keep one service-owned restart job and coalesce duplicate Restart commands while it is active
- clear and cancel pending restart work before Stop, and serialize the replacement start against Stop

## Maintainer feedback

The custom lifecycle/token class and all ViewModel, broadcast, resource, and other UI changes have been removed from this PR. Optional terminal UI feedback is isolated in draft #6152.

## Validation

- focused `CoreServiceRestartTest`: 5/5 passed
- full `:app:testPlaystoreDebugUnitTest`: 62/62 passed
- `:app:compilePlaystoreDebugKotlin` and x86_64 `:app:assemblePlaystoreDebug`
- API 37 / 16 KB emulator, VPN and proxy-only: successful service replacement and terminal connected state
- duplicate proxy-only Restart commands produced one replacement service
- VPN and proxy-only Restart-to-Stop race: no service record reappeared during ten polls over ten seconds
- crash buffer remained empty
- root-mode runtime not run: the stock emulator has no `su`