### PR TITLE
Refresh group profile counts after subscription updates

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/AppConfig.kt
@@ -189,6 +189,7 @@ object AppConfig {
 
     const val MSG_SUB_UPDATE_START = 8
     const val MSG_SUB_UPDATE_CANCEL = 81
+    const val MSG_SUB_UPDATE_DATA_CHANGED = 82
 
     /** Notification channel IDs and names. */
     // Use a new ID because Android does not let an app raise an existing channel's importance.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/MessageHelper.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/MessageHelper.kt
@@ -71,6 +71,13 @@ object MessageHelper {
         sendMsg(ctx, AppConfig.BROADCAST_ACTION_ACTIVITY, what, content)
     }
 
+    fun sendSubscriptionDataChanged(ctx: Context, subscriptionIds: Collection<String>) {
+        val changedIds = ArrayList(subscriptionIds.filter { it.isNotBlank() }.distinct())
+        if (changedIds.isNotEmpty()) {
+            sendMsg2UI(ctx, AppConfig.MSG_SUB_UPDATE_DATA_CHANGED, changedIds)
+        }
+    }
+
     /**
      * Sends a message to the test service.
      *

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/SubscriptionUpdateService.kt
@@ -15,6 +15,7 @@ import com.v2ray.ang.extension.serializable
 import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.helper.NotificationHelper
 import com.v2ray.ang.util.LogUtil
 import kotlinx.coroutines.CompletableDeferred
@@ -94,14 +95,21 @@ class SubscriptionUpdateService : Service() {
 
         runningTasks.incrementAndGet()
         serviceScope.launch {
+            val changedSubscriptionIds = linkedSetOf<String>()
             updateSemaphore.withPermit {
                 try {
                     message.subIds.forEach { subId ->
-                        updateSingle(subId, message.forcedUpdate)
+                        updateSingle(subId, message.forcedUpdate) {
+                            changedSubscriptionIds += subId
+                        }
                     }
                 } catch (e: Exception) {
                     LogUtil.e(AppConfig.TAG, "SubscriptionUpdateService update failed", e)
                 } finally {
+                    MessageHelper.sendSubscriptionDataChanged(
+                        this@SubscriptionUpdateService,
+                        changedSubscriptionIds
+                    )
                     if (runningTasks.decrementAndGet() == 0 && activeWorkers.isEmpty()) {
                         NotificationHelper.stopForeground(this@SubscriptionUpdateService)
                         stopSelf()
@@ -111,7 +119,11 @@ class SubscriptionUpdateService : Service() {
         }
     }
 
-    private suspend fun updateSingle(subId: String, forcedUpdate: Boolean) {
+    private suspend fun updateSingle(
+        subId: String,
+        forcedUpdate: Boolean,
+        onDataChanged: () -> Unit
+    ) {
         val subItem = MmkvManager.decodeSubscription(subId) ?: return
         if (!subItem.enabled || subItem.url.isEmpty()) {
             return
@@ -126,37 +138,42 @@ class SubscriptionUpdateService : Service() {
             content = getString(R.string.subscription_update_updating, subItem.remarks)
         )
 
-        if (forcedUpdate || MmkvManager.decodeSettingsBool(AppConfig.PREF_UPDATE_SUBSCRIPTION, false)) {
-            AngConfigManager.updateConfigViaSub(sub)
-        }
-
-        if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_TEST_AFTER_UPDATE_SUBSCRIPTION, false)) {
-            testSubscriptionServers(sub)
-
-            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST, false)) {
-                LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: removing invalid servers for ${subItem.remarks}")
-                showNotification(
-                    context = this,
-                    titleResId = R.string.title_del_invalid_config,
-                    content = subItem.remarks
-                )
-                AngConfigManager.removeInvalidServer(subId)
+        var dataChanged = false
+        try {
+            if (forcedUpdate || MmkvManager.decodeSettingsBool(AppConfig.PREF_UPDATE_SUBSCRIPTION, false)) {
+                dataChanged = AngConfigManager.updateConfigViaSub(sub).configCount > 0
             }
-            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST, false)) {
-                LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: sorting servers for ${subItem.remarks}")
-                showNotification(
-                    context = this,
-                    titleResId = R.string.title_sort_by_test_results,
-                    content = subItem.remarks
-                )
-                AngConfigManager.sortByTestResultsForSub(subId)
-            }
-        }
 
-        LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: Finished ${subItem.remarks}")
+            if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_TEST_AFTER_UPDATE_SUBSCRIPTION, false)) {
+                dataChanged = testSubscriptionServers(sub) || dataChanged
+
+                if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_REMOVE_INVALID_AFTER_TEST, false)) {
+                    LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: removing invalid servers for ${subItem.remarks}")
+                    showNotification(
+                        context = this,
+                        titleResId = R.string.title_del_invalid_config,
+                        content = subItem.remarks
+                    )
+                    AngConfigManager.removeInvalidServer(subId)
+                }
+                if (MmkvManager.decodeSettingsBool(AppConfig.PREF_AUTO_SORT_AFTER_TEST, false)) {
+                    LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: sorting servers for ${subItem.remarks}")
+                    showNotification(
+                        context = this,
+                        titleResId = R.string.title_sort_by_test_results,
+                        content = subItem.remarks
+                    )
+                    AngConfigManager.sortByTestResultsForSub(subId)
+                }
+            }
+
+            LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: Finished ${subItem.remarks}")
+        } finally {
+            if (dataChanged) onDataChanged()
+        }
     }
 
-    private suspend fun testSubscriptionServers(sub: SubscriptionCache) {
+    private suspend fun testSubscriptionServers(sub: SubscriptionCache): Boolean {
         val subId = sub.guid
         LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: starting test phase for ${sub.subscription.remarks}")
         showNotification(
@@ -166,24 +183,25 @@ class SubscriptionUpdateService : Service() {
         )
 
         val guids = MmkvManager.decodeServerList(subId)
-        if (guids.isNotEmpty()) {
-            val deferred = CompletableDeferred<Unit>()
-            lateinit var worker: RealPingWorkerService
-            worker = RealPingWorkerService(
-                context = this,
-                guids = guids,
-                onEvent = { event ->
-                    handleWorkerEvent(event, sub.subscription.remarks) {
-                        activeWorkers.remove(worker)
-                        deferred.complete(Unit)
-                    }
+        if (guids.isEmpty()) return false
+
+        val deferred = CompletableDeferred<Unit>()
+        lateinit var worker: RealPingWorkerService
+        worker = RealPingWorkerService(
+            context = this,
+            guids = guids,
+            onEvent = { event ->
+                handleWorkerEvent(event, sub.subscription.remarks) {
+                    activeWorkers.remove(worker)
+                    deferred.complete(Unit)
                 }
-            )
-            activeWorkers.add(worker)
-            worker.start()
-            deferred.await()
-            LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: test phase finished for ${sub.subscription.remarks}")
-        }
+            }
+        )
+        activeWorkers.add(worker)
+        worker.start()
+        deferred.await()
+        LogUtil.i(AppConfig.TAG, "SubscriptionUpdateService: test phase finished for ${sub.subscription.remarks}")
+        return true
     }
 
     private fun handleWorkerEvent(event: RealPingEvent, remarks: String, onWorkerDone: () -> Unit) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -70,6 +70,13 @@ class MainRepository(
                     safeIntent.getStringExtra("content")
                 )
 
+                AppConfig.MSG_SUB_UPDATE_DATA_CHANGED -> safeIntent
+                    .serializable<ArrayList<String>>("content")
+                    ?.filter { it.isNotBlank() }
+                    ?.distinct()
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let(MainServiceEvent::SubscriptionDataChanged)
+
                 else -> null
             }
             event?.let { _mainServiceEvent.tryEmit(it) }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
@@ -12,4 +12,5 @@ sealed class MainServiceEvent {
     data object MeasureConfigSuccess : MainServiceEvent()
     data class MeasureConfigNotify(val progress: String) : MainServiceEvent()
     data class MeasureConfigFinish(val finishedCount: String?) : MainServiceEvent()
+    data class SubscriptionDataChanged(val subscriptionIds: List<String>) : MainServiceEvent()
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -42,7 +42,8 @@ import java.util.regex.PatternSyntaxException
 
 class MainViewModel(
     application: Application,
-    private val dataSource: MainDataSource
+    private val dataSource: MainDataSource,
+    private val serviceEventDispatcher: CoroutineDispatcher = Dispatchers.Main.immediate,
 ) : BaseViewModel(application) {
 
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
@@ -90,7 +91,7 @@ class MainViewModel(
     }
 
     private fun collectServiceEvents() {
-        viewModelScope.launch {
+        viewModelScope.launch(serviceEventDispatcher) {
             dataSource.mainServiceEvent.collect { event ->
                 handleServiceEvent(event)
             }
@@ -131,6 +132,16 @@ class MainViewModel(
             is MainServiceEvent.MeasureConfigFinish -> {
                 onTestsFinished()
             }
+
+            is MainServiceEvent.SubscriptionDataChanged -> {
+                refreshSubscriptionGroupData(event.subscriptionIds)
+            }
+        }
+    }
+
+    private fun refreshSubscriptionGroupData(subscriptionIds: Collection<String>) {
+        viewModelScope.launch(preloadDispatcher) {
+            populateSubscriptionGroupData(subscriptionIds)
         }
     }
 
@@ -470,8 +481,12 @@ class MainViewModel(
                             toast(dataSource.getString(R.string.title_update_subscription_result, result.configCount, result.successCount, result.failureCount, result.skipCount))
                     }
                     if (result.configCount > 0) {
-                        setupGroupTab(forceRefresh = true)
-                        refreshSelectedGuid()
+                        val changedSubscriptionIds = if (subId.isEmpty()) {
+                            uiState.value.groups.map { it.id }.filter { it.isNotEmpty() }
+                        } else {
+                            listOf(subId)
+                        }
+                        populateSubscriptionGroupData(changedSubscriptionIds)
                     }
                 } catch (cancelled: CancellationException) {
                     throw cancelled
@@ -663,6 +678,25 @@ class MainViewModel(
         }
     }
 
+    internal suspend fun populateSubscriptionGroupData(subscriptionIds: Collection<String>) {
+        initialPageReady.await()
+        val refreshOrder = subscriptionGroupRefreshOrder(
+            visibleGroupIds = uiState.value.groups.map { it.id },
+            selectedGroupId = uiState.value.selectedGroupId,
+            changedSubscriptionIds = subscriptionIds,
+        )
+        refreshOrder.forEach { groupId ->
+            try {
+                updateGroupUi(groupId, loadGroup(groupId, forceRefresh = true))
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Exception) {
+                LogUtil.e(AppConfig.TAG, "Failed to refresh subscription group: $groupId", error)
+            }
+        }
+        refreshSelectedGuid()
+    }
+
     fun filterConfig(keyword: String) {
         if (keyword == keywordFilter) return
         keywordFilter = keyword
@@ -841,5 +875,25 @@ class MainViewModel(
             }
             throw IllegalArgumentException("Unknown ViewModel class")
         }
+    }
+}
+
+internal fun subscriptionGroupRefreshOrder(
+    visibleGroupIds: List<String>,
+    selectedGroupId: String,
+    changedSubscriptionIds: Collection<String>,
+): List<String> {
+    val changedIds = changedSubscriptionIds.filterTo(LinkedHashSet()) { it.isNotEmpty() }
+    if (changedIds.isEmpty()) return emptyList()
+
+    val affectedIds = visibleGroupIds.filterTo(LinkedHashSet()) {
+        it.isNotEmpty() && it in changedIds
+    }
+    if (visibleGroupIds.any { it.isEmpty() }) affectedIds += ""
+    if (affectedIds.isEmpty()) return emptyList()
+
+    return buildList(affectedIds.size) {
+        if (selectedGroupId in affectedIds) add(selectedGroupId)
+        addAll(affectedIds.filter { it != selectedGroupId })
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -78,6 +78,10 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
     fun updateSubscriptionsOnly() {
         launchLoading {
             try {
+                val subscriptionIds = subscriptions.asSequence()
+                    .filter { it.subscription.enabled && it.subscription.url.isNotEmpty() }
+                    .map { it.guid }
+                    .toList()
                 val result = withContext(Dispatchers.IO) {
                     AngConfigManager.updateConfigViaSubAll()
                 }
@@ -93,6 +97,9 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
                         toast(getString(R.string.title_update_subscription_result, result.configCount, result.successCount, result.failureCount, result.skipCount))
                 }
                 reload()
+                if (result.configCount > 0) {
+                    MessageHelper.sendSubscriptionDataChanged(app, subscriptionIds)
+                }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (e: Exception) {
@@ -103,7 +110,6 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
     }
 
     fun updateSubscriptionsMore() {
-        SettingsChangeManager.makeSetupGroupTab()
         val subIds = MmkvManager.decodeSubscriptions()
             .filter { it.subscription.enabled && it.subscription.url.isNotEmpty() }
             .map { it.guid }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainSubscriptionRefreshTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/MainSubscriptionRefreshTest.kt
@@ -1,0 +1,132 @@
+package com.v2ray.ang.ui.main
+
+import android.app.Application
+import com.v2ray.ang.dto.entities.ProfileItem
+import com.v2ray.ang.dto.entities.SubscriptionCache
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.enums.EConfigType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class MainSubscriptionRefreshTest {
+
+    @Test
+    fun populateSubscriptionGroupData_refreshesChangedGroupsAndAggregateState() = runBlocking {
+        val fixture = Fixture()
+        fixture.loadInitialState()
+
+        assertEquals(2, fixture.viewModel.serverGroupState(ALL).value.servers.size)
+        assertEquals(1, fixture.viewModel.serverGroupState(GROUP_A).value.servers.size)
+        assertEquals(1, fixture.viewModel.serverGroupState(GROUP_B).value.servers.size)
+
+        fixture.addProfile(GROUP_A, "a-2")
+        fixture.viewModel.populateSubscriptionGroupData(listOf(GROUP_A))
+
+        assertEquals(3, fixture.viewModel.serverGroupState(ALL).value.servers.size)
+        assertEquals(2, fixture.viewModel.serverGroupState(GROUP_A).value.servers.size)
+        assertEquals(1, fixture.viewModel.serverGroupState(GROUP_B).value.servers.size)
+    }
+
+    @Test
+    fun subscriptionGroupRefreshOrder_prioritizesSelectedGroupAndDeduplicatesIds() {
+        assertEquals(
+            listOf(GROUP_B, GROUP_A, ALL),
+            subscriptionGroupRefreshOrder(
+                visibleGroupIds = listOf(ALL, GROUP_A, GROUP_B),
+                selectedGroupId = GROUP_B,
+                changedSubscriptionIds = listOf(GROUP_A, GROUP_B, GROUP_A),
+            )
+        )
+        assertEquals(
+            listOf(ALL),
+            subscriptionGroupRefreshOrder(
+                visibleGroupIds = listOf(ALL, GROUP_A, GROUP_B),
+                selectedGroupId = GROUP_A,
+                changedSubscriptionIds = listOf("not-visible"),
+            )
+        )
+        assertEquals(
+            emptyList<String>(),
+            subscriptionGroupRefreshOrder(
+                visibleGroupIds = listOf(ALL, GROUP_A, GROUP_B),
+                selectedGroupId = GROUP_A,
+                changedSubscriptionIds = emptyList(),
+            )
+        )
+    }
+
+    private class Fixture {
+        private val groupGuids = linkedMapOf(
+            GROUP_A to mutableListOf("a-1"),
+            GROUP_B to mutableListOf("b-1"),
+        )
+        private val profiles = linkedMapOf(
+            "a-1" to profile(GROUP_A, "a-1"),
+            "b-1" to profile(GROUP_B, "b-1"),
+        )
+        private val dataSource = mock<MainDataSource>()
+
+        val viewModel: MainViewModel
+
+        init {
+            whenever(dataSource.mainServiceEvent).thenReturn(emptyFlow())
+            whenever(dataSource.getSelectedSubscriptionId()).thenReturn(GROUP_A)
+            whenever(dataSource.getSelectServer()).thenReturn(null)
+            whenever(dataSource.getConfirmRemove()).thenReturn(false)
+            whenever(dataSource.getDoubleColumnDisplay()).thenReturn(false)
+            whenever(dataSource.getSubscriptions()).thenReturn(
+                listOf(
+                    SubscriptionCache(ALL, SubscriptionItem(remarks = "All")),
+                    SubscriptionCache(GROUP_A, SubscriptionItem(remarks = "Group A")),
+                    SubscriptionCache(GROUP_B, SubscriptionItem(remarks = "Group B")),
+                )
+            )
+            whenever(dataSource.getServerGuidList(any())).thenAnswer { invocation ->
+                val groupId = invocation.getArgument<String>(0)
+                if (groupId == ALL) profiles.keys.toList()
+                else groupGuids[groupId]?.toList().orEmpty()
+            }
+            whenever(dataSource.decodeServerConfig(any())).thenAnswer { invocation ->
+                profiles[invocation.getArgument<String>(0)]
+            }
+            whenever(dataSource.getSubscriptionItem(any())).thenAnswer { invocation ->
+                SubscriptionItem(remarks = invocation.getArgument<String>(0))
+            }
+
+            viewModel = MainViewModel(
+                application = mock<Application>(),
+                dataSource = dataSource,
+                serviceEventDispatcher = Dispatchers.Unconfined,
+            )
+        }
+
+        suspend fun loadInitialState() {
+            viewModel.setupGroupTab(forceRefresh = true).join()
+            viewModel.populateSubscriptionGroupData(listOf(GROUP_A, GROUP_B))
+        }
+
+        fun addProfile(groupId: String, guid: String) {
+            groupGuids.getValue(groupId) += guid
+            profiles[guid] = profile(groupId, guid)
+        }
+    }
+
+    companion object {
+        private const val ALL = ""
+        private const val GROUP_A = "group-a"
+        private const val GROUP_B = "group-b"
+
+        private fun profile(groupId: String, remarks: String) = ProfileItem(
+            configType = EConfigType.VMESS,
+            subscriptionId = groupId,
+            remarks = remarks,
+            description = "description",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- notify the main UI when synchronous or service-backed subscription updates finish
- repopulate affected subscription groups and the aggregate All group so pager counts update without selecting each tab
- add regression coverage for affected-group refresh ordering and cached count replacement

## Testing

- `:app:testPlaystoreDebugUnitTest --tests com.v2ray.ang.ui.main.MainSubscriptionRefreshTest`
- `:app:testPlaystoreDebugUnitTest :app:compilePlaystoreDebugKotlin` (59 tests, 0 failures)
- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86_64`
- Pixel 9 Pro API 37 x86_64 emulator: verified synchronous count update 1 -> 2 and service-backed auto-test update 2 -> 3 while another group remained selected, without tapping the updated group tab