### PR TITLE
Fix routing-rule creation and crash caused by duplicate IDs

### DIFF
--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -202,6 +202,7 @@ dependencies {
 
     // Testing Libraries
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     testImplementation(libs.org.mockito.mockito.inline)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -30,8 +30,28 @@ import com.v2ray.ang.util.Utils
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import java.util.UUID
 
 internal class ProfileStorageException(message: String) : IllegalStateException(message)
+
+/** Keep the first occurrence of an ID; repair only missing or colliding identities, never rule contents. */
+internal fun ensureRoutingRulesetIds(rulesets: List<RulesetItem>): Boolean {
+    val reserved = rulesets.mapTo(mutableSetOf()) { it.id }
+    val seen = mutableSetOf<String>()
+    var changed = false
+    for (ruleset in rulesets) {
+        if (ruleset.id.isNullOrBlank() || !seen.add(ruleset.id)) {
+            var id: String
+            do {
+                id = UUID.randomUUID().toString()
+            } while (!reserved.add(id))
+            ruleset.id = id
+            seen.add(id)
+            changed = true
+        }
+    }
+    return changed
+}
 
 object MmkvManager {
 
@@ -786,7 +806,12 @@ object MmkvManager {
     fun decodeRoutingRulesets(): MutableList<RulesetItem>? {
         val ruleset = settingsStorage.decodeString(PREF_ROUTING_RULESET)
         if (ruleset.isNullOrEmpty()) return null
-        return JsonUtil.fromJsonSafe(ruleset, Array<RulesetItem>::class.java)?.toMutableList() ?: mutableListOf()
+        val rulesets = JsonUtil.fromJsonSafe(ruleset, Array<RulesetItem>::class.java)?.toMutableList() ?: mutableListOf()
+        // Repair older imports before any caller uses IDs for editing or Compose keys.
+        if (ensureRoutingRulesetIds(rulesets)) {
+            check(encodeRoutingRulesets(rulesets)) { "Failed to persist routing rule IDs" }
+        }
+        return rulesets
     }
 
     /**
@@ -794,11 +819,10 @@ object MmkvManager {
      *
      * @param rulesetList The list of routing rulesets.
      */
-    fun encodeRoutingRulesets(rulesetList: MutableList<RulesetItem>?) {
-        if (rulesetList.isNullOrEmpty())
-            encodeSettings(PREF_ROUTING_RULESET, "")
-        else
-            encodeSettings(PREF_ROUTING_RULESET, JsonUtil.toJson(rulesetList))
+    fun encodeRoutingRulesets(rulesetList: MutableList<RulesetItem>?): Boolean {
+        rulesetList?.let { ensureRoutingRulesetIds(it) }
+        val content = if (rulesetList.isNullOrEmpty()) "" else JsonUtil.toJson(rulesetList)
+        return encodeSettings(PREF_ROUTING_RULESET, content)
     }
 
     //endregion

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -111,15 +111,16 @@ object SettingsManager {
      * @param rulesetList The list of rulesets.
      */
     private fun resetRoutingRulesetsCommon(rulesetList: MutableList<RulesetItem>) {
-        val rulesetNew: MutableList<RulesetItem> = mutableListOf()
-        MmkvManager.decodeRoutingRulesets()?.forEach { key ->
-            if (key.locked == true) {
-                rulesetNew.add(key)
-            }
-        }
-
-        rulesetNew.addAll(rulesetList)
+        val rulesetNew = mergeRoutingRulesets(MmkvManager.decodeRoutingRulesets().orEmpty(), rulesetList)
         MmkvManager.encodeRoutingRulesets(rulesetNew)
+    }
+
+    internal fun mergeRoutingRulesets(current: List<RulesetItem>, imported: List<RulesetItem>): MutableList<RulesetItem> {
+        val locked = current.filter { it.locked == true }
+        // An exported copy of a retained locked rule must not be appended again. Different
+        // rules (even with the same ID or title) are kept; storage repairs colliding IDs.
+        val retained = locked.toSet()
+        return (locked + imported.filterNot { it in retained }).toMutableList()
     }
 
     /**

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.os.Bundle
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -31,17 +32,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.v2ray.ang.AppConfig.BUILTIN_OUTBOUND_TAGS
 import com.v2ray.ang.AppConfig.TAG_PROXY
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.entities.RulesetItem
 import com.v2ray.ang.extension.nullIfBlank
-import com.v2ray.ang.extension.toast
-import com.v2ray.ang.extension.toastSuccess
-import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.apppicker.AppPickerActivity
 import com.v2ray.ang.ui.base.BaseComponentActivity
+import com.v2ray.ang.ui.base.BaseViewModelEvent
 import com.v2ray.ang.ui.compose.AppTopBar
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 import com.v2ray.ang.ui.compose.FormDropdownField
@@ -49,73 +51,42 @@ import com.v2ray.ang.ui.compose.FormTextField
 import com.v2ray.ang.ui.compose.NavigationBarsSpacer
 import com.v2ray.ang.ui.compose.SettingsSwitchItem
 import com.v2ray.ang.ui.compose.verticalScrollbar
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import java.util.UUID
 
 private val ROUTING_NETWORK_OPTIONS = listOf("tcp", "udp", "tcp,udp")
 
 class RoutingEditActivity : BaseComponentActivity() {
-    private val rulesetId by lazy { intent.getStringExtra("ruleset_id") }
-
-    private var initial: RulesetItem? = null
-    private lateinit var outboundSuggestions: List<String>
-    private var canUseProcess: Boolean = false
+    private val viewModel: RoutingEditViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        initial = rulesetId?.let { SettingsManager.getRoutingRuleset(it) }
-        if (initial == null) {
-            finish()
-            return
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.viewModelEvent.collect { event ->
+                    if (event == BaseViewModelEvent.FinishActivity) finish()
+                }
+            }
         }
-        val profileRemarks = SettingsManager.getProfileRemarks()
-        outboundSuggestions = (BUILTIN_OUTBOUND_TAGS.toList() + profileRemarks).distinct()
-        canUseProcess = SettingsManager.canUseProcessRouting()
+        viewModel.initialize(intent.getStringExtra("ruleset_id"))
     }
 
     @Composable
     override fun ScreenContent() {
+        val state by viewModel.state.collectAsStateWithLifecycle()
+        val loaded = state ?: return
         RoutingEditScreen(
-            rulesetId = rulesetId,
-            initial = initial,
-            outboundSuggestions = outboundSuggestions,
-            canUseProcess = canUseProcess,
+            initial = loaded.initial,
+            outboundSuggestions = loaded.outboundSuggestions,
+            canUseProcess = loaded.canUseProcess,
             onBackClick = { finish() },
-            onSave = { saveServer(it) },
-            onDelete = { deleteServer() }
+            onSave = viewModel::save,
+            onDelete = viewModel::delete
         )
-    }
-
-    private fun saveServer(rulesetItem: RulesetItem): Boolean {
-        if (rulesetItem.remarks.isNullOrEmpty()) {
-            toast(R.string.sub_setting_remarks)
-            return false
-        }
-        if (rulesetItem.id.isEmpty()) {
-            rulesetItem.id = UUID.randomUUID().toString()
-        }
-        SettingsManager.saveRoutingRuleset(rulesetId, rulesetItem)
-        toastSuccess(R.string.toast_success)
-        finish()
-        return true
-    }
-
-    private fun deleteServer(): Boolean {
-        if (!rulesetId.isNullOrEmpty()) {
-            lifecycleScope.launch(Dispatchers.IO) {
-                SettingsManager.removeRoutingRuleset(rulesetId)
-                withContext(Dispatchers.Main) { finish() }
-            }
-        }
-        return true
     }
 }
 
 @Composable
 fun RoutingEditScreen(
-    rulesetId: String?,
     initial: RulesetItem?,
     outboundSuggestions: List<String>,
     canUseProcess: Boolean,
@@ -151,7 +122,7 @@ fun RoutingEditScreen(
     }
 
     fun buildRuleset(): RulesetItem {
-        val rulesetItem = SettingsManager.getRoutingRuleset(rulesetId) ?: RulesetItem()
+        val rulesetItem = initial?.copy() ?: RulesetItem()
         rulesetItem.apply {
             this.remarks = remarks
             this.locked = locked

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingEditViewModel.kt
@@ -1,0 +1,86 @@
+package com.v2ray.ang.ui.routing
+
+import android.app.Application
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
+import com.v2ray.ang.dto.entities.RulesetItem
+import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.ui.base.BaseViewModel
+import com.v2ray.ang.util.LogUtil
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+
+data class RoutingEditState(
+    val initial: RulesetItem?,
+    val outboundSuggestions: List<String>,
+    val canUseProcess: Boolean
+)
+
+class RoutingEditViewModel(application: Application) : BaseViewModel(application) {
+    private val _state = MutableStateFlow<RoutingEditState?>(null)
+    val state: StateFlow<RoutingEditState?> = _state.asStateFlow()
+    private var initialized = false
+    private var rulesetId: String? = null
+
+    fun initialize(id: String?) {
+        if (initialized) return
+        initialized = true
+        rulesetId = id
+        launchLoading {
+            try {
+                val loaded = withContext(Dispatchers.IO) {
+                    val initial = id?.let { SettingsManager.getRoutingRuleset(it) }
+                    // No ID is the Add action. Only a missing explicitly requested rule is invalid.
+                    if (id != null && initial == null) return@withContext null
+                    RoutingEditState(
+                        initial = initial,
+                        outboundSuggestions = (AppConfig.BUILTIN_OUTBOUND_TAGS.toList() + SettingsManager.getProfileRemarks()).distinct(),
+                        canUseProcess = SettingsManager.canUseProcessRouting()
+                    )
+                }
+                if (loaded == null) finishActivity() else _state.value = loaded
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LogUtil.e(AppConfig.TAG, "Failed to load routing rule id=$id", e)
+                toastError(R.string.toast_failure)
+                finishActivity()
+            }
+        }
+    }
+
+    fun save(ruleset: RulesetItem): Boolean {
+        if (_state.value == null || isLoading.value) return false
+        if (ruleset.remarks.isNullOrEmpty()) {
+            toast(R.string.sub_setting_remarks)
+            return false
+        }
+        persist("save") { SettingsManager.saveRoutingRuleset(rulesetId, ruleset) }
+        return true
+    }
+
+    fun delete() {
+        val id = rulesetId ?: return
+        if (_state.value == null || isLoading.value) return
+        persist("delete") { SettingsManager.removeRoutingRuleset(id) }
+    }
+
+    private fun persist(operation: String, write: () -> Unit) {
+        launchLoading {
+            try {
+                withContext(Dispatchers.IO) { write() }
+                if (operation == "save") toastSuccess(R.string.toast_success)
+                finishActivity()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LogUtil.e(AppConfig.TAG, "Failed to $operation routing rule id=$rulesetId", e)
+                toastError(R.string.toast_failure)
+            }
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
@@ -263,7 +263,8 @@ fun RoutingSettingScreen(
                 .verticalScrollbar(lazyListState),
             contentPadding = NavigationBarsBottomPadding()
         ) {
-            item(key = "domain_strategy") {
+            // Rule IDs are strings, so the header cannot collide with an imported ID.
+            item(key = 0) {
                 SettingsListItem(
                     title = stringResource(R.string.routing_settings_domain_strategy),
                     entries = domainStrategies,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
@@ -1,41 +1,53 @@
 package com.v2ray.ang.ui.routing
 
 import android.app.Application
+import androidx.lifecycle.viewModelScope
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
 import com.v2ray.ang.dto.entities.RulesetItem
 import com.v2ray.ang.extension.moveItem
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.base.BaseViewModel
+import com.v2ray.ang.util.LogUtil
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import java.util.UUID
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class RoutingSettingsViewModel(application: Application) : BaseViewModel(application) {
     private val rulesets: MutableList<RulesetItem> = mutableListOf()
 
     private val _rulesetsFlow = MutableStateFlow<List<RulesetItem>>(emptyList())
     val rulesetsFlow: StateFlow<List<RulesetItem>> = _rulesetsFlow.asStateFlow()
+    private var reloadJob: Job? = null
 
     fun getAll(): List<RulesetItem> = rulesets.toList()
 
     fun reload() {
-        val loaded = MmkvManager.decodeRoutingRulesets()?.toMutableList() ?: mutableListOf()
-        var needsSave = false
-        loaded.forEachIndexed { index, item ->
-            if (item.id.isEmpty()) {
-                item.id = UUID.randomUUID().toString()
-                SettingsManager.saveRoutingRuleset(index, item)
-                needsSave = true
+        reloadJob?.cancel()
+        reloadJob = viewModelScope.launch {
+            try {
+                val loaded = withContext(Dispatchers.IO) { MmkvManager.decodeRoutingRulesets().orEmpty() }
+                rulesets.clear()
+                rulesets.addAll(loaded)
+                _rulesetsFlow.value = rulesets.toList()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LogUtil.e(AppConfig.TAG, "Failed to load routing rules", e)
+                toastError(R.string.toast_failure)
             }
         }
-        rulesets.clear()
-        rulesets.addAll(loaded)
-        _rulesetsFlow.value = rulesets.toList()
     }
 
     fun update(position: Int, item: RulesetItem) {
         if (position in rulesets.indices) {
+            reloadJob?.cancel()
             rulesets[position] = item
             SettingsManager.saveRoutingRuleset(position, item)
             _rulesetsFlow.value = rulesets.toList()
@@ -44,6 +56,7 @@ class RoutingSettingsViewModel(application: Application) : BaseViewModel(applica
 
     fun move(fromPosition: Int, toPosition: Int) {
         if (rulesets.moveItem(fromPosition, toPosition)) {
+            reloadJob?.cancel()
             MmkvManager.encodeRoutingRulesets(rulesets)
             _rulesetsFlow.value = rulesets.toList()
         }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/RoutingRulesetIdentityTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/RoutingRulesetIdentityTest.kt
@@ -1,0 +1,93 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.dto.entities.RulesetItem
+import com.v2ray.ang.util.JsonUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RoutingRulesetIdentityTest {
+    @Test
+    fun repairsLegacyAndDuplicateIdsWithoutChangingRulesOrOrder() {
+        val rules = JsonUtil.fromJson(
+            """[{"remarks":"same","domain":["first.example"],"locked":true},
+                {"id":"kept","remarks":"same","ip":["192.0.2.1"],"enabled":false},
+                {"id":"kept","remarks":"same","port":"443"},
+                {"id":null,"remarks":"null ID"},{"id":" ","remarks":"blank ID"}]""",
+            Array<RulesetItem>::class.java
+        )!!.toList()
+        val contents = rules.map { it.copy(id = "") }
+
+        assertTrue(ensureRoutingRulesetIds(rules))
+
+        assertEquals("kept", rules[1].id)
+        assertEquals(contents, rules.map { it.copy(id = "") })
+        assertUniqueIds(rules)
+        val reloaded = JsonUtil.fromJson(JsonUtil.toJson(rules), Array<RulesetItem>::class.java)!!.toList()
+        assertFalse(ensureRoutingRulesetIds(reloaded))
+        assertEquals(rules, reloaded)
+    }
+
+    @Test
+    fun preservesAlreadyUniqueIdsIncludingRepeatedTitles() {
+        val rules = listOf(rule("first"), rule("second"), rule("domain_strategy"))
+        assertFalse(ensureRoutingRulesetIds(rules))
+        assertEquals(listOf("first", "second", "domain_strategy"), rules.map { it.id })
+    }
+
+    @Test
+    fun emptyListNeedsNoRepair() {
+        assertFalse(ensureRoutingRulesetIds(emptyList()))
+    }
+
+    @Test
+    fun exportingAndReimportingDoesNotDuplicateLockedRule() {
+        val current = listOf(rule("locked", locked = true), rule("unlocked"))
+        val exported = JsonUtil.fromJson(JsonUtil.toJson(current), Array<RulesetItem>::class.java)!!.toList()
+
+        val merged = SettingsManager.mergeRoutingRulesets(current, exported)
+
+        assertEquals(current, merged)
+        assertFalse(ensureRoutingRulesetIds(merged))
+        assertEquals(current, SettingsManager.mergeRoutingRulesets(merged, exported))
+    }
+
+    @Test
+    fun keepsDifferentImportedRulesEvenIfIdsAndTitlesCollide() {
+        val locked = rule("same-id", locked = true)
+        val changed = locked.copy(domain = listOf("different.example"))
+        val imported = listOf(locked.copy(), changed, rule("same-id"), rule("another"))
+
+        val merged = SettingsManager.mergeRoutingRulesets(listOf(locked, rule("removed")), imported)
+        val expected = listOf(locked, changed, imported[2], imported[3]).map { it.copy(id = "") }
+        assertTrue(ensureRoutingRulesetIds(merged))
+
+        assertEquals("same-id", merged.first().id)
+        assertEquals(expected, merged.map { it.copy(id = "") })
+        assertUniqueIds(merged)
+    }
+
+    @Test
+    fun importedDuplicatesAreNotSilentlyDiscarded() {
+        val imported = listOf(rule("duplicate"), rule("duplicate"))
+        val merged = SettingsManager.mergeRoutingRulesets(emptyList(), imported)
+        assertTrue(ensureRoutingRulesetIds(merged))
+        assertEquals(2, merged.size)
+        assertUniqueIds(merged)
+    }
+
+    @Test
+    fun emptyImportRetainsOnlyLockedRules() {
+        val locked = rule("locked", locked = true)
+        assertEquals(listOf(locked), SettingsManager.mergeRoutingRulesets(listOf(rule("unlocked"), locked), emptyList()))
+        assertTrue(SettingsManager.mergeRoutingRulesets(emptyList(), emptyList()).isEmpty())
+    }
+
+    private fun assertUniqueIds(rules: List<RulesetItem>) {
+        assertTrue(rules.all { it.id.isNotBlank() })
+        assertEquals(rules.size, rules.map { it.id }.toSet().size)
+    }
+
+    private fun rule(id: String, locked: Boolean = false) = RulesetItem(id = id, remarks = "same", locked = locked)
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/routing/RoutingEditViewModelTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/routing/RoutingEditViewModelTest.kt
@@ -1,0 +1,285 @@
+package com.v2ray.ang.ui.routing
+
+import android.app.Application
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.tencent.mmkv.MMKV
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
+import com.v2ray.ang.dto.entities.RulesetItem
+import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.ui.base.BaseViewModelEvent
+import com.v2ray.ang.util.JsonUtil
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+// Test-only dispatcher replacement; remove the opt-in when kotlinx-coroutines-test stabilizes it.
+@OptIn(ExperimentalCoroutinesApi::class)
+class RoutingEditViewModelTest {
+    private val values = ConcurrentHashMap<String, String>()
+    private val models = mutableListOf<RoutingEditViewModel>()
+    private lateinit var log: MockedStatic<Log>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+        log = mockStatic(Log::class.java)
+        reset(storage)
+        whenever(storage.decodeString(any())).thenAnswer { values[it.getArgument<String>(0)] }
+        whenever(storage.encode(any<String>(), any<String>())).thenAnswer {
+            values[it.getArgument(0)] = it.getArgument(1)
+            true
+        }
+    }
+
+    @After
+    fun tearDown() {
+        models.forEach { it.viewModelScope.cancel() }
+        log.close()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun addWithoutIdOpensEmptyEditorAndPersistsNewRule() = runTest {
+        val model = model()
+        assertNull(model.state.value)
+        assertFalse(model.save(rule("", "Too early")))
+        model.initialize(null)
+        val state = model.state.filterNotNull().first()
+        assertNull(state.initial)
+        assertTrue(state.outboundSuggestions.contains(AppConfig.TAG_PROXY))
+
+        assertTrue(model.save(rule("", "New rule")))
+        assertEquals(BaseViewModelEvent.FinishActivity, model.viewModelEvent.first())
+        val saved = MmkvManager.decodeRoutingRulesets()!!.single()
+        assertEquals("New rule", saved.remarks)
+        assertTrue(saved.id.isNotBlank())
+    }
+
+    @Test
+    fun staleAndEmptyExplicitIdsCloseInsteadOfOpeningAddEditor() = runTest {
+        for (id in listOf("missing", "")) {
+            val model = model()
+            model.initialize(id)
+            assertEquals(BaseViewModelEvent.FinishActivity, model.viewModelEvent.first())
+            assertNull(model.state.value)
+        }
+    }
+
+    @Test
+    fun editsCorrectIdAfterOrderChangesDespiteRepeatedTitles() = runTest {
+        val first = rule("first", "Same")
+        val second = rule("second", "Same")
+        MmkvManager.encodeRoutingRulesets(mutableListOf(first, second))
+        val model = model()
+        model.initialize("second")
+        val state = model.state.filterNotNull().first()
+        assertEquals(second, state.initial)
+        model.initialize("first")
+        assertEquals(second, model.state.value!!.initial)
+        MmkvManager.encodeRoutingRulesets(mutableListOf(second, first))
+
+        model.save(second.copy(remarks = "Edited"))
+        assertEquals(BaseViewModelEvent.FinishActivity, model.viewModelEvent.first())
+        assertEquals(listOf(second.copy(remarks = "Edited"), first), MmkvManager.decodeRoutingRulesets())
+    }
+
+    @Test
+    fun deletesOnlyRequestedIdAfterReorder() = runTest {
+        val first = rule("first", "Same")
+        val second = rule("second", "Same")
+        MmkvManager.encodeRoutingRulesets(mutableListOf(first, second))
+        val model = model()
+        model.initialize("second")
+        model.state.filterNotNull().first()
+        MmkvManager.encodeRoutingRulesets(mutableListOf(second, first))
+
+        model.delete()
+        assertEquals(BaseViewModelEvent.FinishActivity, model.viewModelEvent.first())
+        assertEquals(listOf(first), MmkvManager.decodeRoutingRulesets())
+    }
+
+    @Test
+    fun missingRemarksDoNotSaveOrCloseEditor() = runTest {
+        val model = model()
+        model.initialize(null)
+        model.state.filterNotNull().first()
+        assertFalse(model.save(rule("", "")))
+        assertFalse(model.save(rule("", "").copy(remarks = null)))
+        assertNull(MmkvManager.decodeRoutingRulesets())
+        verify(model, org.mockito.kotlin.times(2)).toast(R.string.sub_setting_remarks)
+        model.delete()
+        runCurrent()
+        assertNull(MmkvManager.decodeRoutingRulesets())
+    }
+
+    @Test
+    fun storageFailureLeavesEditorOpenForRetry() = runTest {
+        val model = model()
+        model.initialize(null)
+        model.state.filterNotNull().first()
+        whenever(storage.encode(eq(AppConfig.PREF_ROUTING_RULESET), any<String>())).thenThrow(IllegalStateException("Test write failure"))
+        model.save(rule("", "Retry"))
+        runCurrent()
+        model.isLoading.first { !it }
+        verify(model).toastError(R.string.toast_failure)
+        assertNull(model.state.value!!.initial)
+        assertNull(MmkvManager.decodeRoutingRulesets())
+    }
+
+    @Test
+    fun loadingFailureClosesEditorAndReportsFailure() = runTest {
+        whenever(storage.decodeString(AppConfig.PREF_ROUTING_RULESET)).thenThrow(IllegalStateException("Test read failure"))
+        val model = model()
+        model.initialize("existing")
+        assertEquals(BaseViewModelEvent.FinishActivity, model.viewModelEvent.first())
+        verify(model).toastError(R.string.toast_failure)
+        assertNull(model.state.value)
+    }
+
+    @Test
+    fun storageRepairsLegacyIdsOnceBeforePublishing() = runTest {
+        values[AppConfig.PREF_ROUTING_RULESET] = """[{"id":"duplicate","remarks":"Same"},{"id":"duplicate","remarks":"Same"},{"remarks":"Legacy"}]"""
+        val model = RoutingSettingsViewModel(mock<Application>())
+        try {
+            assertTrue(model.rulesetsFlow.value.isEmpty())
+            model.reload()
+            val rules = model.rulesetsFlow.first { it.isNotEmpty() }
+            assertEquals(3, rules.map { it.id }.toSet().size)
+            assertTrue(rules.all { it.id.isNotBlank() })
+            assertEquals(rules, MmkvManager.decodeRoutingRulesets())
+            assertEquals(rules, JsonUtil.fromJson(values[AppConfig.PREF_ROUTING_RULESET]!!, Array<RulesetItem>::class.java)!!.toList())
+        } finally {
+            model.viewModelScope.cancel()
+        }
+    }
+
+    @Test
+    fun failedIdRepairIsNotPublishedAsIfItWerePersisted() = runTest {
+        values[AppConfig.PREF_ROUTING_RULESET] = """[{"remarks":"Legacy"}]"""
+        whenever(storage.encode(eq(AppConfig.PREF_ROUTING_RULESET), any<String>())).thenReturn(false)
+        val model = spy(RoutingSettingsViewModel(mock<Application>()))
+        doNothing().whenever(model).toastError(any<Int>())
+        try {
+            model.reload()
+            runCurrent()
+            model.viewModelScope.coroutineContext[kotlinx.coroutines.Job]!!.children.toList().forEach { it.join() }
+            verify(model).toastError(R.string.toast_failure)
+            assertTrue(model.rulesetsFlow.value.isEmpty())
+            assertEquals("""[{"remarks":"Legacy"}]""", values[AppConfig.PREF_ROUTING_RULESET])
+        } finally {
+            model.viewModelScope.cancel()
+        }
+    }
+
+    @Test
+    fun loadingEmptyRuleListPublishesEmptyState() = runTest {
+        val model = RoutingSettingsViewModel(mock<Application>())
+        try {
+            model.reload()
+            runCurrent()
+            model.viewModelScope.coroutineContext[kotlinx.coroutines.Job]!!.children.toList().forEach { it.join() }
+            assertTrue(model.rulesetsFlow.value.isEmpty())
+            assertNull(MmkvManager.decodeRoutingRulesets())
+        } finally {
+            model.viewModelScope.cancel()
+        }
+    }
+
+    @Test
+    fun pendingReloadCannotUndoToggleOrReorder() = runTest {
+        for (reorder in listOf(false, true)) {
+            val first = rule("first", "Same")
+            val second = rule("second", "Same")
+            MmkvManager.encodeRoutingRulesets(mutableListOf(first, second))
+            val model = RoutingSettingsViewModel(mock<Application>())
+            val release = CountDownLatch(1)
+            try {
+                model.reload()
+                model.rulesetsFlow.first { it.isNotEmpty() }
+                val started = CompletableDeferred<Unit>()
+                val blockOnce = AtomicBoolean(true)
+                whenever(storage.decodeString(AppConfig.PREF_ROUTING_RULESET)).thenAnswer {
+                    val snapshot = values[AppConfig.PREF_ROUTING_RULESET]
+                    if (blockOnce.getAndSet(false)) {
+                        started.complete(Unit)
+                        check(release.await(5, TimeUnit.SECONDS))
+                    }
+                    snapshot
+                }
+                model.reload()
+                started.await()
+                val expected = if (reorder) {
+                    model.move(0, 1)
+                    listOf(second, first)
+                } else {
+                    model.update(0, first.copy(enabled = false))
+                    listOf(first.copy(enabled = false), second)
+                }
+                release.countDown()
+                model.viewModelScope.coroutineContext[kotlinx.coroutines.Job]!!.children.toList().forEach { it.join() }
+                assertEquals(expected, model.rulesetsFlow.value)
+                assertEquals(expected, MmkvManager.decodeRoutingRulesets())
+            } finally {
+                release.countDown()
+                model.viewModelScope.cancel()
+            }
+        }
+    }
+
+    private fun model(): RoutingEditViewModel = spy(RoutingEditViewModel(mock<Application>())).also {
+        doNothing().whenever(it).toast(any<Int>())
+        doNothing().whenever(it).toastSuccess(any<Int>())
+        doNothing().whenever(it).toastError(any<Int>())
+        models.add(it)
+    }
+
+    private fun rule(id: String, remarks: String) = RulesetItem(id = id, remarks = remarks, outboundTag = AppConfig.TAG_PROXY)
+
+    companion object {
+        private val storage: MMKV = mock()
+
+        @BeforeClass
+        @JvmStatic
+        fun initializeStorageHandles() {
+            mockStatic(MMKV::class.java).use { mmkv ->
+                for (name in listOf("SETTING", "MAIN")) {
+                    mmkv.`when`<MMKV> { MMKV.mmkvWithID(name, MMKV.MULTI_PROCESS_MODE) }.thenReturn(storage)
+                }
+                MmkvManager.decodeRoutingRulesets()
+                MmkvManager.decodeAllServerList()
+            }
+        }
+    }
+}

--- a/V2rayNG/gradle/libs.versions.toml
+++ b/V2rayNG/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 core = { module = "com.google.zxing:core", version.ref = "core" }
 work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 work-multiprocess = { module = "androidx.work:work-multiprocess", version.ref = "workRuntimeKtx" }


### PR DESCRIPTION
## Summary

Fix two routing-rule identity issues in a focused branch based on current `master` (`c548e5f615d87a9220fd066b9f31fa127551ff90`, **Use ruleset IDs for routing edits**).

### 1. Adding a routing rule immediately closes the editor

The Add action intentionally starts `RoutingEditActivity` without `ruleset_id`. After the ID-based editing change, the activity resolved that to `initial == null` and unconditionally called `finish()`. Thus a valid new-rule request was treated as a stale edit request.

The editor now distinguishes these cases:

- **No ID:** open a blank editor and create a rule on Save.
- **Existing ID:** load and edit that rule, regardless of its current list position.
- **Explicit ID that no longer exists, including an empty ID:** close without creating or modifying another rule.

### 2. Imported or previously saved duplicate IDs can crash the routing list

The routing list and its reorderable rows use `RulesetItem.id` as a Compose key. Importing an exported ruleset retains the current locked rules and previously appended the entire import, including copies of those same locked rules with the same IDs. The old reload code repaired empty IDs only. Nonempty duplicates therefore reached Compose and also made ID-based edit/delete ambiguous.

This duplicate-ID exposure predates the latest editing change; it is **not a repeated-title problem**. Rules with identical remarks must remain supported.

## Fix

- Enforce nonblank, unique IDs when reading and writing routing lists through the existing `MmkvManager` storage boundary.
- Repair legacy missing/null/blank IDs and duplicate IDs, preserving the first valid occurrence, all rule contents, and list order. Persist repaired identities before exposing the list to callers; do not publish ephemeral replacements when that write fails.
- Keep retained locked rules without re-appending their exact exported copies. Preserve different imported rules even when their titles or IDs collide; assign fresh IDs rather than discard those rules.
- Use a non-string header key so an imported ID such as `domain_strategy` cannot collide with non-rule content.
- Remove the per-row ID migration from the list ViewModel. Load off the UI thread and cancel obsolete reloads, including reloads superseded by a toggle/reorder.
- Give the editor its own lifecycle-owned ViewModel, consistent with the upstream UI guide: loaded state is a lifecycle-collected `StateFlow`, storage runs off the UI thread, and the form builds an edited copy rather than reading MMKV during composition. Uncommitted text remains `rememberSaveable` form state.

No routing/export fields are renamed or removed. No rules are deduplicated by title. No native dependency, Shizuku, TV, Logcat, or combined-branch changes are included.

## Validation

- **18 focused JVM regression tests passed**, including legacy JSON, null/blank/duplicate IDs, stable persistence across reload, locked export/import round trips, repeated titles, Add vs stale edit, ID-based edit/delete after reorder, read/write failure handling, and pending reload vs toggle/reorder.
- **Full Play Store debug unit suite: 75 tests passed.**
- `:app:compilePlaystoreDebugKotlin` and `:app:assemblePlaystoreDebug` passed.
- Installed the matching-signer x86_64 Play Store debug APK on the **Pixel 9 Pro API 37.1 emulator**. Verified Add → Save → reopen, saving with the IME visible, two independent rules with the same remarks, locked-rule export/reimport twice, editing only the intended rule, unsaved input surviving activity recreation, keyboard Save, and D-pad Delete/confirmation. No application crash appeared in the crash buffer.
- `git diff --check` passed.

### Existing lint failures

`:app:lintPlaystoreDebug` ran and reports **4 errors, 302 warnings, and 1 hint**. The four errors are API-level checks in unchanged upstream code: `Process.waitFor(timeout, unit)` in `RootManager.kt` and `RootShell.kt`, and `windowLightNavigationBar` in the day/night theme resources. This PR adds no lint suppressions or baseline and does not bundle unrelated fixes for those findings.

**Not run:** runtime validation on physical hardware or other Android versions, TalkBack spoken-output testing, and F-Droid builds. The changes do not branch by distribution; runtime interaction evidence is limited to the emulator above.
