### PR TITLE
feat add-proc-resolver-pre-android-q

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import libv2ray.CoreCallbackHandler
 import libv2ray.CoreController
+import libv2ray.Libv2ray
 import libv2ray.ProcessFinder
 import java.lang.ref.SoftReference
 import java.net.InetSocketAddress
@@ -59,7 +60,7 @@ object CoreServiceManager {
             field = value
             val service = value?.get()?.getService()
             CoreNativeManager.initCoreEnv(service)
-            if (service != null && processFinder == null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            if (service != null && processFinder == null) {
                 processFinder = XrayProcessFinder(service)
                 coreController.registerProcessFinder(processFinder)
             }
@@ -395,7 +396,13 @@ object CoreServiceManager {
         private val cm: ConnectivityManager? = context.getSystemService(ConnectivityManager::class.java)
 
         override fun findProcessByConnection(network: String, srcIP: String, srcPort: Long, destIP: String, destPort: Long): Long {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return -1L
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                return try {
+                    Libv2ray.resolveUidFromProc(network, srcIP, srcPort, destIP, destPort)
+                } catch (_: Exception) {
+                    -1L
+                }
+            }
             if (cm == null) return -1L
             val proto = when (network) {
                 "tcp" -> OsConstants.IPPROTO_TCP


### PR DESCRIPTION
@2dust Before there was no way to use the uid based per app routing for api < 29. So for those pre q devices what we do is parse the proc files and find the uid of the app owning the connection and pass into xray.

first this need to be merged : https://github.com/2dust/AndroidLibXrayLite/pull/206 