### PR TITLE
Do not remove policy levels when traffic statistics is disabled

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -113,7 +113,13 @@ object CoreConfigManager {
             }
         } else {
             json.remove("stats")
-            json.remove("policy")
+            // Keep user-defined policy levels, only strip the stats-related system block
+            json.get("policy")?.takeIf { it.isJsonObject }?.asJsonObject?.let { policy ->
+                policy.remove("system")
+                if (policy.entrySet().isEmpty()) {
+                    json.remove("policy")
+                }
+            }
         }
 
         if (!needTun()) {
@@ -709,7 +715,7 @@ object CoreConfigManager {
     private fun applySpeedDisabled(v2rayConfig: V2rayConfig) {
         if (MmkvManager.decodeSettingsBool(AppConfig.PREF_SPEED_ENABLED) != true) {
             v2rayConfig.stats = null
-            v2rayConfig.policy = null
+            v2rayConfig.policy?.system = null
         }
     }
 


### PR DESCRIPTION
Disabling traffic statistics removed the whole policy section from the generated config, including the levels block (uplinkOnly, downlinkOnly, connIdle, handshake) from the template or from a user's custom config. Only the stats-related policy.system block should be stripped; keep policy.levels intact in both the unified and the custom config paths.