### PR TITLE
Add happyEyeballs to the freedom outbound

### DIFF
--- a/V2rayNG/app/src/main/assets/v2ray_config.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config.json
@@ -76,7 +76,11 @@
     "protocol": "freedom",
     "streamSettings": {
       "sockopt": {
-        "domainStrategy": "UseIP"
+        "domainStrategy": "UseIP",
+        "happyEyeballs": {
+          "tryDelayMs": 250,
+          "interleave": 2
+        }
       }
     },
     "tag": "direct"

--- a/V2rayNG/app/src/main/assets/v2ray_config_with_tun.json
+++ b/V2rayNG/app/src/main/assets/v2ray_config_with_tun.json
@@ -93,7 +93,11 @@
     "protocol": "freedom",
     "streamSettings": {
       "sockopt": {
-        "domainStrategy": "UseIP"
+        "domainStrategy": "UseIP",
+        "happyEyeballs": {
+          "tryDelayMs": 250,
+          "interleave": 2
+        }
       }
     },
     "tag": "direct"


### PR DESCRIPTION
 `"domainStrategy": "UseIP"` may choose IPv6 for IPv4-only systems and this causes the connection to fail.
 although 5-times-Xray-core-retry makes this problem less noticeable (of course, in addition to causing a lot of delay, IPv6 can be selected every 5 times!)
 
 But the correct approach is to use happyEyeballs.
 
 
