### PR TITLE
Prevent duplicate subscription IDs from crashing Compose lists

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -718,7 +718,8 @@ object MmkvManager {
         return if (json.isNullOrBlank()) {
             mutableListOf()
         } else {
-            JsonUtil.fromJsonSafe(json, Array<String>::class.java)?.toMutableList() ?: mutableListOf()
+            // Keep the first occurrence so a damaged index cannot produce duplicate Compose keys.
+            JsonUtil.fromJsonSafe(json, Array<String>::class.java)?.distinct()?.toMutableList() ?: mutableListOf()
         }
     }
 

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionIndexTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/SubscriptionIndexTest.kt
@@ -1,0 +1,114 @@
+package com.v2ray.ang.handler
+
+import android.util.Log
+import com.tencent.mmkv.MMKV
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.util.JsonUtil
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SubscriptionIndexTest {
+    private val mainValues = mutableMapOf<String, String>()
+    private val subValues = mutableMapOf<String, String>()
+
+    @Before
+    fun prepareStorage() {
+        for ((storage, values) in listOf(main to mainValues, subs to subValues)) {
+            reset(storage)
+            whenever(storage.decodeString(any())).thenAnswer { values[it.getArgument<String>(0)] }
+            whenever(storage.encode(any<String>(), any<String>())).thenAnswer {
+                values[it.getArgument(0)] = it.getArgument(1)
+                true
+            }
+            whenever(storage.allKeys()).thenAnswer { values.keys.toTypedArray() }
+        }
+    }
+
+    @Test
+    fun duplicateIdsKeepTheirFirstPositionWithoutWritingStorage() {
+        val stored = """["second","first","second","third","first"]"""
+        mainValues["SUB_IDS"] = stored
+
+        assertEquals(listOf("second", "first", "third"), MmkvManager.decodeSubsList())
+        assertEquals(stored, mainValues["SUB_IDS"])
+        verify(main, never()).encode(any<String>(), any<String>())
+    }
+
+    @Test
+    fun duplicateIndexEntriesProduceOnlyOneSubscriptionRow() {
+        mainValues["SUB_IDS"] = """["b","a","b","a"]"""
+        subValues["a"] = JsonUtil.toJson(SubscriptionItem(remarks = "Alpha"))
+        subValues["b"] = JsonUtil.toJson(SubscriptionItem(remarks = "Beta"))
+
+        val rows = MmkvManager.decodeSubscriptions()
+
+        assertEquals(listOf("b", "a"), rows.map { it.guid })
+        assertEquals(listOf("Beta", "Alpha"), rows.map { it.subscription.remarks })
+    }
+
+    @Test
+    fun repeatedAndBlankNamesDoNotMergeDifferentSubscriptions() {
+        mainValues["SUB_IDS"] = """["a","b","c","d"]"""
+        listOf("a" to "Same", "b" to "Same", "c" to "", "d" to " ").forEach { (id, name) ->
+            subValues[id] = JsonUtil.toJson(SubscriptionItem(remarks = name))
+        }
+
+        assertEquals(listOf("a", "b", "c", "d"), MmkvManager.decodeSubscriptions().map { it.guid })
+    }
+
+    @Test
+    fun decodedIndexRemainsMutableAndCanBeSavedInANewOrder() {
+        mainValues["SUB_IDS"] = """["a","b","a"]"""
+        val ids = MmkvManager.decodeSubsList()
+        ids.remove("a")
+        ids.add(0, "c")
+        MmkvManager.encodeSubsList(ids)
+
+        assertEquals("""["c","b"]""", mainValues["SUB_IDS"])
+        assertEquals(listOf("c", "b"), MmkvManager.decodeSubsList())
+    }
+
+    @Test
+    fun missingBlankAndEmptyIndexesRemainEmpty() {
+        assertEquals(emptyList<String>(), MmkvManager.decodeSubsList())
+        listOf("", " ", "[]", "null").forEach { stored ->
+            mainValues["SUB_IDS"] = stored
+            assertEquals(emptyList<String>(), MmkvManager.decodeSubsList())
+        }
+    }
+
+    @Test
+    fun malformedIndexKeepsTheExistingEmptyFallback() {
+        mockStatic(Log::class.java).use {
+            mainValues["SUB_IDS"] = "{"
+            assertEquals(emptyList<String>(), MmkvManager.decodeSubsList())
+        }
+    }
+
+    companion object {
+        private val main: MMKV = mock()
+        private val subs: MMKV = mock()
+        private val settings: MMKV = mock()
+
+        @BeforeClass
+        @JvmStatic
+        fun initializeHandles() {
+            mockStatic(MMKV::class.java).use {
+                it.`when`<MMKV> { MMKV.mmkvWithID("MAIN", MMKV.MULTI_PROCESS_MODE) }.thenReturn(main)
+                it.`when`<MMKV> { MMKV.mmkvWithID("SUB", MMKV.MULTI_PROCESS_MODE) }.thenReturn(subs)
+                it.`when`<MMKV> { MMKV.mmkvWithID("SETTING", MMKV.MULTI_PROCESS_MODE) }.thenReturn(settings)
+                MmkvManager.decodeSubscriptions()
+                MmkvManager.decodeSettingsString("test-initialize")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Prevent duplicate entries in the persisted subscription index from producing duplicate Compose keys. The production change is one `distinct()` call in `MmkvManager.decodeSubsList()`, with a short explanatory comment and six regression tests.

## Why

Subscription records are stored by GUID, while their display order is stored separately in the `MAIN/SUB_IDS` JSON array. If that array contains repeated GUIDs, `decodeSubscriptions()` currently emits the same record repeatedly. Both the subscription `LazyColumn` and its reorderable items use that GUID as their key, so a damaged index can cause a duplicate-key Compose crash.

For example, with existing records `a`, `b`, and `c`:

```text
Saved index:       [b, a, b, c, a]
Before:            [b, a, b, c, a]
After:             [b, a, c]
```

This is defensive handling of already-duplicated stored data, not a claim that creating subscriptions with the same name produces duplicate IDs.

## Scope and behavior

- Normalize the shared reader so subscription rows and other index consumers receive unique GUIDs.
- Preserve the first occurrence and existing order, and keep returning a mutable list for current callers.
- Do not change subscription records, names, IDs, Compose keys, or the persisted format.
- Do not write back during reads. Existing normal index writes can subsequently persist the deduplicated list.
- Preserve distinct subscriptions with equal or blank names and the existing empty/malformed-index fallback.

No UI, localization, native-library, or dependency changes. Based directly on current `upstream/master`; independent of the accessibility changes in #6158.

## Validation

- Ran the six new regression tests against unchanged upstream: three failed, exposing repeated decoded IDs/rows and a surviving duplicate after removal.
- With the fix, all six pass: `:app:testPlaystoreDebugUnitTest --tests com.v2ray.ang.handler.SubscriptionIndexTest`.
- Full `:app:testPlaystoreDebugUnitTest`: **63 tests passed**.
- `:app:compilePlaystoreDebugKotlin` and `:app:assemblePlaystoreDebug`: passed.
- API 37.1 Pixel 9 Pro emulator: injected repeated GUIDs into real MMKV storage; verified exactly three rows in first-occurrence order, correct edit target, and safe list reopening. A subsequent device-side assertion confirmed that the raw saved index still contained duplicates while both readers returned unique IDs. No app crash was observed.
- Removed the temporary fixtures and restored the emulator's pre-test APK and original subscription index.
