### PR TITLE
Fix Logcat refresh button navigation inset

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -191,9 +192,10 @@ fun LogcatScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = {
-                viewModel.loadLogcat()
-            }) {
+            FloatingActionButton(
+                onClick = { viewModel.loadLogcat() },
+                modifier = Modifier.navigationBarsPadding()
+            ) {
                 Icon(
                     painterResource(R.drawable.ic_restore_24dp),
                     contentDescription = stringResource(R.string.acc_refresh)


### PR DESCRIPTION
## Summary

- Apply navigation-bar insets to the Logcat refresh floating action button.
- Keep the existing edge-to-edge log list behavior unchanged.

## Root cause

#6075 changed the Logcat scaffold to use zero content insets and added navigation-bar padding only to the log list. The floating action button therefore remained positioned inside the navigation-bar area.

## Validation

- `:app:testPlaystoreDebugUnitTest`
- `:app:compilePlaystoreDebugKotlin`
- `:app:assemblePlaystoreDebug`
- Pixel 5 emulator with three-button navigation: reproduced the clipped button before the fix; verified it is fully visible above Back/Home/Recents afterward.
- Activated Refresh using UI-tree-derived coordinates and verified that the log list populated; crash buffer remained empty.