### PR TITLE
Ask for a group name when importing subscriptions

### DIFF
--- a/V2rayNG/app/src/androidTest/java/com/v2ray/ang/ui/main/SubscriptionImportTest.kt
+++ b/V2rayNG/app/src/androidTest/java/com/v2ray/ang/ui/main/SubscriptionImportTest.kt
@@ -5,7 +5,12 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.os.Bundle
 import android.util.Base64
+import android.util.Log
+import android.view.View
+import android.view.accessibility.AccessibilityManager
 import android.view.accessibility.AccessibilityNodeInfo
+import androidx.core.text.BidiFormatter
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -29,6 +34,50 @@ class SubscriptionImportTest {
     private val prefix = "http://127.0.0.1:1/${UUID.randomUUID()}"
 
     @Test
+    fun batchShowsEachUrlAndRestartsInitialFocus() = withMain { scenario, viewModel ->
+        val urls = listOf("$prefix/first", "$prefix/skipped", "$prefix/last?token=test&source=clipboard")
+        val base = instrumentation.targetContext.getString(R.string.sub_import_default_name)
+        val talkBack = instrumentation.targetContext.getSystemService(AccessibilityManager::class.java)
+            .isTouchExplorationEnabled
+        scenario.onActivity {
+            it.getSystemService(ClipboardManager::class.java)
+                .setPrimaryClip(ClipData.newPlainText("subscriptions", urls.joinToString("\n")))
+        }
+        clickText(instrumentation.targetContext.getString(R.string.acc_add))
+        clickText(instrumentation.targetContext.getString(R.string.menu_item_import_config_clipboard))
+
+        urls.forEachIndexed { index, url ->
+            waitUntil { viewModel.uiState.value.subscriptionImport?.url == url }
+            assertEquals(if (index == 0) base else "$base 2", viewModel.uiState.value.subscriptionImport?.name)
+            assertNull(saved(url))
+            val context = instrumentation.targetContext
+            val displayUrl = BidiFormatter.getInstance(context.resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL)
+                .unicodeWrap(url)
+            val expectedMessage = context.getString(R.string.sub_import_message, displayUrl)
+            waitUntil {
+                val root = automation.rootInActiveWindow
+                val message = findNode(root) { it.text?.toString() == expectedMessage }
+                message != null && if (talkBack) message.isAccessibilityFocused
+                else findNode(root) { it.isEditable }?.isFocused == true
+            }
+            val message = findNode(automation.rootInActiveWindow) { it.text?.contains(url) == true }!!
+            assertEquals(expectedMessage, message.text.toString())
+            assertNotNull(findNode(automation.rootInActiveWindow) {
+                AccessibilityNodeInfoCompat.wrap(it).paneTitle?.toString() == context.getString(R.string.sub_import_title)
+            })
+            Log.i("SubscriptionImportTest", "Initial focus: talkBack=$talkBack, message=${message.text}")
+            clickText(instrumentation.targetContext.getString(
+                if (index == 1) R.string.action_cancel else R.string.action_ok
+            ))
+        }
+        waitUntil { !viewModel.isLoading.value }
+        assertEquals(base, saved(urls[0])?.subscription?.remarks)
+        assertNull(saved(urls[1]))
+        assertEquals("$base 2", saved(urls[2])?.subscription?.remarks)
+        assertNull(viewModel.uiState.value.subscriptionImport)
+    }
+
+    @Test
     fun confirmationPreservesDraftOnRecreationAndSavesOnlyAfterOk() = withMain { scenario, viewModel ->
         val url = "$prefix/confirm"
         scenario.onActivity {
@@ -36,24 +85,27 @@ class SubscriptionImportTest {
         }
         clickText(instrumentation.targetContext.getString(R.string.acc_add))
         clickText(instrumentation.targetContext.getString(R.string.menu_item_import_config_clipboard))
-        waitUntil { viewModel.uiState.value.subscriptionImportName != null }
+        waitUntil { viewModel.uiState.value.subscriptionImport?.name != null }
         assertNull(saved(url))
+        assertEquals(url, viewModel.uiState.value.subscriptionImport?.url)
 
         action(viewModel, MainAction.ChangeSubscriptionImportName("  "))
         action(viewModel, MainAction.ConfirmSubscriptionImport)
         assertNull(saved(url))
-        assertEquals("  ", viewModel.uiState.value.subscriptionImportName)
+        assertEquals("  ", viewModel.uiState.value.subscriptionImport?.name)
 
         setDialogText("Travel subscription")
         scenario.recreate()
-        waitUntil { viewModel.uiState.value.subscriptionImportName == "Travel subscription" }
+        waitUntil { viewModel.uiState.value.subscriptionImport?.name == "Travel subscription" }
+        assertEquals(url, viewModel.uiState.value.subscriptionImport?.url)
+        waitUntil { findNode(automation.rootInActiveWindow) { it.text?.contains(url) == true } != null }
         clickText(instrumentation.targetContext.getString(R.string.action_ok))
         waitUntil { !viewModel.isLoading.value }
         val group = saved(url)!!
         assertEquals("Travel subscription", group.subscription.remarks)
         scenario.recreate()
         assertEquals("Travel subscription", MmkvManager.decodeSubscription(group.guid)?.remarks)
-        assertNull(viewModel.uiState.value.subscriptionImportName)
+        assertNull(viewModel.uiState.value.subscriptionImport?.name)
     }
 
     @Test
@@ -68,23 +120,23 @@ class SubscriptionImportTest {
             }
             val url = "$prefix/cancel"
             action(viewModel, MainAction.ImportBatchConfig(url))
-            waitUntil { viewModel.uiState.value.subscriptionImportName != null }
-            assertEquals("$base 3", viewModel.uiState.value.subscriptionImportName)
+            waitUntil { viewModel.uiState.value.subscriptionImport?.name != null }
+            assertEquals("$base 3", viewModel.uiState.value.subscriptionImport?.name)
             clickText(instrumentation.targetContext.getString(R.string.action_cancel))
             waitUntil { !viewModel.isLoading.value }
             assertNull(saved(url))
-            assertNull(viewModel.uiState.value.subscriptionImportName)
+            assertNull(viewModel.uiState.value.subscriptionImport?.name)
 
             action(viewModel, MainAction.ImportBatchConfig(url))
-            waitUntil { viewModel.uiState.value.subscriptionImportName != null }
-            assertEquals("$base 3", viewModel.uiState.value.subscriptionImportName)
+            waitUntil { viewModel.uiState.value.subscriptionImport?.name != null }
+            assertEquals("$base 3", viewModel.uiState.value.subscriptionImport?.name)
             clickText(instrumentation.targetContext.getString(R.string.action_ok))
             waitUntil { !viewModel.isLoading.value }
             assertEquals("$base 3", saved(url)?.subscription?.remarks)
 
             action(viewModel, MainAction.ImportBatchConfig("$prefix/next"))
-            waitUntil { viewModel.uiState.value.subscriptionImportName != null }
-            assertEquals("$base 4", viewModel.uiState.value.subscriptionImportName)
+            waitUntil { viewModel.uiState.value.subscriptionImport?.name != null }
+            assertEquals("$base 4", viewModel.uiState.value.subscriptionImport?.name)
             action(viewModel, MainAction.CancelSubscriptionImport)
             waitUntil { !viewModel.isLoading.value }
             assertNull(saved("$prefix/next"))
@@ -99,7 +151,7 @@ class SubscriptionImportTest {
         try {
             val result = AngConfigManager.importBatchConfig(
                 "vless://${UUID.randomUUID()}@127.0.0.1:443?security=none#$name", "", true
-            ) { _, _ ->
+            ) { _, _, _ ->
                 fail("A proxy profile must not open the subscription naming dialog")
                 null
             }
@@ -119,21 +171,24 @@ class SubscriptionImportTest {
             val second = "$prefix/second"
             val encoded = Base64.encodeToString("$first\n$first\n$second".toByteArray(), Base64.NO_WRAP)
             val suggestions = mutableListOf<String?>()
-            val result = AngConfigManager.importBatchConfig(encoded, "", true) { suggested, _ ->
+            val urls = mutableListOf<String>()
+            val result = AngConfigManager.importBatchConfig(encoded, "", true) { url, suggested, _ ->
                 suggestions += suggested
+                urls += url
                 if (suggested == null) null else "Chosen name"
             }
             assertEquals(ConfigImportResult(subscriptionCount = 1), result)
             assertEquals(listOf("Provided name", null), suggestions)
+            assertEquals(listOf(first, second), urls)
             assertEquals("Chosen name", saved(first)?.subscription?.remarks)
             assertNull(saved(second))
-            val duplicate = AngConfigManager.importBatchConfig(first, "", true) { _, _ ->
+            val duplicate = AngConfigManager.importBatchConfig(first, "", true) { _, _, _ ->
                 fail("An existing URL must not prompt again")
                 null
             }
             assertEquals(ConfigImportResult(duplicateSubscriptionCount = 1), duplicate)
             try {
-                AngConfigManager.importBatchConfig("$prefix/interrupted", "", true) { _, _ ->
+                AngConfigManager.importBatchConfig("$prefix/interrupted", "", true) { _, _, _ ->
                     throw CancellationException("Test owner ended")
                 }
                 fail("Cancellation must propagate")
@@ -159,7 +214,7 @@ class SubscriptionImportTest {
                 it.text?.toString() == message
             } != null
         }
-        assertNull(viewModel.uiState.value.subscriptionImportName)
+        assertNull(viewModel.uiState.value.subscriptionImport?.name)
         assertEquals(1, MmkvManager.decodeSubscriptions().count { it.subscription.url == url })
     }
 
@@ -174,14 +229,14 @@ class SubscriptionImportTest {
             val encoded = Base64.encodeToString("$first\n$second\n$first".toByteArray(), Base64.NO_WRAP)
             assertEquals(
                 ConfigImportResult(duplicateSubscriptionCount = 2),
-                AngConfigManager.importBatchConfig(encoded, "", true) { _, _ ->
+                AngConfigManager.importBatchConfig(encoded, "", true) { _, _, _ ->
                     fail("Existing subscriptions must not prompt for names")
                     null
                 }
             )
 
             val concurrent = "$prefix/concurrent"
-            val result = AngConfigManager.importBatchConfig(concurrent, "", true) { _, _ ->
+            val result = AngConfigManager.importBatchConfig(concurrent, "", true) { _, _, _ ->
                 MmkvManager.encodeSubscription("", SubscriptionItem(remarks = "Other import", url = concurrent, enabled = false))
                 "Confirmed name"
             }
@@ -199,7 +254,7 @@ class SubscriptionImportTest {
             ActivityScenario.launch(MainActivity::class.java).use { scenario ->
                 lateinit var viewModel: MainViewModel
                 scenario.onActivity { viewModel = ViewModelProvider(it)[MainViewModel::class.java] }
-                assertNull(viewModel.uiState.value.subscriptionImportName)
+                assertNull(viewModel.uiState.value.subscriptionImport?.name)
                 block(scenario, viewModel)
             }
         } finally {

--- a/V2rayNG/app/src/androidTest/java/com/v2ray/ang/ui/main/SubscriptionImportTest.kt
+++ b/V2rayNG/app/src/androidTest/java/com/v2ray/ang/ui/main/SubscriptionImportTest.kt
@@ -1,0 +1,200 @@
+package com.v2ray.ang.ui.main
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.os.Bundle
+import android.util.Base64
+import android.view.accessibility.AccessibilityNodeInfo
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.v2ray.ang.R
+import com.v2ray.ang.dto.entities.SubscriptionItem
+import com.v2ray.ang.handler.AngConfigManager
+import com.v2ray.ang.handler.MmkvManager
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.UUID
+
+@RunWith(AndroidJUnit4::class)
+class SubscriptionImportTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val prefix = "http://127.0.0.1:1/${UUID.randomUUID()}"
+
+    @Test
+    fun confirmationPreservesDraftOnRecreationAndSavesOnlyAfterOk() = withMain { scenario, viewModel ->
+        val url = "$prefix/confirm"
+        scenario.onActivity {
+            it.getSystemService(ClipboardManager::class.java).setPrimaryClip(ClipData.newPlainText("subscription", url))
+        }
+        clickText(instrumentation.targetContext.getString(R.string.acc_add))
+        clickText(instrumentation.targetContext.getString(R.string.menu_item_import_config_clipboard))
+        waitUntil { viewModel.uiState.value.subscriptionImportName != null }
+        assertNull(saved(url))
+
+        action(viewModel, MainAction.ChangeSubscriptionImportName("  "))
+        action(viewModel, MainAction.ConfirmSubscriptionImport)
+        assertNull(saved(url))
+        assertEquals("  ", viewModel.uiState.value.subscriptionImportName)
+
+        setDialogText("Travel subscription")
+        scenario.recreate()
+        waitUntil { viewModel.uiState.value.subscriptionImportName == "Travel subscription" }
+        clickText(instrumentation.targetContext.getString(R.string.action_ok))
+        waitUntil { !viewModel.isLoading.value }
+        val group = saved(url)!!
+        assertEquals("Travel subscription", group.subscription.remarks)
+        scenario.recreate()
+        assertEquals("Travel subscription", MmkvManager.decodeSubscription(group.guid)?.remarks)
+        assertNull(viewModel.uiState.value.subscriptionImportName)
+    }
+
+    @Test
+    fun cancellationAndNumberedDefaultsDoNotCreateUnconfirmedGroups() = withMain { _, viewModel ->
+        val base = instrumentation.targetContext.getString(R.string.sub_import_default_name)
+        val ids = listOf(UUID.randomUUID().toString(), UUID.randomUUID().toString())
+        try {
+            ids.forEachIndexed { index, id ->
+                MmkvManager.encodeSubscription(id, SubscriptionItem(
+                    remarks = if (index == 0) base else "$base 2", enabled = false
+                ))
+            }
+            val url = "$prefix/cancel"
+            action(viewModel, MainAction.ImportBatchConfig(url))
+            waitUntil { viewModel.uiState.value.subscriptionImportName != null }
+            assertEquals("$base 3", viewModel.uiState.value.subscriptionImportName)
+            clickText(instrumentation.targetContext.getString(R.string.action_cancel))
+            waitUntil { !viewModel.isLoading.value }
+            assertNull(saved(url))
+            assertNull(viewModel.uiState.value.subscriptionImportName)
+
+            action(viewModel, MainAction.ImportBatchConfig(url))
+            waitUntil { viewModel.uiState.value.subscriptionImportName != null }
+            assertEquals("$base 3", viewModel.uiState.value.subscriptionImportName)
+            clickText(instrumentation.targetContext.getString(R.string.action_ok))
+            waitUntil { !viewModel.isLoading.value }
+            assertEquals("$base 3", saved(url)?.subscription?.remarks)
+
+            action(viewModel, MainAction.ImportBatchConfig("$prefix/next"))
+            waitUntil { viewModel.uiState.value.subscriptionImportName != null }
+            assertEquals("$base 4", viewModel.uiState.value.subscriptionImportName)
+            action(viewModel, MainAction.CancelSubscriptionImport)
+            waitUntil { !viewModel.isLoading.value }
+            assertNull(saved("$prefix/next"))
+        } finally {
+            ids.forEach(MmkvManager::removeSubscription)
+        }
+    }
+
+    @Test
+    fun ordinaryProxyImportDoesNotAskForSubscriptionName() = runBlocking {
+        val name = "proxy-${UUID.randomUUID()}"
+        try {
+            val result = AngConfigManager.importBatchConfig(
+                "vless://${UUID.randomUUID()}@127.0.0.1:443?security=none#$name", "", true
+            ) { _, _ ->
+                fail("A proxy profile must not open the subscription naming dialog")
+                null
+            }
+            assertEquals(1 to 0, result)
+            assertTrue(MmkvManager.decodeAllServerList().any { MmkvManager.decodeServerConfig(it)?.remarks == name })
+        } finally {
+            MmkvManager.decodeAllServerList()
+                .filter { MmkvManager.decodeServerConfig(it)?.remarks == name }
+                .forEach(MmkvManager::removeServer)
+        }
+    }
+
+    @Test
+    fun encodedBatchPromptsOncePerNewUrlAndCancellationPropagates() = runBlocking {
+        try {
+            val first = "$prefix/first#Provided%20name"
+            val second = "$prefix/second"
+            val encoded = Base64.encodeToString("$first\n$first\n$second".toByteArray(), Base64.NO_WRAP)
+            val suggestions = mutableListOf<String?>()
+            val result = AngConfigManager.importBatchConfig(encoded, "", true) { suggested, _ ->
+                suggestions += suggested
+                if (suggested == null) null else "Chosen name"
+            }
+            assertEquals(0 to 1, result)
+            assertEquals(listOf("Provided name", null), suggestions)
+            assertEquals("Chosen name", saved(first)?.subscription?.remarks)
+            assertNull(saved(second))
+            AngConfigManager.importBatchConfig(first, "", true) { _, _ ->
+                fail("An existing URL must not prompt again")
+                null
+            }
+            try {
+                AngConfigManager.importBatchConfig("$prefix/interrupted", "", true) { _, _ ->
+                    throw CancellationException("Test owner ended")
+                }
+                fail("Cancellation must propagate")
+            } catch (_: CancellationException) {
+                assertNull(saved("$prefix/interrupted"))
+            }
+        } finally {
+            removeTestGroups()
+        }
+    }
+
+    private fun withMain(block: (ActivityScenario<MainActivity>, MainViewModel) -> Unit) {
+        try {
+            ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+                lateinit var viewModel: MainViewModel
+                scenario.onActivity { viewModel = ViewModelProvider(it)[MainViewModel::class.java] }
+                assertNull(viewModel.uiState.value.subscriptionImportName)
+                block(scenario, viewModel)
+            }
+        } finally {
+            removeTestGroups()
+        }
+    }
+
+    private fun action(viewModel: MainViewModel, action: MainAction) =
+        instrumentation.runOnMainSync { viewModel.onAction(action) }
+
+    private fun saved(url: String) = MmkvManager.decodeSubscriptions().find { it.subscription.url == url }
+
+    private fun removeTestGroups() = MmkvManager.decodeSubscriptions()
+        .filter { it.subscription.url.startsWith(prefix) }
+        .forEach { MmkvManager.removeSubscription(it.guid) }
+
+    private fun waitUntil(condition: () -> Boolean) {
+        val deadline = System.nanoTime() + 20_000_000_000L
+        while (!condition()) {
+            check(System.nanoTime() < deadline) { "Timed out waiting for import state" }
+            Thread.sleep(50)
+        }
+    }
+
+    private fun findNode(node: AccessibilityNodeInfo?, predicate: (AccessibilityNodeInfo) -> Boolean): AccessibilityNodeInfo? {
+        if (node == null || predicate(node)) return node
+        for (index in 0 until node.childCount) {
+            findNode(node.getChild(index), predicate)?.let { return it }
+        }
+        return null
+    }
+
+    private fun setDialogText(value: String) {
+        waitUntil {
+            findNode(instrumentation.uiAutomation.rootInActiveWindow) { it.isEditable }
+                ?.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, Bundle().apply {
+                    putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, value)
+                }) == true
+        }
+    }
+
+    private fun clickText(text: String) {
+        waitUntil {
+            var node = findNode(instrumentation.uiAutomation.rootInActiveWindow) {
+                it.text?.toString() == text || it.contentDescription?.toString() == text
+            }
+            while (node != null && !node.isClickable) node = node.parent
+            node?.performAction(AccessibilityNodeInfo.ACTION_CLICK) == true
+        }
+    }
+}

--- a/V2rayNG/app/src/androidTest/java/com/v2ray/ang/ui/main/SubscriptionImportTest.kt
+++ b/V2rayNG/app/src/androidTest/java/com/v2ray/ang/ui/main/SubscriptionImportTest.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.ui.main
 
+import android.app.UiAutomation
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.os.Bundle
@@ -10,6 +11,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.v2ray.ang.R
+import com.v2ray.ang.dto.ConfigImportResult
 import com.v2ray.ang.dto.entities.SubscriptionItem
 import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.handler.MmkvManager
@@ -23,6 +25,7 @@ import java.util.UUID
 @RunWith(AndroidJUnit4::class)
 class SubscriptionImportTest {
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val automation = instrumentation.getUiAutomation(UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)
     private val prefix = "http://127.0.0.1:1/${UUID.randomUUID()}"
 
     @Test
@@ -100,7 +103,7 @@ class SubscriptionImportTest {
                 fail("A proxy profile must not open the subscription naming dialog")
                 null
             }
-            assertEquals(1 to 0, result)
+            assertEquals(ConfigImportResult(configCount = 1), result)
             assertTrue(MmkvManager.decodeAllServerList().any { MmkvManager.decodeServerConfig(it)?.remarks == name })
         } finally {
             MmkvManager.decodeAllServerList()
@@ -120,14 +123,15 @@ class SubscriptionImportTest {
                 suggestions += suggested
                 if (suggested == null) null else "Chosen name"
             }
-            assertEquals(0 to 1, result)
+            assertEquals(ConfigImportResult(subscriptionCount = 1), result)
             assertEquals(listOf("Provided name", null), suggestions)
             assertEquals("Chosen name", saved(first)?.subscription?.remarks)
             assertNull(saved(second))
-            AngConfigManager.importBatchConfig(first, "", true) { _, _ ->
+            val duplicate = AngConfigManager.importBatchConfig(first, "", true) { _, _ ->
                 fail("An existing URL must not prompt again")
                 null
             }
+            assertEquals(ConfigImportResult(duplicateSubscriptionCount = 1), duplicate)
             try {
                 AngConfigManager.importBatchConfig("$prefix/interrupted", "", true) { _, _ ->
                     throw CancellationException("Test owner ended")
@@ -136,6 +140,55 @@ class SubscriptionImportTest {
             } catch (_: CancellationException) {
                 assertNull(saved("$prefix/interrupted"))
             }
+        } finally {
+            removeTestGroups()
+        }
+    }
+
+    @Test
+    fun duplicateImportExplainsWhyNothingWasAdded() = withMain { _, viewModel ->
+        val url = "$prefix/duplicate"
+        MmkvManager.encodeSubscription("", SubscriptionItem(remarks = "Existing", url = url, enabled = false))
+        val message = instrumentation.targetContext.resources.getQuantityString(
+            R.plurals.import_subscription_duplicate, 1
+        )
+
+        action(viewModel, MainAction.ImportBatchConfig(url))
+        waitUntil {
+            findNode(automation.rootInActiveWindow) {
+                it.text?.toString() == message
+            } != null
+        }
+        assertNull(viewModel.uiState.value.subscriptionImportName)
+        assertEquals(1, MmkvManager.decodeSubscriptions().count { it.subscription.url == url })
+    }
+
+    @Test
+    fun encodedDuplicatesAndConcurrentImportKeepTheirReason() = runBlocking {
+        try {
+            val first = "$prefix/duplicate-first"
+            val second = "$prefix/duplicate-second"
+            listOf(first, second).forEach { url ->
+                MmkvManager.encodeSubscription("", SubscriptionItem(remarks = "Existing", url = url, enabled = false))
+            }
+            val encoded = Base64.encodeToString("$first\n$second\n$first".toByteArray(), Base64.NO_WRAP)
+            assertEquals(
+                ConfigImportResult(duplicateSubscriptionCount = 2),
+                AngConfigManager.importBatchConfig(encoded, "", true) { _, _ ->
+                    fail("Existing subscriptions must not prompt for names")
+                    null
+                }
+            )
+
+            val concurrent = "$prefix/concurrent"
+            val result = AngConfigManager.importBatchConfig(concurrent, "", true) { _, _ ->
+                MmkvManager.encodeSubscription("", SubscriptionItem(remarks = "Other import", url = concurrent, enabled = false))
+                "Confirmed name"
+            }
+            assertEquals(ConfigImportResult(duplicateSubscriptionCount = 1), result)
+            assertEquals("Other import", saved(concurrent)?.subscription?.remarks)
+            assertEquals(1, MmkvManager.decodeSubscriptions().count { it.subscription.url == concurrent })
+            assertEquals(ConfigImportResult(), AngConfigManager.importBatchConfig("not a subscription", "", true))
         } finally {
             removeTestGroups()
         }
@@ -181,7 +234,7 @@ class SubscriptionImportTest {
 
     private fun setDialogText(value: String) {
         waitUntil {
-            findNode(instrumentation.uiAutomation.rootInActiveWindow) { it.isEditable }
+            findNode(automation.rootInActiveWindow) { it.isEditable }
                 ?.performAction(AccessibilityNodeInfo.ACTION_SET_TEXT, Bundle().apply {
                     putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, value)
                 }) == true
@@ -190,7 +243,7 @@ class SubscriptionImportTest {
 
     private fun clickText(text: String) {
         waitUntil {
-            var node = findNode(instrumentation.uiAutomation.rootInActiveWindow) {
+            var node = findNode(automation.rootInActiveWindow) {
                 it.text?.toString() == text || it.contentDescription?.toString() == text
             }
             while (node != null && !node.isClickable) node = node.parent

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/ConfigImportResult.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/ConfigImportResult.kt
@@ -1,0 +1,8 @@
+package com.v2ray.ang.dto
+
+/** Import counts, including subscription URLs skipped because they already exist. */
+data class ConfigImportResult(
+    val configCount: Int = 0,
+    val subscriptionCount: Int = 0,
+    val duplicateSubscriptionCount: Int = 0
+)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -26,6 +26,7 @@ import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.QRCodeDecoder
 import com.v2ray.ang.util.Utils
+import kotlinx.coroutines.CancellationException
 import java.net.URI
 
 object AngConfigManager {
@@ -177,9 +178,16 @@ object AngConfigManager {
      * @param server The server string.
      * @param subid The subscription ID.
      * @param append Whether to append the configurations.
+     * @param requestSubscriptionName Optional confirmation before saving each new subscription;
+     * receives its suggested name and existing names, and returns null to skip it.
      * @return A pair containing the number of configurations and subscriptions imported.
      */
-    fun importBatchConfig(server: String?, subid: String, append: Boolean): Pair<Int, Int> {
+    suspend fun importBatchConfig(
+        server: String?,
+        subid: String,
+        append: Boolean,
+        requestSubscriptionName: (suspend (String?, Set<String>) -> String?)? = null
+    ): Pair<Int, Int> {
         return try {
             var count = parseBatchConfig(Utils.decode(server), subid, append)
             if (count <= 0) {
@@ -189,9 +197,9 @@ object AngConfigManager {
                 count = parseCustomConfigServer(server, subid, append)
             }
 
-            var countSub = parseBatchSubscription(server)
+            var countSub = parseBatchSubscription(server, requestSubscriptionName)
             if (countSub <= 0) {
-                countSub = parseBatchSubscription(Utils.decode(server))
+                countSub = parseBatchSubscription(Utils.decode(server), requestSubscriptionName)
             }
             if (countSub > 0) {
                 updateConfigViaSubAll()
@@ -210,7 +218,10 @@ object AngConfigManager {
      * @param servers The servers string.
      * @return The number of subscriptions parsed.
      */
-    private fun parseBatchSubscription(servers: String?): Int {
+    private suspend fun parseBatchSubscription(
+        servers: String?,
+        requestSubscriptionName: (suspend (String?, Set<String>) -> String?)?
+    ): Int {
         try {
             if (servers == null) {
                 return 0
@@ -221,10 +232,12 @@ object AngConfigManager {
                 .distinct()
                 .forEach { str ->
                     if (Utils.isValidSubUrl(str)) {
-                        count += importUrlAsSubscription(str)
+                        count += importUrlAsSubscription(str, requestSubscriptionName)
                     }
                 }
             return count
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to parse batch subscription", e)
         }
@@ -602,7 +615,10 @@ object AngConfigManager {
      * @param url The URL.
      * @return The number of subscriptions imported.
      */
-    private fun importUrlAsSubscription(url: String): Int {
+    private suspend fun importUrlAsSubscription(
+        url: String,
+        requestSubscriptionName: (suspend (String?, Set<String>) -> String?)?
+    ): Int {
         val subscriptions = MmkvManager.decodeSubscriptions()
         subscriptions.forEach {
             if (it.subscription.url == url) {
@@ -610,8 +626,16 @@ object AngConfigManager {
             }
         }
         val uri = URI(Utils.fixIllegalUrl(url))
+        val remarks = if (requestSubscriptionName == null) {
+            uri.fragment ?: "import sub"
+        } else {
+            requestSubscriptionName(uri.fragment, subscriptions.map { it.subscription.remarks }.toSet())
+                ?.trim()?.takeIf { it.isNotEmpty() } ?: return 0
+        }
+        // Another import may have saved this URL while the naming dialog was open.
+        if (MmkvManager.decodeSubscriptions().any { it.subscription.url == url }) return 0
         val subItem = SubscriptionItem()
-        subItem.remarks = uri.fragment ?: "import sub"
+        subItem.remarks = remarks
         subItem.url = url
         MmkvManager.encodeSubscription("", subItem)
         return 1

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -182,14 +182,14 @@ object AngConfigManager {
      * @param subid The subscription ID.
      * @param append Whether to append the configurations.
      * @param requestSubscriptionName Optional confirmation before saving each new subscription;
-     * receives its suggested name and existing names, and returns null to skip it.
+     * receives its URL, suggested name and existing names, and returns null to skip it.
      * @return Imported configuration/subscription counts and duplicate subscription count.
      */
     suspend fun importBatchConfig(
         server: String?,
         subid: String,
         append: Boolean,
-        requestSubscriptionName: (suspend (String?, Set<String>) -> String?)? = null
+        requestSubscriptionName: (suspend (String, String?, Set<String>) -> String?)? = null
     ): ConfigImportResult {
         return try {
             var count = parseBatchConfig(Utils.decode(server), subid, append)
@@ -223,7 +223,7 @@ object AngConfigManager {
      */
     private suspend fun parseBatchSubscription(
         servers: String?,
-        requestSubscriptionName: (suspend (String?, Set<String>) -> String?)?
+        requestSubscriptionName: (suspend (String, String?, Set<String>) -> String?)?
     ): ConfigImportResult {
         try {
             if (servers == null) {
@@ -625,7 +625,7 @@ object AngConfigManager {
      */
     private suspend fun importUrlAsSubscription(
         url: String,
-        requestSubscriptionName: (suspend (String?, Set<String>) -> String?)?
+        requestSubscriptionName: (suspend (String, String?, Set<String>) -> String?)?
     ): SubscriptionImportOutcome {
         val subscriptions = MmkvManager.decodeSubscriptions()
         subscriptions.forEach {
@@ -637,7 +637,7 @@ object AngConfigManager {
         val remarks = if (requestSubscriptionName == null) {
             uri.fragment ?: "import sub"
         } else {
-            requestSubscriptionName(uri.fragment, subscriptions.map { it.subscription.remarks }.toSet())
+            requestSubscriptionName(url, uri.fragment, subscriptions.map { it.subscription.remarks }.toSet())
                 ?.trim()?.takeIf { it.isNotEmpty() } ?: return SubscriptionImportOutcome.Cancelled
         }
         // Another import may have saved this URL while the naming dialog was open.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/AngConfigManager.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.text.TextUtils
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.core.CoreConfigManager
+import com.v2ray.ang.dto.ConfigImportResult
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.UrlContentRequest
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -30,6 +31,8 @@ import kotlinx.coroutines.CancellationException
 import java.net.URI
 
 object AngConfigManager {
+
+    private enum class SubscriptionImportOutcome { Imported, Duplicate, Cancelled }
 
     private data class ParsedProfile(
         val profile: ProfileItem,
@@ -180,14 +183,14 @@ object AngConfigManager {
      * @param append Whether to append the configurations.
      * @param requestSubscriptionName Optional confirmation before saving each new subscription;
      * receives its suggested name and existing names, and returns null to skip it.
-     * @return A pair containing the number of configurations and subscriptions imported.
+     * @return Imported configuration/subscription counts and duplicate subscription count.
      */
     suspend fun importBatchConfig(
         server: String?,
         subid: String,
         append: Boolean,
         requestSubscriptionName: (suspend (String?, Set<String>) -> String?)? = null
-    ): Pair<Int, Int> {
+    ): ConfigImportResult {
         return try {
             var count = parseBatchConfig(Utils.decode(server), subid, append)
             if (count <= 0) {
@@ -197,18 +200,18 @@ object AngConfigManager {
                 count = parseCustomConfigServer(server, subid, append)
             }
 
-            var countSub = parseBatchSubscription(server, requestSubscriptionName)
-            if (countSub <= 0) {
-                countSub = parseBatchSubscription(Utils.decode(server), requestSubscriptionName)
+            var subscriptions = parseBatchSubscription(server, requestSubscriptionName)
+            if (subscriptions.subscriptionCount == 0 && subscriptions.duplicateSubscriptionCount == 0) {
+                subscriptions = parseBatchSubscription(Utils.decode(server), requestSubscriptionName)
             }
-            if (countSub > 0) {
+            if (subscriptions.subscriptionCount > 0) {
                 updateConfigViaSubAll()
             }
 
-            count to countSub
+            subscriptions.copy(configCount = count)
         } catch (e: ProfileStorageException) {
             LogUtil.e(AppConfig.TAG, "Failed to store imported profiles", e)
-            0 to 0
+            ConfigImportResult()
         }
     }
 
@@ -216,32 +219,37 @@ object AngConfigManager {
      * Parses a batch of subscriptions.
      *
      * @param servers The servers string.
-     * @return The number of subscriptions parsed.
+     * @return Imported and duplicate subscription counts.
      */
     private suspend fun parseBatchSubscription(
         servers: String?,
         requestSubscriptionName: (suspend (String?, Set<String>) -> String?)?
-    ): Int {
+    ): ConfigImportResult {
         try {
             if (servers == null) {
-                return 0
+                return ConfigImportResult()
             }
 
             var count = 0
+            var duplicates = 0
             servers.lines()
                 .distinct()
                 .forEach { str ->
                     if (Utils.isValidSubUrl(str)) {
-                        count += importUrlAsSubscription(str, requestSubscriptionName)
+                        when (importUrlAsSubscription(str, requestSubscriptionName)) {
+                            SubscriptionImportOutcome.Imported -> count++
+                            SubscriptionImportOutcome.Duplicate -> duplicates++
+                            SubscriptionImportOutcome.Cancelled -> Unit
+                        }
                     }
                 }
-            return count
+            return ConfigImportResult(subscriptionCount = count, duplicateSubscriptionCount = duplicates)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             LogUtil.e(AppConfig.TAG, "Failed to parse batch subscription", e)
         }
-        return 0
+        return ConfigImportResult()
     }
 
     /**
@@ -613,16 +621,16 @@ object AngConfigManager {
      * Imports a URL as a subscription.
      *
      * @param url The URL.
-     * @return The number of subscriptions imported.
+     * @return Whether the subscription was imported, already present, or cancelled.
      */
     private suspend fun importUrlAsSubscription(
         url: String,
         requestSubscriptionName: (suspend (String?, Set<String>) -> String?)?
-    ): Int {
+    ): SubscriptionImportOutcome {
         val subscriptions = MmkvManager.decodeSubscriptions()
         subscriptions.forEach {
             if (it.subscription.url == url) {
-                return 0
+                return SubscriptionImportOutcome.Duplicate
             }
         }
         val uri = URI(Utils.fixIllegalUrl(url))
@@ -630,15 +638,17 @@ object AngConfigManager {
             uri.fragment ?: "import sub"
         } else {
             requestSubscriptionName(uri.fragment, subscriptions.map { it.subscription.remarks }.toSet())
-                ?.trim()?.takeIf { it.isNotEmpty() } ?: return 0
+                ?.trim()?.takeIf { it.isNotEmpty() } ?: return SubscriptionImportOutcome.Cancelled
         }
         // Another import may have saved this URL while the naming dialog was open.
-        if (MmkvManager.decodeSubscriptions().any { it.subscription.url == url }) return 0
+        if (MmkvManager.decodeSubscriptions().any { it.subscription.url == url }) {
+            return SubscriptionImportOutcome.Duplicate
+        }
         val subItem = SubscriptionItem()
         subItem.remarks = remarks
         subItem.url = url
         MmkvManager.encodeSubscription("", subItem)
-        return 1
+        return SubscriptionImportOutcome.Imported
     }
 
     /** Generates a description for the profile.

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainActivity.kt
@@ -54,6 +54,10 @@ import kotlinx.coroutines.withContext
 
 class MainActivity : HelperBaseComponentActivity() {
 
+    companion object {
+        const val EXTRA_IMPORT_CONFIG = "importConfig"
+    }
+
     private val mainViewModel: MainViewModel by viewModels {
         MainViewModel.Factory(application, MainRepository(application as AngApplication))
     }
@@ -93,8 +97,20 @@ class MainActivity : HelperBaseComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mainViewModel.onAction(MainAction.Initialize)
+        if (savedInstanceState == null) importFromIntent(intent)
 
         checkAndRequestPermission(PermissionType.POST_NOTIFICATIONS) {}
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        importFromIntent(intent)
+    }
+
+    private fun importFromIntent(intent: Intent) {
+        val config = intent.getStringExtra(EXTRA_IMPORT_CONFIG) ?: return
+        intent.removeExtra(EXTRA_IMPORT_CONFIG)
+        mainViewModel.onAction(MainAction.ImportBatchConfig(config, subscriptionId = "", append = false))
     }
 
     @Composable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -26,7 +26,8 @@ data class MainUiState(
     val locateTarget: LocateTarget? = null,
     val confirmRemove: Boolean = false,
     val doubleColumnDisplay: Boolean = false,
-    val shareQRCodeBitmap: android.graphics.Bitmap? = null
+    val shareQRCodeBitmap: android.graphics.Bitmap? = null,
+    val subscriptionImportName: String? = null
 )
 
 /**
@@ -64,7 +65,14 @@ sealed interface MainAction {
     data class ShareFullContent(val guid: String) : MainAction
     data object DismissQRCodeDialog : MainAction
 
-    data class ImportBatchConfig(val configText: String) : MainAction
+    data class ImportBatchConfig(
+        val configText: String,
+        val subscriptionId: String? = null,
+        val append: Boolean = true
+    ) : MainAction
+    data class ChangeSubscriptionImportName(val name: String) : MainAction
+    data object ConfirmSubscriptionImport : MainAction
+    data object CancelSubscriptionImport : MainAction
 
     data object LocateHandled : MainAction
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainContract.kt
@@ -27,8 +27,10 @@ data class MainUiState(
     val confirmRemove: Boolean = false,
     val doubleColumnDisplay: Boolean = false,
     val shareQRCodeBitmap: android.graphics.Bitmap? = null,
-    val subscriptionImportName: String? = null
+    val subscriptionImport: SubscriptionImportState? = null
 )
+
+data class SubscriptionImportState(val url: String, val name: String)
 
 /**
  * All possible user interaction intents

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
@@ -1,5 +1,6 @@
 package com.v2ray.ang.ui.main
 
+import com.v2ray.ang.dto.ConfigImportResult
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -48,7 +49,7 @@ interface MainDataSource : Closeable {
         subscriptionId: String,
         updateUI: Boolean,
         requestSubscriptionName: suspend (String?, Set<String>) -> String?
-    ): Pair<Int, Int>
+    ): ConfigImportResult
 
     fun updateConfigViaSubAll(): SubscriptionUpdateResult
     fun updateConfigViaSub(subscriptionCache: SubscriptionCache): SubscriptionUpdateResult

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
@@ -46,7 +46,8 @@ interface MainDataSource : Closeable {
     suspend fun importBatchConfig(
         server: String?,
         subscriptionId: String,
-        updateUI: Boolean
+        updateUI: Boolean,
+        requestSubscriptionName: suspend (String?, Set<String>) -> String?
     ): Pair<Int, Int>
 
     fun updateConfigViaSubAll(): SubscriptionUpdateResult

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDataSource.kt
@@ -48,7 +48,7 @@ interface MainDataSource : Closeable {
         server: String?,
         subscriptionId: String,
         updateUI: Boolean,
-        requestSubscriptionName: suspend (String?, Set<String>) -> String?
+        requestSubscriptionName: suspend (String, String?, Set<String>) -> String?
     ): ConfigImportResult
 
     fun updateConfigViaSubAll(): SubscriptionUpdateResult

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.LayoutDirection
@@ -49,8 +48,6 @@ fun SubscriptionImportDialog(url: String, name: String, onAction: (MainAction) -
     AlertDialog(
         onDismissRequest = { onAction(MainAction.CancelSubscriptionImport) },
         modifier = Modifier.semantics { paneTitle = title },
-        // The pane announces the title, leaving the URL message as the first focus target.
-        title = { Text(title, modifier = Modifier.clearAndSetSemantics {}) },
         text = {
             Column(
                 Modifier

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -1,5 +1,7 @@
 package com.v2ray.ang.ui.main
 
+import android.view.accessibility.AccessibilityManager
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -18,25 +20,48 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.core.text.BidiFormatter
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 
 @Composable
-fun SubscriptionImportDialog(name: String, onAction: (MainAction) -> Unit) {
+fun SubscriptionImportDialog(url: String, name: String, onAction: (MainAction) -> Unit) {
     val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    val context = LocalContext.current
+    val title = stringResource(R.string.sub_import_title)
+    val displayUrl = BidiFormatter.getInstance(LocalLayoutDirection.current == LayoutDirection.Rtl).unicodeWrap(url)
+    val touchExplorationEnabled = remember(url, context) {
+        context.getSystemService(AccessibilityManager::class.java).isTouchExplorationEnabled
+    }
+    LaunchedEffect(url) {
+        // Leave TalkBack on the first readable item; other users can start typing immediately.
+        if (!touchExplorationEnabled) focusRequester.requestFocus()
+    }
 
     AlertDialog(
         onDismissRequest = { onAction(MainAction.CancelSubscriptionImport) },
-        title = { Text(stringResource(R.string.sub_import_title)) },
+        modifier = Modifier.semantics { paneTitle = title },
+        // The pane announces the title, leaving the URL message as the first focus target.
+        title = { Text(title, modifier = Modifier.clearAndSetSemantics {}) },
         text = {
             Column(
                 Modifier
                     .consumeWindowInsets(WindowInsets.navigationBars)
                     .imePadding()
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
+                Text(
+                    text = stringResource(R.string.sub_import_message, displayUrl)
+                )
                 OutlinedTextField(
                     value = name,
                     onValueChange = { onAction(MainAction.ChangeSubscriptionImportName(it)) },

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -1,9 +1,64 @@
 package com.v2ray.ang.ui.main
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import com.v2ray.ang.R
 import com.v2ray.ang.ui.compose.DeleteConfirmDialog
+
+@Composable
+fun SubscriptionImportDialog(name: String, onAction: (MainAction) -> Unit) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    AlertDialog(
+        onDismissRequest = { onAction(MainAction.CancelSubscriptionImport) },
+        title = { Text(stringResource(R.string.title_sub_setting)) },
+        text = {
+            Column(
+                Modifier
+                    .consumeWindowInsets(WindowInsets.navigationBars)
+                    .imePadding()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { onAction(MainAction.ChangeSubscriptionImportName(it)) },
+                    label = { Text(stringResource(R.string.sub_import_name)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().focusRequester(focusRequester)
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = name.isNotBlank(),
+                onClick = { onAction(MainAction.ConfirmSubscriptionImport) }
+            ) { Text(stringResource(R.string.action_ok)) }
+        },
+        dismissButton = {
+            TextButton(onClick = { onAction(MainAction.CancelSubscriptionImport) }) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        }
+    )
+}
 
 @Composable
 fun MainDialogs(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainDialogs.kt
@@ -29,7 +29,7 @@ fun SubscriptionImportDialog(name: String, onAction: (MainAction) -> Unit) {
 
     AlertDialog(
         onDismissRequest = { onAction(MainAction.CancelSubscriptionImport) },
-        title = { Text(stringResource(R.string.title_sub_setting)) },
+        title = { Text(stringResource(R.string.sub_import_title)) },
         text = {
             Column(
                 Modifier

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -184,8 +184,9 @@ class MainRepository(
     override suspend fun importBatchConfig(
         server: String?,
         subscriptionId: String,
-        updateUI: Boolean
-    ): Pair<Int, Int> = AngConfigManager.importBatchConfig(server, subscriptionId, updateUI)
+        updateUI: Boolean,
+        requestSubscriptionName: suspend (String?, Set<String>) -> String?
+    ): Pair<Int, Int> = AngConfigManager.importBatchConfig(server, subscriptionId, updateUI, requestSubscriptionName)
 
     override fun updateConfigViaSubAll(): SubscriptionUpdateResult =
         AngConfigManager.updateConfigViaSubAll()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -9,6 +9,7 @@ import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.ConnectionTestResult
+import com.v2ray.ang.dto.ConfigImportResult
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -186,7 +187,7 @@ class MainRepository(
         subscriptionId: String,
         updateUI: Boolean,
         requestSubscriptionName: suspend (String?, Set<String>) -> String?
-    ): Pair<Int, Int> = AngConfigManager.importBatchConfig(server, subscriptionId, updateUI, requestSubscriptionName)
+    ): ConfigImportResult = AngConfigManager.importBatchConfig(server, subscriptionId, updateUI, requestSubscriptionName)
 
     override fun updateConfigViaSubAll(): SubscriptionUpdateResult =
         AngConfigManager.updateConfigViaSubAll()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -186,7 +186,7 @@ class MainRepository(
         server: String?,
         subscriptionId: String,
         updateUI: Boolean,
-        requestSubscriptionName: suspend (String?, Set<String>) -> String?
+        requestSubscriptionName: suspend (String, String?, Set<String>) -> String?
     ): ConfigImportResult = AngConfigManager.importBatchConfig(server, subscriptionId, updateUI, requestSubscriptionName)
 
     override fun updateConfigViaSubAll(): SubscriptionUpdateResult =

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -115,6 +115,10 @@ fun MainScreen(
         onConfirmRemove = { guid -> showRemoveConfirm = null; onAction(MainAction.RemoveServer(guid)) }
     )
 
+    uiState.subscriptionImportName?.let { name ->
+        SubscriptionImportDialog(name = name, onAction = onAction)
+    }
+
     if (shareTarget != null) {
         val (guid, profile, more) = shareTarget!!
         ShareMethodDialog(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -115,8 +116,10 @@ fun MainScreen(
         onConfirmRemove = { guid -> showRemoveConfirm = null; onAction(MainAction.RemoveServer(guid)) }
     )
 
-    uiState.subscriptionImportName?.let { name ->
-        SubscriptionImportDialog(name = name, onAction = onAction)
+    uiState.subscriptionImport?.let { pending ->
+        key(pending.url) {
+            SubscriptionImportDialog(url = pending.url, name = pending.name, onAction = onAction)
+        }
     }
 
     if (shareTarget != null) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -219,11 +219,11 @@ class MainViewModel(
             is MainAction.ImportBatchConfig -> importBatchConfig(action)
             is MainAction.ChangeSubscriptionImportName -> {
                 _uiState.update {
-                    if (it.subscriptionImportName == null) it else it.copy(subscriptionImportName = action.name)
+                    it.copy(subscriptionImport = it.subscriptionImport?.copy(name = action.name))
                 }
             }
             MainAction.ConfirmSubscriptionImport -> {
-                uiState.value.subscriptionImportName?.trim()?.takeIf { it.isNotEmpty() }?.let {
+                uiState.value.subscriptionImport?.name?.trim()?.takeIf { it.isNotEmpty() }?.let {
                     subscriptionNameResult?.complete(it)
                 }
             }
@@ -454,8 +454,8 @@ class MainViewModel(
                         var cancelledSubscription = false
                         val (count, countSub, duplicateCount) = dataSource.importBatchConfig(
                             action.configText, subscriptionId, action.append
-                        ) { suggestedName, existingNames ->
-                            requestSubscriptionName(suggestedName, existingNames).also {
+                        ) { url, suggestedName, existingNames ->
+                            requestSubscriptionName(url, suggestedName, existingNames).also {
                                 if (it == null) cancelledSubscription = true
                             }
                         }
@@ -486,20 +486,20 @@ class MainViewModel(
         }
     }
 
-    private suspend fun requestSubscriptionName(suggestedName: String?, existingNames: Set<String>): String? =
+    private suspend fun requestSubscriptionName(url: String, suggestedName: String?, existingNames: Set<String>): String? =
         withContext(Dispatchers.Main.immediate) {
             val result = CompletableDeferred<String?>()
             subscriptionNameResult = result
             val baseName = suggestedName?.takeIf { it.isNotBlank() }
                 ?: dataSource.getString(R.string.sub_import_default_name)
             _uiState.update {
-                it.copy(subscriptionImportName = uniqueSubscriptionName(baseName, existingNames))
+                it.copy(subscriptionImport = SubscriptionImportState(url, uniqueSubscriptionName(baseName, existingNames)))
             }
             try {
                 result.await()
             } finally {
                 subscriptionNameResult = null
-                _uiState.update { it.copy(subscriptionImportName = null) }
+                _uiState.update { it.copy(subscriptionImport = null) }
             }
         }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -452,7 +452,7 @@ class MainViewModel(
                 withContext(ioDispatcher) {
                     try {
                         var cancelledSubscription = false
-                        val (count, countSub) = dataSource.importBatchConfig(
+                        val (count, countSub, duplicateCount) = dataSource.importBatchConfig(
                             action.configText, subscriptionId, action.append
                         ) { suggestedName, existingNames ->
                             requestSubscriptionName(suggestedName, existingNames).also {
@@ -466,6 +466,11 @@ class MainViewModel(
                             }
 
                             countSub > 0 -> setupGroupTab(forceRefresh = true)
+                            duplicateCount > 0 -> toastError(
+                                localizedContext.resources.getQuantityString(
+                                    R.plurals.import_subscription_duplicate, duplicateCount
+                                )
+                            )
                             !cancelledSubscription -> toastError(R.string.toast_failure)
                         }
                     } catch (cancelled: CancellationException) {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -40,6 +40,15 @@ import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.PatternSyntaxException
 
+internal fun uniqueSubscriptionName(baseName: String, existingNames: Set<String>): String {
+    var name = baseName
+    var suffix = 2
+    while (name in existingNames) {
+        name = "$baseName ${suffix++}"
+    }
+    return name
+}
+
 class MainViewModel(
     application: Application,
     private val dataSource: MainDataSource
@@ -77,6 +86,8 @@ class MainViewModel(
     private var preloadJob: Job? = null
     private var selectedGroupLoadJob: Job? = null
     private var reloadJob: Job? = null
+    private val importMutex = Mutex()
+    private var subscriptionNameResult: CompletableDeferred<String?>? = null
 
     @Volatile
     private var testingGroupId: String? = null
@@ -205,7 +216,18 @@ class MainViewModel(
             is MainAction.SelectServer -> updateSelectedGuid(action.guid)
             is MainAction.RemoveServer -> removeServerAndRefresh(action.guid)
             is MainAction.Search -> filterConfig(action.query)
-            is MainAction.ImportBatchConfig -> importBatchConfig(action.configText)
+            is MainAction.ImportBatchConfig -> importBatchConfig(action)
+            is MainAction.ChangeSubscriptionImportName -> {
+                _uiState.update {
+                    if (it.subscriptionImportName == null) it else it.copy(subscriptionImportName = action.name)
+                }
+            }
+            MainAction.ConfirmSubscriptionImport -> {
+                uiState.value.subscriptionImportName?.trim()?.takeIf { it.isNotEmpty() }?.let {
+                    subscriptionNameResult?.complete(it)
+                }
+            }
+            MainAction.CancelSubscriptionImport -> subscriptionNameResult?.complete(null)
             MainAction.LocateHandled -> consumeLocateTarget()
             is MainAction.ShareQRCode -> {
                 val bitmap = dataSource.share2QRCode(action.guid)
@@ -422,31 +444,59 @@ class MainViewModel(
     }
 
     // ---------- Business actions (coroutine-based) ----------
-    private fun importBatchConfig(configText: String) {
+    private fun importBatchConfig(action: MainAction.ImportBatchConfig) {
+        if (!importMutex.tryLock()) return
+        val subscriptionId = action.subscriptionId ?: uiState.value.selectedGroupId
         launchLoading {
-            withContext(ioDispatcher) {
-                try {
-                    val (count, countSub) = dataSource.importBatchConfig(
-                        configText, uiState.value.selectedGroupId, true
-                    )
-                    when {
-                        count > 0 -> {
-                            toast(dataSource.getString(R.string.title_import_config_count, count))
-                            setupGroupTab(forceRefresh = true)
+            try {
+                withContext(ioDispatcher) {
+                    try {
+                        var cancelledSubscription = false
+                        val (count, countSub) = dataSource.importBatchConfig(
+                            action.configText, subscriptionId, action.append
+                        ) { suggestedName, existingNames ->
+                            requestSubscriptionName(suggestedName, existingNames).also {
+                                if (it == null) cancelledSubscription = true
+                            }
                         }
+                        when {
+                            count > 0 -> {
+                                toast(dataSource.getString(R.string.title_import_config_count, count))
+                                setupGroupTab(forceRefresh = true)
+                            }
 
-                        countSub > 0 -> setupGroupTab(forceRefresh = true)
-                        else -> toastError(R.string.toast_failure)
+                            countSub > 0 -> setupGroupTab(forceRefresh = true)
+                            !cancelledSubscription -> toastError(R.string.toast_failure)
+                        }
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (e: Exception) {
+                        LogUtil.e(AppConfig.TAG, "Failed to import batch config", e)
+                        toastError(R.string.toast_failure)
                     }
-                } catch (cancelled: CancellationException) {
-                    throw cancelled
-                } catch (e: Exception) {
-                    LogUtil.e(AppConfig.TAG, "Failed to import batch config", e)
-                    toastError(R.string.toast_failure)
                 }
+            } finally {
+                importMutex.unlock()
             }
         }
     }
+
+    private suspend fun requestSubscriptionName(suggestedName: String?, existingNames: Set<String>): String? =
+        withContext(Dispatchers.Main.immediate) {
+            val result = CompletableDeferred<String?>()
+            subscriptionNameResult = result
+            val baseName = suggestedName?.takeIf { it.isNotBlank() }
+                ?: dataSource.getString(R.string.sub_import_default_name)
+            _uiState.update {
+                it.copy(subscriptionImportName = uniqueSubscriptionName(baseName, existingNames))
+            }
+            try {
+                result.await()
+            } finally {
+                subscriptionNameResult = null
+                _uiState.update { it.copy(subscriptionImportName = null) }
+            }
+        }
 
     private fun importConfigViaSub() {
         val subId = uiState.value.selectedGroupId

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/shortcut/ScScannerActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/shortcut/ScScannerActivity.kt
@@ -4,10 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import com.v2ray.ang.R
-import com.v2ray.ang.extension.toastError
-import com.v2ray.ang.extension.toastSuccess
-import com.v2ray.ang.handler.AngConfigManager
 import com.v2ray.ang.ui.base.HelperBaseComponentActivity
 import com.v2ray.ang.ui.main.MainActivity
 
@@ -27,15 +23,9 @@ class ScScannerActivity : HelperBaseComponentActivity() {
     private fun importQRcode() {
         launchQRCodeScanner { scanResult ->
             if (scanResult != null) {
-                val (count, countSub) = AngConfigManager.importBatchConfig(scanResult, "", false)
-
-                if (count + countSub > 0) {
-                    toastSuccess(R.string.toast_success)
-                } else {
-                    toastError(R.string.toast_failure)
-                }
-
-                startActivity(Intent(this, MainActivity::class.java))
+                startActivity(Intent(this, MainActivity::class.java).apply {
+                    putExtra(MainActivity.EXTRA_IMPORT_CONFIG, scanResult)
+                })
             }
             finish()
         }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -551,4 +551,12 @@
     <string name="sub_import_title">تسمية مجموعة الاشتراك</string>
     <string name="sub_import_name">اسم الاشتراك</string>
     <string name="sub_import_default_name">اشتراك مستورد</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="zero">هذه الاشتراكات موجودة بالفعل.</item>
+        <item quantity="one">هذا الاشتراك موجود بالفعل.</item>
+        <item quantity="two">هذان الاشتراكان موجودان بالفعل.</item>
+        <item quantity="few">هذه الاشتراكات موجودة بالفعل.</item>
+        <item quantity="many">هذه الاشتراكات موجودة بالفعل.</item>
+        <item quantity="other">هذه الاشتراكات موجودة بالفعل.</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">لا تتوفر تفاصيل</string>
     <string name="value_unknown">غير معروف</string>
 
+    <string name="sub_import_title">تسمية مجموعة الاشتراك</string>
     <string name="sub_import_name">اسم الاشتراك</string>
     <string name="sub_import_default_name">اشتراك مستورد</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">لا تتوفر تفاصيل</string>
     <string name="value_unknown">غير معروف</string>
 
+    <string name="sub_import_name">اسم الاشتراك</string>
+    <string name="sub_import_default_name">اشتراك مستورد</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">غير معروف</string>
 
     <string name="sub_import_title">تسمية مجموعة الاشتراك</string>
+    <string name="sub_import_message">أدخل اسمًا لمجموعة الاشتراك: %1$s.</string>
     <string name="sub_import_name">اسم الاشتراك</string>
     <string name="sub_import_default_name">اشتراك مستورد</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">অজানা</string>
 
     <string name="sub_import_title">সাবস্ক্রিপশন গ্রুপের নাম দিন</string>
+    <string name="sub_import_message">সাবস্ক্রিপশন গ্রুপের নাম দিন: %1$s।</string>
     <string name="sub_import_name">সাবস্ক্রিপশনের নাম</string>
     <string name="sub_import_default_name">আমদানি করা সাবস্ক্রিপশন</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">কোনো বিবরণ পাওয়া যায়নি</string>
     <string name="value_unknown">অজানা</string>
 
+    <string name="sub_import_name">সাবস্ক্রিপশনের নাম</string>
+    <string name="sub_import_default_name">আমদানি করা সাবস্ক্রিপশন</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -551,4 +551,8 @@
     <string name="sub_import_title">সাবস্ক্রিপশন গ্রুপের নাম দিন</string>
     <string name="sub_import_name">সাবস্ক্রিপশনের নাম</string>
     <string name="sub_import_default_name">আমদানি করা সাবস্ক্রিপশন</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="one">এই সাবস্ক্রিপশনটি ইতিমধ্যেই আছে।</item>
+        <item quantity="other">এই সাবস্ক্রিপশনগুলো ইতিমধ্যেই আছে।</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">কোনো বিবরণ পাওয়া যায়নি</string>
     <string name="value_unknown">অজানা</string>
 
+    <string name="sub_import_title">সাবস্ক্রিপশন গ্রুপের নাম দিন</string>
     <string name="sub_import_name">সাবস্ক্রিপশনের নাম</string>
     <string name="sub_import_default_name">আমদানি করা সাবস্ক্রিপশন</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">دووسمندی نؽ</string>
     <string name="value_unknown">نا مؽخص</string>
 
+    <string name="sub_import_name">نوم اشتراک</string>
+    <string name="sub_import_default_name">اشتراک وارد وابیده</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -548,12 +548,12 @@
     <string name="connection_test_empty_message">دووسمندی نؽ</string>
     <string name="value_unknown">نا مؽخص</string>
 
-    <string name="sub_import_title">نوم‌گذاری گروه اشتراک</string>
-    <string name="sub_import_message">نوم گروه اشتراک ن وارد کُنید: %1$s.</string>
+    <string name="sub_import_title">نوم ناهاڌن بونکۊ اشتراک</string>
+    <string name="sub_import_message">نوم بونکۊ اشتراک ن بزنین: %1$s.</string>
     <string name="sub_import_name">نوم اشتراک</string>
-    <string name="sub_import_default_name">اشتراک وارد وابیده</string>
+    <string name="sub_import_default_name">اشتراک و من ٱوورده وابیڌه</string>
     <plurals name="import_subscription_duplicate">
         <item quantity="one">ای اشتراک ز زیتر بیڌس</item>
-        <item quantity="other">ای اشتراکا ز زیتر بیڌن</item>
+        <item quantity="other">ای اشتراکا ز زیتر بیڌسووݩ</item>
     </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">نا مؽخص</string>
 
     <string name="sub_import_title">نوم‌گذاری گروه اشتراک</string>
+    <string name="sub_import_message">نوم گروه اشتراک ن وارد کُنید: %1$s.</string>
     <string name="sub_import_name">نوم اشتراک</string>
     <string name="sub_import_default_name">اشتراک وارد وابیده</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -551,4 +551,8 @@
     <string name="sub_import_title">نوم‌گذاری گروه اشتراک</string>
     <string name="sub_import_name">نوم اشتراک</string>
     <string name="sub_import_default_name">اشتراک وارد وابیده</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="one">ای اشتراک ز زیتر بیڌس</item>
+        <item quantity="other">ای اشتراکا ز زیتر بیڌن</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">دووسمندی نؽ</string>
     <string name="value_unknown">نا مؽخص</string>
 
+    <string name="sub_import_title">نوم‌گذاری گروه اشتراک</string>
     <string name="sub_import_name">نوم اشتراک</string>
     <string name="sub_import_default_name">اشتراک وارد وابیده</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -551,4 +551,8 @@
     <string name="sub_import_title">نام‌گذاری گروه اشتراک</string>
     <string name="sub_import_name">نام اشتراک</string>
     <string name="sub_import_default_name">اشتراک واردشده</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="one">این اشتراک از قبل وجود دارد.</item>
+        <item quantity="other">این اشتراک‌ها از قبل وجود دارند.</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">ناشناخته</string>
 
     <string name="sub_import_title">نام‌گذاری گروه اشتراک</string>
+    <string name="sub_import_message">نام گروه اشتراک را وارد کنید: %1$s.</string>
     <string name="sub_import_name">نام اشتراک</string>
     <string name="sub_import_default_name">اشتراک واردشده</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">جزئیاتی در دسترس نیست</string>
     <string name="value_unknown">ناشناخته</string>
 
+    <string name="sub_import_name">نام اشتراک</string>
+    <string name="sub_import_default_name">اشتراک واردشده</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">جزئیاتی در دسترس نیست</string>
     <string name="value_unknown">ناشناخته</string>
 
+    <string name="sub_import_title">نام‌گذاری گروه اشتراک</string>
     <string name="sub_import_name">نام اشتراک</string>
     <string name="sub_import_default_name">اشتراک واردشده</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">подробности отсутствуют</string>
     <string name="value_unknown">неизвестно</string>
 
+    <string name="sub_import_name">Название подписки</string>
+    <string name="sub_import_default_name">Импортированная подписка</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">подробности отсутствуют</string>
     <string name="value_unknown">неизвестно</string>
 
+    <string name="sub_import_title">Назовите группу подписки</string>
     <string name="sub_import_name">Название подписки</string>
     <string name="sub_import_default_name">Импортированная подписка</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">неизвестно</string>
 
     <string name="sub_import_title">Назовите группу подписки</string>
+    <string name="sub_import_message">Укажите название группы подписки: %1$s.</string>
     <string name="sub_import_name">Название подписки</string>
     <string name="sub_import_default_name">Импортированная подписка</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -551,4 +551,10 @@
     <string name="sub_import_title">Назовите группу подписки</string>
     <string name="sub_import_name">Название подписки</string>
     <string name="sub_import_default_name">Импортированная подписка</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="one">Эта подписка уже существует.</item>
+        <item quantity="few">Эти подписки уже существуют.</item>
+        <item quantity="many">Эти подписки уже существуют.</item>
+        <item quantity="other">Эти подписки уже существуют.</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">không xác định</string>
 
     <string name="sub_import_title">Đặt tên nhóm đăng ký</string>
+    <string name="sub_import_message">Nhập tên cho nhóm đăng ký: %1$s.</string>
     <string name="sub_import_name">Tên đăng ký</string>
     <string name="sub_import_default_name">Đăng ký đã nhập</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">không có thông tin chi tiết</string>
     <string name="value_unknown">không xác định</string>
 
+    <string name="sub_import_name">Tên đăng ký</string>
+    <string name="sub_import_default_name">Đăng ký đã nhập</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -551,4 +551,7 @@
     <string name="sub_import_title">Đặt tên nhóm đăng ký</string>
     <string name="sub_import_name">Tên đăng ký</string>
     <string name="sub_import_default_name">Đăng ký đã nhập</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="other">Gói đăng ký đã tồn tại.</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">không có thông tin chi tiết</string>
     <string name="value_unknown">không xác định</string>
 
+    <string name="sub_import_title">Đặt tên nhóm đăng ký</string>
     <string name="sub_import_name">Tên đăng ký</string>
     <string name="sub_import_default_name">Đăng ký đã nhập</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">无详细信息</string>
     <string name="value_unknown">未知</string>
 
+    <string name="sub_import_title">为订阅分组命名</string>
     <string name="sub_import_name">订阅名称</string>
     <string name="sub_import_default_name">导入订阅</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">未知</string>
 
     <string name="sub_import_title">为订阅分组命名</string>
+    <string name="sub_import_message">请为订阅分组命名：%1$s。</string>
     <string name="sub_import_name">订阅名称</string>
     <string name="sub_import_default_name">导入订阅</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -551,4 +551,7 @@
     <string name="sub_import_title">为订阅分组命名</string>
     <string name="sub_import_name">订阅名称</string>
     <string name="sub_import_default_name">导入订阅</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="other">订阅已存在。</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">无详细信息</string>
     <string name="value_unknown">未知</string>
 
+    <string name="sub_import_name">订阅名称</string>
+    <string name="sub_import_default_name">导入订阅</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">未知</string>
 
     <string name="sub_import_title">為訂閱群組命名</string>
+    <string name="sub_import_message">請為訂閱群組命名：%1$s。</string>
     <string name="sub_import_name">訂閱名稱</string>
     <string name="sub_import_default_name">匯入訂閱</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">沒有詳細資訊</string>
     <string name="value_unknown">未知</string>
 
+    <string name="sub_import_title">為訂閱群組命名</string>
     <string name="sub_import_name">訂閱名稱</string>
     <string name="sub_import_default_name">匯入訂閱</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -551,4 +551,7 @@
     <string name="sub_import_title">為訂閱群組命名</string>
     <string name="sub_import_name">訂閱名稱</string>
     <string name="sub_import_default_name">匯入訂閱</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="other">訂閱已存在。</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">沒有詳細資訊</string>
     <string name="value_unknown">未知</string>
 
+    <string name="sub_import_name">訂閱名稱</string>
+    <string name="sub_import_default_name">匯入訂閱</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -551,4 +551,8 @@
     <string name="sub_import_title">Name subscription group</string>
     <string name="sub_import_name">Subscription name</string>
     <string name="sub_import_default_name">import sub</string>
+    <plurals name="import_subscription_duplicate">
+        <item quantity="one">This subscription already exists.</item>
+        <item quantity="other">These subscriptions already exist.</item>
+    </plurals>
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -548,4 +548,6 @@
     <string name="connection_test_empty_message">no details available</string>
     <string name="value_unknown">unknown</string>
 
+    <string name="sub_import_name">Subscription name</string>
+    <string name="sub_import_default_name">import sub</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -548,6 +548,7 @@
     <string name="connection_test_empty_message">no details available</string>
     <string name="value_unknown">unknown</string>
 
+    <string name="sub_import_title">Name subscription group</string>
     <string name="sub_import_name">Subscription name</string>
     <string name="sub_import_default_name">import sub</string>
 </resources>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -549,6 +549,7 @@
     <string name="value_unknown">unknown</string>
 
     <string name="sub_import_title">Name subscription group</string>
+    <string name="sub_import_message">Provide the name for the subscription group: %1$s.</string>
     <string name="sub_import_name">Subscription name</string>
     <string name="sub_import_default_name">import sub</string>
     <plurals name="import_subscription_duplicate">

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/SubscriptionImportNameTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/main/SubscriptionImportNameTest.kt
@@ -1,0 +1,32 @@
+package com.v2ray.ang.ui.main
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SubscriptionImportNameTest {
+    @Test
+    fun `uses the placeholder when it is available`() {
+        assertEquals("import sub", uniqueSubscriptionName("import sub", setOf("Other", "import sub 2")))
+    }
+
+    @Test
+    fun `suffix starts at two and skips existing names`() {
+        assertEquals("import sub 4", uniqueSubscriptionName("import sub", setOf("import sub", "import sub 2", "import sub 3")))
+    }
+
+    @Test
+    fun `uses the first free suffix`() {
+        assertEquals("import sub 3", uniqueSubscriptionName("import sub", setOf("import sub", "import sub 2", "import sub 4")))
+    }
+
+    @Test
+    fun `preserves names supplied by the subscription link`() {
+        assertEquals("My group", uniqueSubscriptionName("My group", emptySet()))
+        assertEquals("My group 2", uniqueSubscriptionName("My group", setOf("My group")))
+    }
+
+    @Test
+    fun `supports localized placeholders`() {
+        assertEquals("Подписка 2", uniqueSubscriptionName("Подписка", setOf("Подписка")))
+    }
+}


### PR DESCRIPTION
Clipboard and QR imports currently save new subscription groups immediately. Links without a name all receive the same `import sub` placeholder, leaving users with indistinguishable groups to rename afterward. A batch can contain several subscription URLs, so the naming prompt also needs to identify the URL being imported.

This change asks for a name before saving each new subscription group. The dialog has no visible heading and shows **Provide the name for the subscription group: [URL].**, one prefilled text field, and **OK / Cancel** buttons.

- Suggest the URL fragment's name when available, or a localized placeholder otherwise. Choose the first available suffix when the suggestion already exists: `import sub 2`, `import sub 3`, and so on.
- Save only after OK, trim the confirmed name, and disable OK for blank input. Cancel or dismiss skips only the current subscription; a batch continues with the next URL. Previously confirmed groups remain saved.
- Keep the URL and draft name together in the main ViewModel, preserving their association across activity recreation. Key the dialog by URL so each item in a batch gets its own initial focus.
- With TalkBack enabled, let the URL sentence receive initial accessibility focus. Retain a localized accessible pane title without a visible heading, and avoid automatically focusing the editor. Without touch exploration, retain immediate typing in the name field.
- Skip existing subscription URLs, including a recheck after confirmation. When only existing subscriptions are supplied, show localized singular/plural duplicate feedback instead of a generic failure.

Clipboard, QR, and local-file actions share this pipeline. The QR scanner shortcut uses the same confirmation flow while retaining its target-group and append behavior. Ordinary proxy profiles import without prompting, and URL-scheme imports retain their automatic behavior. No existing groups are renamed; storage formats and native dependencies are unchanged. All dialog strings are localized in the nine supported catalogs, with bidirectional formatting around URLs in right-to-left layouts.

Bakhtiari subscription-import wording now matches the [native-speaker correction from hosseinabaspanah in PR #6169](https://github.com/2dust/v2rayNG/pull/6169#issuecomment-5512959269). Four values changed; the field label and singular duplicate message already matched. Resource IDs, plural categories, and the URL placeholder are unchanged.

For the wording-only update at `424b4d32`, XML parsing, exact comparison against all six supplied values, and `git diff --check` passed. **Not run:** builds and tests for this update, as requested.

Earlier functional validation on `7250f15a` (before the Bakhtiari wording correction):

- All 62 Play Store debug JVM tests passed; Kotlin compilation, Play Store debug assembly, and Android-test assembly passed.
- All seven subscription-import instrumentation tests passed on Pixel 6a / Android 13 (API 33), x86_64, with TalkBack enabled and disabled. Coverage includes actual clipboard import, three sequential unnamed URLs, initial accessibility/editor focus, localized message and pane title, OK/Cancel, suffix reuse, recreation, duplicate/concurrent imports, Base64 batches, and ordinary proxy imports.
- The three-URL focus test also passed in Russian and Arabic. It asserts actual native accessibility focus on the URL sentence without requesting focus from the test.
- Checked the heading-free English and Arabic layouts, longer URL wrapping, and the English dialog with the IME visible. Runtime QA used a separate package to preserve the installed app's data. Earlier validation on `477c6b4c` also covered touch confirmation, persisted names after reopening, Tab/Enter cancellation, and D-pad button traversal/activation.
- Earlier validation exercised QR decoding through the scanner's image picker; camera decoding code is unchanged.

Not run: physical-camera QR scanning, end-to-end TalkBack touch gestures or spoken-audio verification, and speech fluency in every locale. The accessibility checks establish native focus, text, title, and action behavior, not complete spoken traversal.

Known accessibility limitation: the editable field's label can be encountered during character/word navigation in the current Compose implementation. Field labeling is unchanged here, pending stable native hint support across the common text fields. No alpha dependency upgrade or editable-field content-description replacement is included. See the [follow-up explanation](https://github.com/2dust/v2rayNG/pull/6174#issuecomment-5508724711).
