### PR TITLE
TalkBack, 7 of 10: Name profile deletion targets

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -5,6 +5,11 @@ import androidx.compose.ui.res.stringResource
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 
+data class ServerDeleteTarget(
+    val guid: String,
+    val profileName: String,
+)
+
 @Composable
 fun MainDialogs(
     showDelAllConfirm: Boolean,
@@ -16,7 +21,7 @@ fun MainDialogs(
     showDelInvalidConfirm: Boolean,
     onDismissDelInvalid: () -> Unit,
     onConfirmDelInvalid: () -> Unit,
-    showRemoveConfirm: String?,
+    showRemoveConfirm: ServerDeleteTarget?,
     onDismissRemove: () -> Unit,
     onConfirmRemove: (String) -> Unit,
 ) {
@@ -41,11 +46,10 @@ fun MainDialogs(
             onDismiss = onDismissDelInvalid
         )
     }
-    if (showRemoveConfirm != null) {
-        val guid = showRemoveConfirm
+    showRemoveConfirm?.let { target ->
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
-            onConfirm = { onConfirmRemove(guid) },
+            message = stringResource(R.string.confirm_delete_profile_named, target.profileName),
+            onConfirm = { onConfirmRemove(target.guid) },
             onDismiss = onDismissRemove
         )
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.ui.main
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.ui.res.stringResource
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
@@ -8,7 +9,14 @@ import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 data class ServerDeleteTarget(
     val guid: String,
     val profileName: String,
-)
+) {
+    companion object {
+        val Saver = listSaver<ServerDeleteTarget?, String>(
+            save = { target -> target?.let { listOf(it.guid, it.profileName) }.orEmpty() },
+            restore = { ServerDeleteTarget(it[0], it[1]) },
+        )
+    }
+}
 
 @Composable
 fun MainDialogs(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainImportMenu.kt
@@ -58,6 +58,21 @@ internal fun serverMenuActions(
     (includeManagementActions || action.isShareAction) && (!isComplexProfile || action.supportsComplexProfiles)
 }
 
+internal fun ServerMenuAction.perform(
+    guid: String,
+    profile: ProfileItem,
+    onAction: (MainAction) -> Unit,
+    onRemove: (String, String) -> Unit,
+) {
+    when (this) {
+        ServerMenuAction.ShareQRCode -> onAction(MainAction.ShareQRCode(guid))
+        ServerMenuAction.ShareClipboard -> onAction(MainAction.ShareClipboard(guid))
+        ServerMenuAction.ShareFullContent -> onAction(MainAction.ShareFullContent(guid))
+        ServerMenuAction.Edit -> onAction(MainAction.EditServer(guid, profile))
+        ServerMenuAction.Delete -> onRemove(guid, profile.remarks)
+    }
+}
+
 @Composable
 fun ImportMenuContent(onAction: (MainAction) -> Unit) = AppDropdownMenuItems(
     items = ImportMenuAction.entries,
@@ -79,7 +94,7 @@ fun ShareMethodDialog(
     more: Boolean,
     onDismiss: () -> Unit,
     onAction: (MainAction) -> Unit,
-    onRemove: (String) -> Unit,
+    onRemove: (String, String) -> Unit,
 ) {
     val menuActions = serverMenuActions(
         isComplexProfile = profile.configType.isComplexType(),
@@ -90,13 +105,7 @@ fun ShareMethodDialog(
         optionText = { stringResource(it.labelRes) },
         onSelected = { action ->
             onDismiss()
-            when (action) {
-                ServerMenuAction.ShareQRCode -> onAction(MainAction.ShareQRCode(guid))
-                ServerMenuAction.ShareClipboard -> onAction(MainAction.ShareClipboard(guid))
-                ServerMenuAction.ShareFullContent -> onAction(MainAction.ShareFullContent(guid))
-                ServerMenuAction.Edit -> onAction(MainAction.EditServer(guid, profile))
-                ServerMenuAction.Delete -> onRemove(guid)
-            }
+            action.perform(guid, profile, onAction, onRemove)
         },
         onDismiss = onDismiss
     )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -60,7 +60,7 @@ fun MainScreen(
     var showRemoveConfirm by remember { mutableStateOf<String?>(null) }
 
     var shareTarget by remember { mutableStateOf<Triple<String, ProfileItem, Boolean>?>(null) }
-    val removeServer: (String) -> Unit = { guid ->
+    val removeServer: (String, String) -> Unit = { guid, _ ->
         if (confirmRemove) showRemoveConfirm = guid else onAction(MainAction.RemoveServer(guid))
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -57,11 +57,15 @@ fun MainScreen(
     var showDelAllConfirm by remember { mutableStateOf(false) }
     var showDelDuplicateConfirm by remember { mutableStateOf(false) }
     var showDelInvalidConfirm by remember { mutableStateOf(false) }
-    var showRemoveConfirm by remember { mutableStateOf<String?>(null) }
+    var showRemoveConfirm by remember { mutableStateOf<ServerDeleteTarget?>(null) }
 
     var shareTarget by remember { mutableStateOf<Triple<String, ProfileItem, Boolean>?>(null) }
-    val removeServer: (String, String) -> Unit = { guid, _ ->
-        if (confirmRemove) showRemoveConfirm = guid else onAction(MainAction.RemoveServer(guid))
+    val removeServer: (String, String) -> Unit = { guid, profileName ->
+        if (confirmRemove) {
+            showRemoveConfirm = ServerDeleteTarget(guid, profileName)
+        } else {
+            onAction(MainAction.RemoveServer(guid))
+        }
     }
 
     val pagerState = rememberPagerState(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -57,7 +58,9 @@ fun MainScreen(
     var showDelAllConfirm by remember { mutableStateOf(false) }
     var showDelDuplicateConfirm by remember { mutableStateOf(false) }
     var showDelInvalidConfirm by remember { mutableStateOf(false) }
-    var showRemoveConfirm by remember { mutableStateOf<ServerDeleteTarget?>(null) }
+    var showRemoveConfirm by rememberSaveable(stateSaver = ServerDeleteTarget.Saver) {
+        mutableStateOf<ServerDeleteTarget?>(null)
+    }
 
     var shareTarget by remember { mutableStateOf<Triple<String, ProfileItem, Boolean>?>(null) }
     val removeServer: (String, String) -> Unit = { guid, profileName ->

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServerPager.kt
@@ -75,7 +75,7 @@ fun GroupPagerPage(
     onEditServer: (String, ProfileItem) -> Unit,
     onShareServer: (String, ProfileItem) -> Unit,
     onMoreServer: (String, ProfileItem) -> Unit,
-    onRemoveServer: (String) -> Unit,
+    onRemoveServer: (String, String) -> Unit,
     contentPadding: PaddingValues
 ) {
     val groupStateFlow = remember(groupId) {
@@ -121,7 +121,7 @@ private class ServerRowActions(
     val edit: (String, ProfileItem) -> Unit,
     val share: (String, ProfileItem) -> Unit,
     val more: (String, ProfileItem) -> Unit,
-    val remove: (String) -> Unit,
+    val remove: (String, String) -> Unit,
 )
 
 @Composable
@@ -374,7 +374,7 @@ private fun ServerListItem(
                             Modifier.size(24.dp)
                         )
                     }
-                    IconButton(onClick = { actions.remove(row.guid) }, Modifier.size(36.dp)) {
+                    IconButton(onClick = { actions.remove(row.guid, row.remarks) }, Modifier.size(36.dp)) {
                         Icon(
                             painterResource(R.drawable.ic_delete_24dp),
                             stringResource(R.string.acc_delete),

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/BaseServerActivity.kt
@@ -490,7 +490,7 @@ abstract class BaseServerActivity : BaseComponentActivity() {
         }
         if (showDeleteDialog) {
             DeleteConfirmDialog(
-                message = stringResource(R.string.confirm_delete_profile),
+                message = stringResource(R.string.confirm_delete_profile_named, initialConfig.remarks),
                 onConfirm = {
                     showDeleteDialog = false
                     deleteServer(editGuid)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
@@ -518,7 +518,7 @@ fun ServerScreen(
     }
     if (showDeleteDialog) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
+            message = stringResource(R.string.confirm_delete_profile_named, remarks),
             onConfirm = { showDeleteDialog = false; onDelete() },
             onDismiss = { showDeleteDialog = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerActivity.kt
@@ -518,7 +518,7 @@ fun ServerScreen(
     }
     if (showDeleteDialog) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile_named, remarks),
+            message = stringResource(R.string.confirm_delete_profile),
             onConfirm = { showDeleteDialog = false; onDelete() },
             onDismiss = { showDeleteDialog = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -485,7 +485,7 @@ fun ServerCustomConfigScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
+            message = stringResource(R.string.confirm_delete_profile_named, remarks),
             onConfirm = {
                 showDeleteConfirm = false
                 onDelete()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerCustomConfigActivity.kt
@@ -208,7 +208,7 @@ fun ServerCustomConfigScreen(
 ) {
     var remarks by rememberSaveable { mutableStateOf(initialRemarks) }
     val textFieldState = rememberTextFieldState(initialText = initialContent)
-    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var showDeleteConfirm by rememberSaveable { mutableStateOf(false) }
     val showDelete = editGuid.isNotEmpty() && !isRunning
 
     val verticalScroll = rememberScrollState()
@@ -485,7 +485,7 @@ fun ServerCustomConfigScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile_named, remarks),
+            message = stringResource(R.string.confirm_delete_profile_named, initialRemarks),
             onConfirm = {
                 showDeleteConfirm = false
                 onDelete()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -305,7 +305,7 @@ fun ServerGroupScreen(
 
     if (showDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_policy_group),
+            message = stringResource(R.string.confirm_delete_policy_group_named, initialRemarks),
             onConfirm = onDelete,
             onDismiss = { showDeleteConfirm = false }
         )

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerGroupActivity.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -232,7 +231,7 @@ fun ServerGroupScreen(
     var subValue by rememberSaveable { mutableStateOf(subDisplay.getOrNull(initialSubIndex).orEmpty()) }
     var testOutbounds by rememberSaveable { mutableStateOf(initialTestOutbounds) }
     var fallbackTag by rememberSaveable { mutableStateOf(initialFallbackTag) }
-    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var showDeleteConfirm by rememberSaveable { mutableStateOf(false) }
     val showDelete = editGuid.isNotEmpty() && !isRunning
     val selectedType = typeEntries.indexOf(typeValue).coerceAtLeast(0).toString()
     val supportsObservatory = BalancerStrategyType.from(selectedType).supportsObservatory

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
@@ -336,14 +336,15 @@ fun ProxyChainScreen(
 
     if (showProfileDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile),
+            message = stringResource(R.string.confirm_delete_profile_named, remarks),
             onConfirm = { showProfileDeleteConfirm = false; onDelete() },
             onDismiss = { showProfileDeleteConfirm = false }
         )
     }
     memberToDeleteKey?.let { memberKey ->
+        val memberName = members.getOrNull(memberKeys.indexOf(memberKey)).orEmpty()
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_proxy_chain_member),
+            message = stringResource(R.string.confirm_delete_proxy_chain_member_named, memberName),
             onConfirm = {
                 val (remainingMembers, remainingKeys) = withoutProxyChainMember(members, memberKeys, memberKey)
                 members = remainingMembers

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/server/ServerProxyChainActivity.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -202,7 +201,7 @@ fun ProxyChainScreen(
     var remarks by rememberSaveable { mutableStateOf(initialRemarks) }
     var members by rememberSaveable { mutableStateOf(initialMembers) }
     var memberKeys by rememberSaveable { mutableStateOf(List(initialMembers.size) { UUID.randomUUID().toString() }) }
-    var showProfileDeleteConfirm by remember { mutableStateOf(false) }
+    var showProfileDeleteConfirm by rememberSaveable { mutableStateOf(false) }
     var memberToDeleteKey by rememberSaveable { mutableStateOf<String?>(null) }
     val showDelete = editGuid.isNotEmpty() && !isRunning
 
@@ -336,7 +335,7 @@ fun ProxyChainScreen(
 
     if (showProfileDeleteConfirm) {
         DeleteConfirmDialog(
-            message = stringResource(R.string.confirm_delete_profile_named, remarks),
+            message = stringResource(R.string.confirm_delete_profile_named, initialRemarks),
             onConfirm = { showProfileDeleteConfirm = false; onDelete() },
             onDismiss = { showProfileDeleteConfirm = false }
         )

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف المكررة المعروضة حاليًا؟</string>
     <string name="confirm_delete_invalid_profiles">يرجى اختبار ملفات التعريف أولًا. هل أنت متأكد من أنك تريد حذف جميع ملفات التعريف غير الصالحة المعروضة حاليًا؟</string>
     <string name="confirm_delete_profile">هل أنت متأكد من أنك تريد حذف ملف التعريف هذا؟</string>
+    <string name="confirm_delete_profile_named">هل أنت متأكد من أنك تريد حذف ملف التعريف هذا؟\n%1$s</string>
     <string name="confirm_delete_policy_group">هل أنت متأكد من أنك تريد حذف مجموعة السياسات هذه؟</string>
+    <string name="confirm_delete_policy_group_named">هل أنت متأكد من أنك تريد حذف مجموعة السياسات هذه؟\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">هل أنت متأكد من أنك تريد حذف هذا العضو من سلسلة الوكلاء؟</string>
+    <string name="confirm_delete_proxy_chain_member_named">هل أنت متأكد من أنك تريد حذف هذا العضو من سلسلة الوكلاء؟\n%1$s</string>
     <string name="confirm_delete_routing_rule">هل أنت متأكد من أنك تريد حذف قاعدة التوجيه هذه؟</string>
     <string name="confirm_delete_subscription_group">هل أنت متأكد من أنك تريد حذف مجموعة الاشتراك هذه؟</string>
     <string name="confirm_delete_asset_file">هل أنت متأكد من أنك تريد حذف ملف الأصول \"%1$s\"؟</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">আপনি কি বর্তমানে প্রদর্শিত সব সদৃশ প্রোফাইল মুছে ফেলতে চান?</string>
     <string name="confirm_delete_invalid_profiles">প্রথমে প্রোফাইলগুলো পরীক্ষা করুন। আপনি কি বর্তমানে প্রদর্শিত সব অবৈধ প্রোফাইল মুছে ফেলতে চান?</string>
     <string name="confirm_delete_profile">আপনি কি এই প্রোফাইলটি মুছে ফেলতে চান?</string>
+    <string name="confirm_delete_profile_named">আপনি কি এই প্রোফাইলটি মুছে ফেলতে চান?\n%1$s</string>
     <string name="confirm_delete_policy_group">আপনি কি এই পলিসি গ্রুপটি মুছে ফেলতে চান?</string>
+    <string name="confirm_delete_policy_group_named">আপনি কি এই পলিসি গ্রুপটি মুছে ফেলতে চান?\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">আপনি কি এই প্রক্সি চেইন সদস্যটিকে মুছে ফেলতে চান?</string>
+    <string name="confirm_delete_proxy_chain_member_named">আপনি কি এই প্রক্সি চেইন সদস্যটিকে মুছে ফেলতে চান?\n%1$s</string>
     <string name="confirm_delete_routing_rule">আপনি কি এই রাউটিং নিয়মটি মুছে ফেলতে চান?</string>
     <string name="confirm_delete_subscription_group">আপনি কি এই সাবস্ক্রিপশন গ্রুপটি মুছে ফেলতে চান?</string>
     <string name="confirm_delete_asset_file">আপনি কি \"%1$s\" অ্যাসেট ফাইলটি মুছে ফেলতে চান?</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">پوی کانفیگا تکراری ک هیم سکو نشووݩ داڌه ابۊن پاک ابۊن، هنی هم اخۊی پاکسووݩ کۊنی؟</string>
     <string name="confirm_delete_invalid_profiles">ٱول کانفیگا ن آزمایش کۊنین. پوی کانفیگا نا موئتبر ک هیم سکو نشووݩ داڌه ابۊن پاک ابۊن، هنی هم اخۊی پاکسووݩ کۊنی؟</string>
     <string name="confirm_delete_profile">ای کانفیگ پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
+    <string name="confirm_delete_profile_named">ای کانفیگ پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
     <string name="confirm_delete_policy_group">ای بونکۊ سیاست پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
+    <string name="confirm_delete_policy_group_named">ای بونکۊ سیاست پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">ای عوزو زنجیره پروکسی پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
+    <string name="confirm_delete_proxy_chain_member_named">ای عوزو زنجیره پروکسی پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟\n%1$s</string>
     <string name="confirm_delete_routing_rule">ای قانووݩ تور جوستن پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
     <string name="confirm_delete_subscription_group">ای بونکۊ اشتراک پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>
     <string name="confirm_delete_asset_file">فایل بونچک جغرافیایی «%1$s» پاک ابۊ، هنی هم اخۊی پاکس کۊنی؟</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">آیا مطمئن هستید که می‌خواهید همه پروفایل‌های تکراری نمایش‌داده‌شده را حذف کنید؟</string>
     <string name="confirm_delete_invalid_profiles">لطفاً ابتدا پروفایل‌ها را آزمایش کنید. آیا مطمئن هستید که می‌خواهید همه پروفایل‌های نامعتبر نمایش‌داده‌شده را حذف کنید؟</string>
     <string name="confirm_delete_profile">آیا مطمئن هستید که می‌خواهید این پروفایل را حذف کنید؟</string>
+    <string name="confirm_delete_profile_named">آیا مطمئن هستید که می‌خواهید این پروفایل را حذف کنید؟\n%1$s</string>
     <string name="confirm_delete_policy_group">آیا مطمئن هستید که می‌خواهید این گروه سیاست را حذف کنید؟</string>
+    <string name="confirm_delete_policy_group_named">آیا مطمئن هستید که می‌خواهید این گروه سیاست را حذف کنید؟\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">آیا مطمئن هستید که می‌خواهید این عضو زنجیره پراکسی را حذف کنید؟</string>
+    <string name="confirm_delete_proxy_chain_member_named">آیا مطمئن هستید که می‌خواهید این عضو زنجیره پراکسی را حذف کنید؟\n%1$s</string>
     <string name="confirm_delete_routing_rule">آیا مطمئن هستید که می‌خواهید این قانون مسیریابی را حذف کنید؟</string>
     <string name="confirm_delete_subscription_group">آیا مطمئن هستید که می‌خواهید این گروه اشتراک را حذف کنید؟</string>
     <string name="confirm_delete_asset_file">آیا مطمئن هستید که می‌خواهید فایل دارایی \"%1$s\" را حذف کنید؟</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">Удалить все отображаемые дубликаты профилей?</string>
     <string name="confirm_delete_invalid_profiles">Выполните проверку перед удалением! Удалить все отображаемые нерабочие профили?</string>
     <string name="confirm_delete_profile">Удалить этот профиль?</string>
+    <string name="confirm_delete_profile_named">Удалить этот профиль?\n%1$s</string>
     <string name="confirm_delete_policy_group">Удалить эту политику группы?</string>
+    <string name="confirm_delete_policy_group_named">Удалить эту группу политик?\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">Удалить этого участника цепочки прокси?</string>
+    <string name="confirm_delete_proxy_chain_member_named">Удалить этого участника цепочки прокси?\n%1$s</string>
     <string name="confirm_delete_routing_rule">Удалить это правило маршрутизации?</string>
     <string name="confirm_delete_subscription_group">Удалить эту подписку?</string>
     <string name="confirm_delete_asset_file">Удалить файл ресурсов «%1$s»?</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">Bạn có chắc muốn xóa tất cả cấu hình trùng lặp đang hiển thị không?</string>
     <string name="confirm_delete_invalid_profiles">Vui lòng kiểm tra các cấu hình trước. Bạn có chắc muốn xóa tất cả cấu hình không hợp lệ đang hiển thị không?</string>
     <string name="confirm_delete_profile">Bạn có chắc muốn xóa cấu hình này không?</string>
+    <string name="confirm_delete_profile_named">Bạn có chắc muốn xóa cấu hình này không?\n%1$s</string>
     <string name="confirm_delete_policy_group">Bạn có chắc muốn xóa nhóm chính sách này không?</string>
+    <string name="confirm_delete_policy_group_named">Bạn có chắc muốn xóa nhóm chính sách này không?\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">Bạn có chắc muốn xóa thành viên này khỏi chuỗi proxy không?</string>
+    <string name="confirm_delete_proxy_chain_member_named">Bạn có chắc muốn xóa thành viên này khỏi chuỗi proxy không?\n%1$s</string>
     <string name="confirm_delete_routing_rule">Bạn có chắc muốn xóa quy tắc định tuyến này không?</string>
     <string name="confirm_delete_subscription_group">Bạn có chắc muốn xóa nhóm đăng ký này không?</string>
     <string name="confirm_delete_asset_file">Bạn có chắc muốn xóa tệp tài nguyên \"%1$s\" không?</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">确定要删除当前显示的所有重复配置吗？</string>
     <string name="confirm_delete_invalid_profiles">请先测试配置。确定要删除当前显示的所有无效配置吗？</string>
     <string name="confirm_delete_profile">确定要删除此配置吗？</string>
+    <string name="confirm_delete_profile_named">确定要删除此配置吗？\n%1$s</string>
     <string name="confirm_delete_policy_group">确定要删除此策略组吗？</string>
+    <string name="confirm_delete_policy_group_named">确定要删除此策略组吗？\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">确定要删除此代理链成员吗？</string>
+    <string name="confirm_delete_proxy_chain_member_named">确定要删除此代理链成员吗？\n%1$s</string>
     <string name="confirm_delete_routing_rule">确定要删除此路由规则吗？</string>
     <string name="confirm_delete_subscription_group">确定要删除此订阅组吗？</string>
     <string name="confirm_delete_asset_file">确定要删除资源文件“%1$s”吗？</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">確定要刪除目前顯示的所有重複設定檔嗎？</string>
     <string name="confirm_delete_invalid_profiles">請先測試設定檔。確定要刪除目前顯示的所有無效設定檔嗎？</string>
     <string name="confirm_delete_profile">確定要刪除此設定檔嗎？</string>
+    <string name="confirm_delete_profile_named">確定要刪除此設定檔嗎？\n%1$s</string>
     <string name="confirm_delete_policy_group">確定要刪除此策略組嗎？</string>
+    <string name="confirm_delete_policy_group_named">確定要刪除此策略組嗎？\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">確定要刪除此代理鏈成員嗎？</string>
+    <string name="confirm_delete_proxy_chain_member_named">確定要刪除此代理鏈成員嗎？\n%1$s</string>
     <string name="confirm_delete_routing_rule">確定要刪除此路由規則嗎？</string>
     <string name="confirm_delete_subscription_group">確定要刪除此訂閱群組嗎？</string>
     <string name="confirm_delete_asset_file">確定要刪除資源檔案「%1$s」嗎？</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -46,8 +46,11 @@
     <string name="confirm_delete_duplicate_profiles">Are you sure you want to delete all duplicate profiles currently shown?</string>
     <string name="confirm_delete_invalid_profiles">Please test the profiles first. Are you sure you want to delete all invalid profiles currently shown?</string>
     <string name="confirm_delete_profile">Are you sure you want to delete this profile?</string>
+    <string name="confirm_delete_profile_named">Are you sure you want to delete this profile?\n%1$s</string>
     <string name="confirm_delete_policy_group">Are you sure you want to delete this policy group?</string>
+    <string name="confirm_delete_policy_group_named">Are you sure you want to delete this policy group?\n%1$s</string>
     <string name="confirm_delete_proxy_chain_member">Are you sure you want to delete this chain member?</string>
+    <string name="confirm_delete_proxy_chain_member_named">Are you sure you want to delete this chain member?\n%1$s</string>
     <string name="confirm_delete_routing_rule">Are you sure you want to delete this routing rule?</string>
     <string name="confirm_delete_subscription_group">Are you sure you want to delete this subscription group?</string>
     <string name="confirm_delete_asset_file">Are you sure you want to delete the asset file \"%1$s\"?</string>

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/ServerMenuDispatchTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/ServerMenuDispatchTest.kt
@@ -1,0 +1,58 @@
+package com.v2ray.ang.ui.main
+
+import com.v2ray.ang.dto.entities.ProfileItem
+import com.v2ray.ang.enums.EConfigType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ServerMenuDispatchTest {
+    @Test
+    fun menuDispatchPreservesActionsAndRequestsDeletionSeparately() {
+        val profile = ProfileItem(configType = EConfigType.VMESS, remarks = "Example")
+        val dispatched = mutableListOf<MainAction>()
+        val removals = mutableListOf<Pair<String, String>>()
+
+        ServerMenuAction.entries.forEach { action ->
+            action.perform("server-guid", profile, dispatched::add) { guid, name ->
+                removals.add(guid to name)
+            }
+        }
+
+        assertEquals(
+            listOf(
+                MainAction.ShareQRCode("server-guid"),
+                MainAction.ShareClipboard("server-guid"),
+                MainAction.ShareFullContent("server-guid"),
+                MainAction.EditServer("server-guid", profile),
+            ),
+            dispatched,
+        )
+        assertEquals(listOf("server-guid" to "Example"), removals)
+    }
+
+    @Test
+    fun duplicateNamesRetainDistinctDeletionIdentities() {
+        val profile = ProfileItem(configType = EConfigType.VMESS, remarks = "Same name")
+        val removals = mutableListOf<Pair<String, String>>()
+
+        listOf("first-guid", "second-guid").forEach { guid ->
+            ServerMenuAction.Delete.perform(guid, profile, { error("Deletion must request confirmation") }) { id, name ->
+                removals.add(id to name)
+            }
+        }
+
+        assertEquals(listOf("first-guid" to "Same name", "second-guid" to "Same name"), removals)
+    }
+
+    @Test
+    fun blankNameDoesNotDiscardTheDeletionRequest() {
+        val profile = ProfileItem(configType = EConfigType.VMESS, remarks = "")
+        val removals = mutableListOf<Pair<String, String>>()
+
+        ServerMenuAction.Delete.perform("server-guid", profile, { error("Deletion must request confirmation") }) { guid, name ->
+            removals.add(guid to name)
+        }
+
+        assertEquals(listOf("server-guid" to ""), removals)
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/ServerMenuDispatchTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/ServerMenuDispatchTest.kt
@@ -1,11 +1,34 @@
 package com.v2ray.ang.ui.main
 
+import androidx.compose.runtime.saveable.SaverScope
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.enums.EConfigType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class ServerMenuDispatchTest {
+    @Test
+    fun pendingDeletionRestoresOnlyItsGuidAndDisplayName() {
+        val scope = SaverScope { it is String }
+        for (guid in listOf("first-guid", "second-guid")) {
+            for (name in listOf("Same name", "", "Профиль\n服务器")) {
+                val target = ServerDeleteTarget(guid, name)
+                val saved = with(ServerDeleteTarget.Saver) { scope.save(target) }
+
+                assertEquals(listOf(guid, name), saved)
+                assertEquals(target, ServerDeleteTarget.Saver.restore(requireNotNull(saved)))
+            }
+        }
+    }
+
+    @Test
+    fun noPendingDeletionHasNoSavedTarget() {
+        val saved = with(ServerDeleteTarget.Saver) { SaverScope { it is String }.save(null) }
+
+        assertNull(saved)
+    }
+
     @Test
     fun menuDispatchPreservesActionsAndRequestsDeletionSeparately() {
         val profile = ProfileItem(configType = EConfigType.VMESS, remarks = "Example")


### PR DESCRIPTION
## Summary

Name the specific deletion target in the existing confirmation dialogs for server
profiles, policy groups, proxy-chain profiles, and individual proxy-chain members.
The localized question comes first, followed by the target name on a separate line.

This covers direct and overflow-menu deletion from the main server list and the
registered profile editors. Bulk-deletion questions stay generic.

## Target identity and restoration

- Main-list deletion captures the profile GUID and displayed name together. The
  dialog uses the name only as text; confirmation still removes by GUID. Duplicate
  names and list reordering cannot retarget the pending operation.
- Only these two strings are saved for the pending main-list dialog, using
  `rememberSaveable` and a small `listSaver`. No full profile or action callback is
  serialized.
- Profile-editor dialogs name the saved profile being deleted, not the unsaved
  remarks field. Renaming or clearing a draft therefore does not change the
  identity in the destructive confirmation.
- Pending single-profile confirmations survive activity recreation consistently
  in the main list and the ordinary, custom-config, policy-group, and proxy-chain
  editors.
- A pending proxy-chain member deletion is tied to its stable draft row key. The
  current position and member name are resolved from that key, and confirmation
  removes the member and its key together. A member that has already disappeared
  is not replaced by another member at its former index.

## Scope and accessibility approach

The existing Material confirmation dialog exposes its visible text through native
semantics. There are no custom announcements, focus manipulation, role overrides,
or role suppression.

The small server-menu dispatcher and stable-key member-removal helper are shared
with Part 9 so its custom actions use the same operation paths. This part does not
change server-row semantics, service behavior, deletion policy, or storage format.
Subscription, asset-file, and routing confirmations remain in their own parts.

The unused legacy `ServerActivity` is left unchanged from upstream. Existing
generic confirmation resources remain available to their existing callers.

## Localization

The three named confirmation templates exist in all nine supported catalogs:
English, Arabic, Bengali, Bakhtiari, Persian, Russian, Vietnamese, Simplified
Chinese, and Traditional Chinese. All 27 entries parse as XML and contain exactly
one `%1$s` target placeholder. The review fixes reuse those resources without
introducing new translated text.

## Validation

Reviewed revision: `b8ce732ae6ac56e54169451cbd7c2bc08f29c5f0`.

- `:app:testPlaystoreDebugUnitTest`: 67 tests passed, no failures, errors, or skips.
  This includes 10 focused dispatcher, pending-target saver, and stable-key
  proxy-chain member tests. Saver coverage includes null, duplicate display names
  under different GUIDs, empty names, non-Latin text, and embedded newlines.
- `:app:compilePlaystoreDebugKotlin`: passed.
- `:app:assemblePlaystoreDebug -PABI_FILTERS=x86_64`: passed.
- Pixel 9 Pro emulator, API 37.1, with TalkBack enabled: inspected native dialog
  text and exercised native accessibility click actions in ordinary, custom,
  policy-group, and proxy-chain editors. Unsaved renames and blank remarks did not
  change the saved deletion target. Cancel preserved each profile; actual
  activity recreation preserved each pending dialog. These emulator checks used
  the identical source tree immediately before committing; source-tree equality
  was checked before the commit.
- Main-list emulator check: recreated a pending dialog, confirmed it, and checked
  through the existing storage owner that only the captured GUID was removed.
  Another profile and the selected-server GUID remained unchanged.
- Used a temporary external QA harness, not an `androidTest` source directory in
  the PR. Removed its test fixtures and restored the emulator's original APK and
  accessibility settings. The existing lab subscription was retained.
- Pairwise `git merge-tree` checks against fetched upstream and all nine companion
  branches passed in both orders and produced identical trees.
- `git diff --check`: passed. No instruction files or generated inputs are in the
  feature diff.

### Not run

- Recorded TalkBack speech, swipe focus order, physical touch, keyboard, and D-pad
  interaction. Native-tree inspection and accessibility action execution do not
  establish exact spoken output or gesture behavior.
- Other Android versions, physical devices, release builds, other ABIs, and the
  full locale/theme/layout matrix. The emulator run used one English x86_64 debug
  configuration; localized resources were checked structurally, not spoken in
  every language.
