### PR TITLE
Fix Logcat crashes caused by duplicate log lines

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatActivity.kt
@@ -131,7 +131,7 @@ fun LogcatScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val logs by viewModel.filteredLogs.collectAsStateWithLifecycle()
+    val logs by viewModel.logEntries.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
 
     var searchQuery by remember { mutableStateOf("") }
@@ -213,8 +213,8 @@ fun LogcatScreen(
                     .verticalScrollbar(listState),
                 contentPadding = NavigationBarsBottomPadding()
             ) {
-                items(items = logs, key = { it }) { log ->
-                    LogcatItem(log = log, onLongClick = { Utils.setClipboard(context, log) })
+                items(items = logs, key = { it.key }) { log ->
+                    LogcatItem(log = log.text, onLongClick = { Utils.setClipboard(context, log.text) })
                     ItemDivider()
                 }
             }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/logcat/LogcatViewModel.kt
@@ -1,14 +1,20 @@
 package com.v2ray.ang.ui.logcat
 
 import android.app.Application
+import androidx.lifecycle.viewModelScope
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.base.BaseViewModel
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import java.io.IOException
 
 class LogcatViewModel(application: Application) : BaseViewModel(application) {
@@ -17,6 +23,10 @@ class LogcatViewModel(application: Application) : BaseViewModel(application) {
 
     private val _filteredLogs = MutableStateFlow<List<String>>(emptyList())
     val filteredLogs: StateFlow<List<String>> = _filteredLogs.asStateFlow()
+    val logEntries: StateFlow<List<LogcatEntry>> = filteredLogs
+        .map(::createLogcatEntries)
+        .flowOn(Dispatchers.Default)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     fun loadLogcat() {
         launchLoading {
@@ -73,4 +83,17 @@ class LogcatViewModel(application: Application) : BaseViewModel(application) {
             logsetsAll.filter { it.contains(currentFilter) }
         }
     }
+}
+
+data class LogcatEntry(val key: String, val text: String)
+
+internal fun createLogcatEntries(logs: List<String>): List<LogcatEntry> {
+    val occurrences = HashMap<String, Int>()
+    // Identical lines are valid. Count oldest-first so filtering other lines or
+    // prepending newer entries does not change the keys of existing occurrences.
+    return logs.asReversed().map { line ->
+        val occurrence = occurrences.getOrDefault(line, 0)
+        occurrences[line] = occurrence + 1
+        LogcatEntry("$occurrence:$line", line)
+    }.asReversed()
 }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/logcat/LogcatEntryTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/logcat/LogcatEntryTest.kt
@@ -1,0 +1,62 @@
+package com.v2ray.ang.ui.logcat
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogcatEntryTest {
+    @Test
+    fun emptyLogProducesNoEntries() {
+        assertTrue(createLogcatEntries(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun identicalTimestampedLinesHaveUniqueKeysWithoutLosingMessages() {
+        val line = "08-31 04:32:41.187 I/GoLog (42): repeated message"
+        val logs = listOf(line, line, line)
+        val entries = createLogcatEntries(logs)
+
+        assertEquals(logs, entries.map { it.text })
+        assertEquals(3, entries.map { it.key }.distinct().size)
+    }
+
+    @Test
+    fun preservesNewestFirstOrderAndOriginalText() {
+        val logs = listOf("newest", "\tat repeatedFrame(File.kt:42)", "middle", "\tat repeatedFrame(File.kt:42)")
+        val entries = createLogcatEntries(logs)
+
+        assertEquals(logs, entries.map { it.text })
+        assertEquals(logs.joinToString("\n"), entries.joinToString("\n") { it.text })
+        assertEquals(logs.size, entries.map { it.key }.distinct().size)
+    }
+
+    @Test
+    fun filteringOtherLinesPreservesKeysOfEveryMatchingOccurrence() {
+        val logs = listOf("match", "other", "match", "last")
+        val entries = createLogcatEntries(logs)
+        val filtered = createLogcatEntries(logs.filter { it.contains("match") })
+
+        assertEquals(entries.filter { it.text.contains("match") }, filtered)
+        assertTrue(createLogcatEntries(logs.filter { it.contains("missing") }).isEmpty())
+        assertEquals(entries, createLogcatEntries(logs))
+    }
+
+    @Test
+    fun refreshWithNewerLinesPreservesExistingOccurrenceKeys() {
+        val logs = listOf("repeated", "older", "repeated")
+        val entries = createLogcatEntries(logs)
+        val refreshed = createLogcatEntries(listOf("newest", "repeated") + logs)
+
+        assertEquals(entries, refreshed.takeLast(entries.size))
+        assertEquals(refreshed.size, refreshed.map { it.key }.distinct().size)
+    }
+
+    @Test
+    fun emptyAndKeyLikeMessagesRemainDistinct() {
+        val logs = listOf("", "0:", "", "1:message", "message", "message")
+        val entries = createLogcatEntries(logs)
+
+        assertEquals(logs, entries.map { it.text })
+        assertEquals(logs.size, entries.map { it.key }.distinct().size)
+    }
+}


### PR DESCRIPTION
## Summary

Fix the Logcat scrolling crash caused by identical log lines being used as Compose lazy-list keys. Preserve every log entry, its original text, and the existing newest-first order.

## Root cause and observed failure

[Commit 258de2097](https://github.com/2dust/v2rayNG/commit/258de209728c7c152d515c882f9c071f9f0c91bb) changed the Logcat list key from the item position to the full log string. A log line is not a unique identity: a burst can contain the same tag, PID, message, and millisecond timestamp more than once. Repeated stack frames in an exception are another common example.

When two such entries are measured, Compose throws:

```text
java.lang.IllegalArgumentException: Key "..." was already used.
If you are using LazyColumn/Row please make sure you provide a unique key for each item.
```

The user-provided physical-device log from August 31 contains three main-thread crashes with this exception. The first involves repeated normal log messages; the later failures involve repeated stack frames from the previous crashes. This explains why reopening and scrolling Logcat can keep crashing after the original event. The private diagnostic log is not included in this PR.

## Fix

- Add a small keyed presentation model in the existing Logcat ViewModel. Each key combines the complete original line with that line's occurrence number.
- Count occurrences from oldest to newest, then retain the current newest-first presentation. Adding newer entries does not renumber the existing occurrences.
- Text filtering keeps all occurrences of a matching line, so the keys of retained entries remain unchanged when unrelated lines are filtered out.
- Build the keyed projection on `Dispatchers.Default`, owned by `viewModelScope` and collected with the existing lifecycle-aware UI mechanism.
- Keep the original string flow as the source for copy and share. Neither generated keys nor occurrence numbers appear in exported text.

This deliberately does not deduplicate the logs or key rows by their visible position. Repeated messages remain available for diagnosis, and filtering does not reassign positional keys to unrelated rows.

## Validation

### Automated checks

- `:app:testPlaystoreDebugUnitTest --tests com.v2ray.ang.ui.logcat.LogcatEntryTest`: six regression tests passed, covering empty input, identical timestamped messages, repeated stack frames and original text/order, filtering, prepended entries, and empty/key-like messages.
- `:app:testPlaystoreDebugUnitTest`: all 63 tests passed.
- `:app:compilePlaystoreDebugKotlin` and `:app:assemblePlaystoreDebug` with `-PABI_FILTERS=x86_64`: passed.
- `git diff --check`: passed.

### Fixed-build emulator check

Tested the Play Store debug APK on the Pixel 9 Pro API 37.1 x86_64 emulator. Generated multiline messages under the app UID so the app's own Logcat reader received genuinely identical complete lines, including timestamps and PIDs.

- Loaded 320 fixture lines in 40 groups of eight identical lines and performed five successive inertial flings through them.
- Filtered to one eight-line group, checked an empty-result query, and restored the complete fixture filter.
- Added another 320 lines, refreshed, left and reopened Logcat, and loaded the updated output.
- Opened the share sheet without sending the log anywhere, then inspected the generated export: all 640 fixture lines were present, with 80 distinct complete lines appearing eight times each and no generated keys added to the text.
- The app process remained alive and the Android crash buffer stayed empty throughout the checked flow.

## Scope

Only the Logcat ViewModel, its list binding, and focused JVM regression tests change. No Tasker changes, native-library revision changes, dependencies, resources, API gates, formatting sweep, or unrelated feature-branch integration are included.
