### PR TITLE
UI: report terminal service restart transitions

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -62,6 +62,7 @@ object CoreServiceManager {
     // replacement start mutually ordered.
     private val restartLock = Any()
     private var restartJob: Job? = null
+    private val restartFeedback = ServiceRestartFeedback()
 
     /** Tun descriptor the core was started with, null in the proxy only and root run modes. */
     private var currentVpnInterface: ParcelFileDescriptor? = null
@@ -112,7 +113,7 @@ object CoreServiceManager {
         } catch (e: Exception) {
             val message = e.message?.takeUnless { it.isBlank() } ?: e.javaClass.simpleName
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: $message", e)
-            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+            reportStartFailure(service, message)
             NotificationManager.cancelNotification()
             return false
         }
@@ -184,7 +185,8 @@ object CoreServiceManager {
         }
 
         if (!isReload) {
-            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_SUCCESS, "")
+            val restarted = synchronized(restartLock) { restartFeedback.complete() }
+            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_SUCCESS, restarted)
         }
         NotificationManager.startSpeedNotification()
         LogUtil.i(AppConfig.TAG, "StartCore-Manager: Core started successfully")
@@ -219,7 +221,9 @@ object CoreServiceManager {
             browserDialer = null
         }
 
-        MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_STOP_SUCCESS, "")
+        if (!synchronized(restartLock) { restartFeedback.isRestarting }) {
+            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_STOP_SUCCESS, "")
+        }
         NotificationManager.cancelNotification()
 
         try {
@@ -366,9 +370,25 @@ object CoreServiceManager {
 
     private fun cancelPendingRestart() {
         val owner = synchronized(restartLock) {
-            restartJob.also { restartJob = null }
+            restartJob.also {
+                restartJob = null
+                restartFeedback.cancel()
+            }
         }
         owner?.cancel()
+    }
+
+    /** Clears restart feedback state and reports a terminal service-start failure to the UI. */
+    internal fun reportStartFailure(service: Service, message: String) {
+        synchronized(restartLock) { restartFeedback.cancel() }
+        MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+    }
+
+    private fun reportRestartFailure(service: Service, message: String) {
+        val wasRestarting = synchronized(restartLock) { restartFeedback.complete() }
+        if (wasRestarting) {
+            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+        }
     }
 
     private suspend fun waitForCoreToStop(): Boolean = waitForCoreToStop(
@@ -495,12 +515,20 @@ object CoreServiceManager {
                     val pendingResult = goAsync()
                     val owner = synchronized(restartLock) {
                         if (hasActiveRestart(restartJob)) null
-                        else SupervisorJob().also { restartJob = it }
+                        else SupervisorJob().also {
+                            restartJob = it
+                            restartFeedback.begin()
+                        }
                     }
                     if (owner == null) {
                         LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart already in progress")
                         pendingResult.finish()
                     } else {
+                        MessageHelper.sendMsg2UI(
+                            serviceControl.getService(),
+                            AppConfig.MSG_STATE_RESTART,
+                            "",
+                        )
                         CoroutineScope(
                             owner + Dispatchers.Default + CoroutineName("CoreServiceRestart")
                         ).launch {
@@ -508,16 +536,24 @@ object CoreServiceManager {
                                 val service = serviceControl.getService()
                                 serviceControl.stopService()
                                 if (!waitForCoreToStop()) {
+                                    val message = "Timed out waiting for core to stop"
                                     LogUtil.e(
                                         AppConfig.TAG,
                                         "StartCore-Manager: Restart timed out waiting for core to stop, " +
                                             "mode=${service::class.java.simpleName}, " +
                                             "profile=${MmkvManager.getSelectServer().orEmpty()}",
                                     )
+                                    reportRestartFailure(service, message)
                                 } else {
                                     synchronized(restartLock) {
                                         if (canStartReplacement(restartJob, owner)) {
-                                            LauncherManager.startService(service)
+                                            val startRequested =
+                                                LauncherManager.startServiceAfterRestart(
+                                                    service
+                                                )
+                                            if (!startRequested) {
+                                                reportRestartFailure(service, "")
+                                            }
                                         }
                                     }
                                 }
@@ -526,6 +562,8 @@ object CoreServiceManager {
                                 throw e
                             } catch (e: Exception) {
                                 val service = serviceControl.getService()
+                                val message = e.message?.takeUnless { it.isBlank() }
+                                    ?: e.javaClass.simpleName
                                 LogUtil.e(
                                     AppConfig.TAG,
                                     "StartCore-Manager: Restart failed, " +
@@ -533,6 +571,7 @@ object CoreServiceManager {
                                         "profile=${MmkvManager.getSelectServer().orEmpty()}",
                                     e,
                                 )
+                                reportRestartFailure(service, message)
                             } finally {
                                 synchronized(restartLock) {
                                     if (restartJob === owner) restartJob = null

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -30,8 +30,12 @@ import com.v2ray.ang.service.DialerWebviewService
 import com.v2ray.ang.service.NetworkMonitor
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
@@ -40,6 +44,9 @@ import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
 
 object CoreServiceManager {
+
+    private const val RESTART_STOP_TIMEOUT_MS = 5_000
+    private const val RESTART_STOP_POLL_INTERVAL_MS = 50
 
     private val coreController: CoreController = CoreNativeManager.newCoreController(CoreCallback())
     private val mMsgReceive = ReceiveMessageHandler()
@@ -50,6 +57,11 @@ object CoreServiceManager {
 
     @Volatile
     private var isReloading = false
+
+    // The owner survives destruction of the old service instance; the lock makes Stop and the
+    // replacement start mutually ordered.
+    private val restartLock = Any()
+    private var restartJob: Job? = null
 
     /** Tun descriptor the core was started with, null in the proxy only and root run modes. */
     private var currentVpnInterface: ParcelFileDescriptor? = null
@@ -352,6 +364,20 @@ object CoreServiceManager {
         return serviceControl?.get()?.getService()
     }
 
+    private fun cancelPendingRestart() {
+        val owner = synchronized(restartLock) {
+            restartJob.also { restartJob = null }
+        }
+        owner?.cancel()
+    }
+
+    private suspend fun waitForCoreToStop(): Boolean = waitForCoreToStop(
+        timeoutMillis = RESTART_STOP_TIMEOUT_MS,
+        pollIntervalMillis = RESTART_STOP_POLL_INTERVAL_MS,
+        isRunning = ::isRunning,
+        wait = ::delay,
+    )
+
     /**
      * Core callback handler implementation for handling V2Ray core events.
      * Handles startup, shutdown, socket protection, and status emission.
@@ -456,6 +482,7 @@ object CoreServiceManager {
 
                 AppConfig.MSG_STATE_STOP -> {
                     LogUtil.i(AppConfig.TAG, "StartCore-Manager: Stop service")
+                    cancelPendingRestart()
                     serviceControl.stopService()
                 }
 
@@ -466,13 +493,53 @@ object CoreServiceManager {
                     if (isOrderedBroadcast) resultCode = Activity.RESULT_OK
 
                     val pendingResult = goAsync()
-                    CoroutineScope(Dispatchers.Default).launch {
-                        try {
-                            serviceControl.stopService()
-                            delay(500L)
-                            LauncherManager.startService(serviceControl.getService())
-                        } finally {
-                            pendingResult.finish()
+                    val owner = synchronized(restartLock) {
+                        if (hasActiveRestart(restartJob)) null
+                        else SupervisorJob().also { restartJob = it }
+                    }
+                    if (owner == null) {
+                        LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart already in progress")
+                        pendingResult.finish()
+                    } else {
+                        CoroutineScope(
+                            owner + Dispatchers.Default + CoroutineName("CoreServiceRestart")
+                        ).launch {
+                            try {
+                                val service = serviceControl.getService()
+                                serviceControl.stopService()
+                                if (!waitForCoreToStop()) {
+                                    LogUtil.e(
+                                        AppConfig.TAG,
+                                        "StartCore-Manager: Restart timed out waiting for core to stop, " +
+                                            "mode=${service::class.java.simpleName}, " +
+                                            "profile=${MmkvManager.getSelectServer().orEmpty()}",
+                                    )
+                                } else {
+                                    synchronized(restartLock) {
+                                        if (canStartReplacement(restartJob, owner)) {
+                                            LauncherManager.startService(service)
+                                        }
+                                    }
+                                }
+                            } catch (e: CancellationException) {
+                                LogUtil.i(AppConfig.TAG, "StartCore-Manager: Restart canceled")
+                                throw e
+                            } catch (e: Exception) {
+                                val service = serviceControl.getService()
+                                LogUtil.e(
+                                    AppConfig.TAG,
+                                    "StartCore-Manager: Restart failed, " +
+                                        "mode=${service::class.java.simpleName}, " +
+                                        "profile=${MmkvManager.getSelectServer().orEmpty()}",
+                                    e,
+                                )
+                            } finally {
+                                synchronized(restartLock) {
+                                    if (restartJob === owner) restartJob = null
+                                }
+                                owner.cancel()
+                                pendingResult.finish()
+                            }
                         }
                     }
                 }
@@ -495,4 +562,27 @@ object CoreServiceManager {
             }
         }
     }
+}
+
+internal fun hasActiveRestart(job: Job?): Boolean = job?.isActive == true
+
+internal fun canStartReplacement(currentJob: Job?, candidateJob: Job): Boolean =
+    currentJob === candidateJob && candidateJob.isActive
+
+internal suspend fun waitForCoreToStop(
+    timeoutMillis: Int,
+    pollIntervalMillis: Int,
+    isRunning: () -> Boolean,
+    wait: suspend (Int) -> Unit,
+): Boolean {
+    require(timeoutMillis >= 0)
+    require(pollIntervalMillis > 0)
+
+    var waitedMillis = 0
+    while (isRunning() && waitedMillis < timeoutMillis) {
+        val nextWait = minOf(pollIntervalMillis, timeoutMillis - waitedMillis)
+        wait(nextWait)
+        waitedMillis += nextWait
+    }
+    return !isRunning()
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/LauncherManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/LauncherManager.kt
@@ -21,22 +21,22 @@ import com.v2ray.ang.util.Utils
 
 object LauncherManager {
 
-    fun startServiceFromToggle(context: Context): Boolean {
-        if (MmkvManager.getSelectServer().isNullOrEmpty()) {
-            context.toast(R.string.app_tile_first_use)
-            return false
-        }
-        try {
-            startContextService(context)
-        } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "LauncherManager: ${e.message}", e)
-            context.toast(e.message ?: e.javaClass.simpleName)
-            return false
-        }
-        return true
-    }
+    fun startServiceFromToggle(context: Context): Boolean =
+        requestServiceStart(context, guid = null, showLifecycleFeedback = true)
 
     fun startService(context: Context, guid: String? = null) {
+        requestServiceStart(context, guid, showLifecycleFeedback = true)
+    }
+
+    /** Starts the replacement service after a daemon-managed restart. */
+    internal fun startServiceAfterRestart(context: Context): Boolean =
+        requestServiceStart(context, guid = null, showLifecycleFeedback = false)
+
+    private fun requestServiceStart(
+        context: Context,
+        guid: String?,
+        showLifecycleFeedback: Boolean,
+    ): Boolean {
         LogUtil.i(AppConfig.TAG, "LauncherManager: startService from ${context::class.java.simpleName}")
 
         if (guid != null) {
@@ -44,10 +44,14 @@ object LauncherManager {
         }
 
         try {
-            startContextService(context)
+            startContextService(context, showLifecycleFeedback)
+            return true
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "LauncherManager: ${e.message}", e)
-            context.toast(e.message ?: e.javaClass.simpleName)
+            if (showLifecycleFeedback) {
+                context.toast(e.message ?: e.javaClass.simpleName)
+            }
+            return false
         }
     }
 
@@ -61,19 +65,29 @@ object LauncherManager {
         MessageHelper.sendMsg2Service(context, AppConfig.MSG_STATE_RESTART, "")
     }
 
+    /** Restarts the active daemon and reports whether one accepted the request. */
+    internal fun restartService(context: Context, onResult: (handled: Boolean) -> Unit) {
+        MessageHelper.sendMsg2ServiceForResult(
+            context,
+            AppConfig.MSG_STATE_RESTART,
+            "",
+            onResult,
+        )
+    }
+
     /** Restarts the active daemon, or delegates to the caller's permission-aware start flow. */
     fun restartServiceOrStart(context: Context, startIfStopped: () -> Unit) {
-        MessageHelper.sendMsg2ServiceForResult(context, AppConfig.MSG_STATE_RESTART, "") { handled ->
+        restartService(context) { handled ->
             if (!handled) startIfStopped()
         }
     }
 
     @Throws(Exception::class)
-    private fun startContextService(context: Context) {
+    private fun startContextService(context: Context, showLifecycleFeedback: Boolean) {
         // Note: isRunning check is removed here to avoid loading Native libraries in the UI process.
         // The check is performed in CoreServiceManager when the service starts in the daemon process.
 
-        val guid = MmkvManager.getSelectServer()
+        val guid = MmkvManager.getSelectServer()?.takeIf { it.isNotEmpty() }
             ?: run {
                 LogUtil.e(AppConfig.TAG, "LauncherManager: No server selected")
                 error(context.getString(R.string.app_tile_first_use))
@@ -100,10 +114,12 @@ object LauncherManager {
             Utils.setClipboard(context, context.getString(R.string.toast_allow_insecure_deprecated))
         }
 
-        if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING)) {
-            context.toast(R.string.toast_warning_pref_proxysharing_short)
-        } else {
-            context.toast(R.string.toast_services_start)
+        if (showLifecycleFeedback) {
+            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_PROXY_SHARING)) {
+                context.toast(R.string.toast_warning_pref_proxysharing_short)
+            } else {
+                context.toast(R.string.toast_services_start)
+            }
         }
 
         val isRootMode = SettingsManager.isRootMode()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/ServiceRestartFeedback.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/ServiceRestartFeedback.kt
@@ -1,0 +1,19 @@
+package com.v2ray.ang.core
+
+/** Tracks restart feedback after the restart job hands off to the replacement service. */
+internal class ServiceRestartFeedback {
+    private var restarting = false
+
+    val isRestarting: Boolean
+        get() = restarting
+
+    fun begin() {
+        restarting = true
+    }
+
+    fun complete(): Boolean = restarting.also { restarting = false }
+
+    fun cancel() {
+        restarting = false
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -87,8 +87,16 @@ class CoreVpnService : VpnService(), ServiceControl {
             return START_NOT_STICKY
         }
         LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received, systemVpnStart=$isSystemVpnStart")
-        if (!setupVpnService()) {
+        val setupFailure = try {
+            if (setupVpnService()) null else "VPN setup failed"
+        } catch (e: Exception) {
+            val message = e.message?.takeUnless { it.isBlank() } ?: e.javaClass.simpleName
+            LogUtil.e(AppConfig.TAG, "StartCore-VPN: $message", e)
+            message
+        }
+        if (setupFailure != null) {
             unlockStart()
+            CoreServiceManager.reportStartFailure(this, setupFailure)
             // Stop service if setup fails to avoid infinite restart loops (START_STICKY)
             stopSelf()
             return START_NOT_STICKY

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -270,10 +270,10 @@ class MainActivity : HelperBaseComponentActivity() {
     }
 
     private fun setSelectServer(guid: String) {
-        val selected = mainViewModel.uiState.value.selectedGuid
-        if (guid != selected) {
-            mainViewModel.updateSelectedGuid(guid)
-            LauncherManager.restartService(this)
+        if (mainViewModel.selectServerForActivation(guid)) {
+            LauncherManager.restartService(this) { handled ->
+                mainViewModel.onServerRestartRequestResult(guid, handled)
+            }
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -53,7 +53,10 @@ class MainRepository(
             val event = when (safeIntent.getIntExtra("key", 0)) {
                 AppConfig.MSG_STATE_RUNNING -> MainServiceEvent.StateRunning
                 AppConfig.MSG_STATE_NOT_RUNNING -> MainServiceEvent.StateNotRunning
-                AppConfig.MSG_STATE_START_SUCCESS -> MainServiceEvent.StateStartSuccess
+                AppConfig.MSG_STATE_RESTART -> MainServiceEvent.StateRestarting
+                AppConfig.MSG_STATE_START_SUCCESS -> MainServiceEvent.StateStartSuccess(
+                    restarted = safeIntent.serializable<Boolean>("content") == true,
+                )
                 AppConfig.MSG_STATE_START_FAILURE -> MainServiceEvent.StateStartFailure
 
                 AppConfig.MSG_STATE_STOP_SUCCESS -> MainServiceEvent.StateStopSuccess

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRestartTracker.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRestartTracker.kt
@@ -1,0 +1,39 @@
+package com.v2ray.ang.ui.main
+
+/** Tracks only the UI state that must remain stable while the daemon replaces its service. */
+internal class MainRestartTracker {
+    private var pending: PendingRestart? = null
+
+    val isIdle: Boolean
+        get() = pending == null
+
+    val hasPendingServerChange: Boolean
+        get() = pending is PendingRestart.ServerChange
+
+    fun beginServerChange(currentGuid: String?, requestedGuid: String): Boolean {
+        if (requestedGuid == currentGuid || pending != null) return false
+        pending = PendingRestart.ServerChange(requestedGuid)
+        return true
+    }
+
+    fun onRestarting() {
+        if (pending == null) pending = PendingRestart.Background
+    }
+
+    fun complete(): String? {
+        val requestedGuid = (pending as? PendingRestart.ServerChange)?.guid
+        pending = null
+        return requestedGuid
+    }
+
+    fun completeUnhandledServerChange(guid: String, handled: Boolean): Boolean {
+        if (handled || pending != PendingRestart.ServerChange(guid)) return false
+        pending = null
+        return true
+    }
+
+    private sealed interface PendingRestart {
+        data object Background : PendingRestart
+        data class ServerChange(val guid: String) : PendingRestart
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
@@ -5,7 +5,8 @@ import com.v2ray.ang.dto.ConnectionTestResult
 sealed class MainServiceEvent {
     data object StateRunning : MainServiceEvent()
     data object StateNotRunning : MainServiceEvent()
-    data object StateStartSuccess : MainServiceEvent()
+    data object StateRestarting : MainServiceEvent()
+    data class StateStartSuccess(val restarted: Boolean) : MainServiceEvent()
     data object StateStartFailure : MainServiceEvent()
     data object StateStopSuccess : MainServiceEvent()
     data class MeasureDelayResult(val result: ConnectionTestResult) : MainServiceEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -81,6 +81,8 @@ class MainViewModel(
     @Volatile
     private var testingGroupId: String? = null
 
+    private val restartTracker = MainRestartTracker()
+
     private val initialPageReady = CompletableDeferred<Unit>()
 
     // ---------- Service events ----------
@@ -99,19 +101,52 @@ class MainViewModel(
 
     private fun handleServiceEvent(event: MainServiceEvent) {
         when (event) {
-            MainServiceEvent.StateRunning -> updateRunningState(true, clearTestingText = false)
-            MainServiceEvent.StateNotRunning -> updateRunningState(false, clearTestingText = false)
-            MainServiceEvent.StateStartSuccess -> {
-                toastSuccess(R.string.toast_services_success)
-                updateRunningState(true)
+            MainServiceEvent.StateRunning -> {
+                if (restartTracker.isIdle) {
+                    updateRunningState(true, clearTestingText = false)
+                }
+            }
+            MainServiceEvent.StateNotRunning -> {
+                if (restartTracker.isIdle) {
+                    updateRunningState(false, clearTestingText = false)
+                }
+            }
+            MainServiceEvent.StateRestarting -> {
+                restartTracker.onRestarting()
+            }
+            is MainServiceEvent.StateStartSuccess -> {
+                val activatedGuid = restartTracker.complete()
+                toastSuccess(
+                    if (event.restarted) R.string.toast_services_restart_success
+                    else R.string.toast_services_success
+                )
+                _uiState.update {
+                    it.copy(
+                        selectedGuid = activatedGuid ?: it.selectedGuid,
+                        isRunning = true,
+                        status = MainStatus.Connected,
+                    )
+                }
             }
 
             MainServiceEvent.StateStartFailure -> {
+                val requestedGuid = restartTracker.complete()
                 toastError(R.string.toast_services_failure)
-                updateRunningState(false)
+                _uiState.update {
+                    it.copy(
+                        selectedGuid = requestedGuid ?: it.selectedGuid,
+                        isRunning = false,
+                        status = MainStatus.Disconnected,
+                    )
+                }
             }
 
-            MainServiceEvent.StateStopSuccess -> updateRunningState(false)
+            MainServiceEvent.StateStopSuccess -> {
+                if (restartTracker.isIdle) {
+                    toastSuccess(R.string.toast_services_stop)
+                    updateRunningState(false)
+                }
+            }
             is MainServiceEvent.MeasureDelayResult -> {
                 _uiState.update { it.copy(status = MainStatus.ConnectionTest(event.result)) }
             }
@@ -202,7 +237,6 @@ class MainViewModel(
             MainAction.UpdateSubscriptions -> importConfigViaSub()
             MainAction.ExportAll -> exportAllAsync()
             is MainAction.SelectGroup -> subscriptionIdChanged(action.groupId)
-            is MainAction.SelectServer -> updateSelectedGuid(action.guid)
             is MainAction.RemoveServer -> removeServerAndRefresh(action.guid)
             is MainAction.Search -> filterConfig(action.query)
             is MainAction.ImportBatchConfig -> importBatchConfig(action.configText)
@@ -224,6 +258,7 @@ class MainViewModel(
             is MainAction.ImportManually,
             MainAction.RestartService,
             MainAction.LocateSelectedServer,
+            is MainAction.SelectServer,
             is MainAction.EditServer,
             is MainAction.ShareClipboard,
             is MainAction.ShareFullContent -> {
@@ -678,13 +713,28 @@ class MainViewModel(
         }
     }
 
-    fun updateSelectedGuid(guid: String) {
+    /** Persists a new selection and waits for the daemon to accept or decline its restart. */
+    internal fun selectServerForActivation(guid: String): Boolean {
+        if (!restartTracker.beginServerChange(uiState.value.selectedGuid, guid)) return false
         dataSource.setSelectServer(guid)
-        _uiState.update { it.copy(selectedGuid = guid) }
+        return true
+    }
+
+    internal fun onServerRestartRequestResult(guid: String, handled: Boolean) {
+        if (!restartTracker.completeUnhandledServerChange(guid, handled)) return
+        _uiState.update {
+            it.copy(
+                selectedGuid = guid,
+                isRunning = false,
+                status = MainStatus.Disconnected,
+            )
+        }
     }
 
     fun refreshSelectedGuid() {
-        _uiState.update { it.copy(selectedGuid = dataSource.getSelectServer()) }
+        if (!restartTracker.hasPendingServerChange) {
+            _uiState.update { it.copy(selectedGuid = dataSource.getSelectServer()) }
+        }
     }
 
     fun removeServerAndRefresh(guid: String) {

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">تعذر الحصول على إذن الإشعارات</string>
     <string name="notification_action_more">انقر للمزيد</string>
     <string name="toast_services_start">بدء الخدمات</string>
-    <string name="toast_services_stop">إيقاف الخدمات</string>
+    <string name="toast_services_stop">تم إيقاف الخدمة</string>
     <string name="toast_services_success">نجاح بدء الخدمات</string>
+    <string name="toast_services_restart_success">تمت إعادة تشغيل الخدمات بنجاح</string>
     <string name="toast_services_failure">فشل بدء الخدمات</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">বিজ্ঞপ্তির অনুমতি পাওয়া যায়নি</string>
     <string name="notification_action_more">আরও দেখতে ক্লিক করুন</string>
     <string name="toast_services_start">সার্ভিস শুরু করুন</string>
-    <string name="toast_services_stop">সার্ভিস বন্ধ করুন</string>
+    <string name="toast_services_stop">সার্ভিস বন্ধ হয়েছে</string>
     <string name="toast_services_success">সার্ভিস সফলভাবে শুরু হয়েছে</string>
+    <string name="toast_services_restart_success">সার্ভিস সফলভাবে পুনরায় চালু হয়েছে</string>
     <string name="toast_services_failure">সার্ভিস শুরু হতে ব্যর্থ হয়েছে</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">گرؽڌن موجوز وارسۊوی مومکن نؽڌ</string>
     <string name="notification_action_more">سی دووسمندیا قلوه کیلیک کوݩ</string>
     <string name="toast_services_start">ره وستن سرویس</string>
-    <string name="toast_services_stop">واڌاشتن سرویس</string>
+    <string name="toast_services_stop">واڌاشتن سرویس وا مووفقیت ٱنجوم وابی</string>
     <string name="toast_services_success">ره وستن سرویس وا مووفقیت ٱنجوم وابی</string>
+    <string name="toast_services_restart_success">ره وندن دووارته سرویس وا مووفقیت ٱنجوم وابی</string>
     <string name="toast_services_failure">ره وستن سرویس وا مووفقیت ٱنجوم نوابی</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">امکان دریافت مجوز ارسال اعلان وجود ندارد</string>
     <string name="notification_action_more">برای اطلاعات بیشتر کلیک کنید</string>
     <string name="toast_services_start">شروع خدمات</string>
-    <string name="toast_services_stop">توقف سرویس</string>
+    <string name="toast_services_stop">سرویس متوقف شد</string>
     <string name="toast_services_success">سرویس با موفقیت شروع شد</string>
+    <string name="toast_services_restart_success">سرویس با موفقیت دوباره راه‌اندازی شد</string>
     <string name="toast_services_failure">شروع سرویس با شکست مواجه شد</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">Разрешение на отображение уведомлений не получено</string>
     <string name="notification_action_more">Ещё…</string>
     <string name="toast_services_start">Запуск служб</string>
-    <string name="toast_services_stop">Остановка служб</string>
+    <string name="toast_services_stop">Служба остановлена</string>
     <string name="toast_services_success">Службы успешно запущены</string>
+    <string name="toast_services_restart_success">Службы успешно перезапущены</string>
     <string name="toast_services_failure">Сбой при запуске служб</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -21,6 +21,7 @@
     <string name="toast_services_start">Đang khởi động v2rayNG…</string>
     <string name="toast_services_stop">Đã dừng v2rayNG!</string>
     <string name="toast_services_success">Đã khởi động v2rayNG!</string>
+    <string name="toast_services_restart_success">Đã khởi động lại v2rayNG!</string>
     <string name="toast_services_failure">Không thể khởi động v2rayNG, kiểm tra lại cấu hình!</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">无法取得通知权限</string>
     <string name="notification_action_more">点击了解更多</string>
     <string name="toast_services_start">启动服务</string>
-    <string name="toast_services_stop">关闭服务</string>
+    <string name="toast_services_stop">服务已停止</string>
     <string name="toast_services_success">启动服务成功</string>
+    <string name="toast_services_restart_success">重启服务成功</string>
     <string name="toast_services_failure">启动服务失败</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">無法取得此通知權限</string>
     <string name="notification_action_more">瞭解更多</string>
     <string name="toast_services_start">啟動服務</string>
-    <string name="toast_services_stop">停止服務</string>
+    <string name="toast_services_stop">服務已停止</string>
     <string name="toast_services_success">啟動服務成功</string>
+    <string name="toast_services_restart_success">重新啟動服務成功</string>
     <string name="toast_services_failure">啟動服務失敗</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -19,8 +19,9 @@
     <string name="toast_permission_denied_notification">Notification permission denied</string>
     <string name="notification_action_more">Tap for more</string>
     <string name="toast_services_start">Starting service</string>
-    <string name="toast_services_stop">Stopping service</string>
+    <string name="toast_services_stop">Service stopped</string>
     <string name="toast_services_success">Service started successfully</string>
+    <string name="toast_services_restart_success">Service restarted successfully</string>
     <string name="toast_services_failure">Failed to start service</string>
 
     <!--ServerActivity-->

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/CoreServiceRestartTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/CoreServiceRestartTest.kt
@@ -1,0 +1,82 @@
+package com.v2ray.ang.core
+
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CoreServiceRestartTest {
+
+    @Test
+    fun activeRestartIsDetectedUntilCancellation() {
+        val restartJob = SupervisorJob()
+
+        assertTrue(hasActiveRestart(restartJob))
+        restartJob.cancel()
+        assertFalse(hasActiveRestart(restartJob))
+    }
+
+    @Test
+    fun onlyCurrentActiveRestartCanStartReplacement() {
+        val currentJob = SupervisorJob()
+        val staleJob = SupervisorJob()
+
+        assertFalse(canStartReplacement(currentJob, staleJob))
+        assertTrue(canStartReplacement(currentJob, currentJob))
+
+        currentJob.cancel()
+        assertFalse(canStartReplacement(currentJob, currentJob))
+        staleJob.cancel()
+    }
+
+    @Test
+    fun waitsUntilCoreReportsStopped() = runBlocking {
+        var running = true
+        val waits = mutableListOf<Int>()
+
+        val stopped = waitForCoreToStop(
+            timeoutMillis = 500,
+            pollIntervalMillis = 50,
+            isRunning = { running },
+            wait = {
+                waits += it
+                if (waits.size == 3) running = false
+            },
+        )
+
+        assertTrue(stopped)
+        assertEquals(listOf(50, 50, 50), waits)
+    }
+
+    @Test
+    fun timeoutUsesOnlyTheRemainingInterval() = runBlocking {
+        val waits = mutableListOf<Int>()
+
+        val stopped = waitForCoreToStop(
+            timeoutMillis = 120,
+            pollIntervalMillis = 50,
+            isRunning = { true },
+            wait = { waits += it },
+        )
+
+        assertFalse(stopped)
+        assertEquals(listOf(50, 50, 20), waits)
+    }
+
+    @Test
+    fun alreadyStoppedCoreDoesNotWait() = runBlocking {
+        var waited = false
+
+        val stopped = waitForCoreToStop(
+            timeoutMillis = 500,
+            pollIntervalMillis = 50,
+            isRunning = { false },
+            wait = { waited = true },
+        )
+
+        assertTrue(stopped)
+        assertFalse(waited)
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/core/ServiceRestartFeedbackTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/core/ServiceRestartFeedbackTest.kt
@@ -1,0 +1,31 @@
+package com.v2ray.ang.core
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ServiceRestartFeedbackTest {
+
+    @Test
+    fun completionReportsRestartExactlyOnce() {
+        val feedback = ServiceRestartFeedback()
+
+        feedback.begin()
+
+        assertTrue(feedback.isRestarting)
+        assertTrue(feedback.complete())
+        assertFalse(feedback.isRestarting)
+        assertFalse(feedback.complete())
+    }
+
+    @Test
+    fun cancellationClearsRestartFeedback() {
+        val feedback = ServiceRestartFeedback()
+        feedback.begin()
+
+        feedback.cancel()
+
+        assertFalse(feedback.isRestarting)
+        assertFalse(feedback.complete())
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainRestartTrackerTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainRestartTrackerTest.kt
@@ -1,0 +1,62 @@
+package com.v2ray.ang.ui.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MainRestartTrackerTest {
+
+    @Test
+    fun serverChangeRejectsCurrentAndConcurrentSelections() {
+        val tracker = MainRestartTracker()
+
+        assertFalse(tracker.beginServerChange("current", "current"))
+        assertTrue(tracker.beginServerChange("current", "next"))
+        assertTrue(tracker.hasPendingServerChange)
+        assertFalse(tracker.beginServerChange("current", "other"))
+    }
+
+    @Test
+    fun backgroundRestartBlocksTransientServiceStateUntilCompletion() {
+        val tracker = MainRestartTracker()
+
+        tracker.onRestarting()
+
+        assertFalse(tracker.isIdle)
+        assertFalse(tracker.hasPendingServerChange)
+        assertNull(tracker.complete())
+        assertTrue(tracker.isIdle)
+    }
+
+    @Test
+    fun completedServerRestartReturnsRequestedGuid() {
+        val tracker = MainRestartTracker()
+        tracker.beginServerChange("current", "next")
+
+        assertEquals("next", tracker.complete())
+        assertTrue(tracker.isIdle)
+    }
+
+    @Test
+    fun handledDaemonResultKeepsServerRestartPending() {
+        val tracker = MainRestartTracker()
+        tracker.beginServerChange("current", "next")
+
+        assertFalse(tracker.completeUnhandledServerChange("next", handled = true))
+        assertFalse(tracker.isIdle)
+        assertEquals("next", tracker.complete())
+    }
+
+    @Test
+    fun daemonAbsentCompletesMatchingServerRestart() {
+        val tracker = MainRestartTracker()
+        tracker.beginServerChange("current", "next")
+
+        assertFalse(tracker.completeUnhandledServerChange("stale", handled = false))
+        assertFalse(tracker.isIdle)
+        assertTrue(tracker.completeUnhandledServerChange("next", handled = false))
+        assertTrue(tracker.isIdle)
+    }
+}


### PR DESCRIPTION
## Dependency

Draft; depends on #6139 and is intentionally stacked on that branch. Until #6139 merges, GitHub's diff also shows its two service-restart files. Rebase this branch onto `master` before requesting review.

## Summary

- keep the main screen stable while the daemon replaces its service
- report distinct terminal restart success, stop, and failure states in every maintained locale
- wait for the daemon acknowledgement when a running server selection requests a restart
- report VPN setup failures through the same terminal service event path

## Validation

- focused `ServiceRestartFeedbackTest` and `MainRestartTrackerTest`: 7/7 passed
- full `:app:testPlaystoreDebugUnitTest`: 69/69 passed
- `:app:compilePlaystoreDebugKotlin` and x86_64 `:app:assemblePlaystoreDebug`
- API 37 / 16 KB emulator, VPN and proxy-only: successful restart feedback, stable connected state, terminal stop feedback, and Restart-to-Stop race with no service resurrection
- running VPN server selection: one replacement service, restart-success feedback, no transient not-connected state; original selection restored
- crash buffer remained empty
- root-mode runtime not run: the stock emulator has no `su`