### PR TITLE
Fix asset cache deletion before save validation

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetUrlActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetUrlActivity.kt
@@ -81,6 +81,20 @@ class UserAssetUrlActivity : BaseComponentActivity() {
     }
 
     private fun saveServer(remarks: String, url: String): Boolean {
+        val assetList = MmkvManager.decodeAssetUrls()
+        if (assetList.any { it.assetUrl.remarks == remarks && it.guid != editAssetId }) {
+            toast(R.string.msg_remark_is_duplicate)
+            return false
+        }
+        if (TextUtils.isEmpty(remarks)) {
+            toast(R.string.sub_setting_remarks)
+            return false
+        }
+        if (TextUtils.isEmpty(url)) {
+            toast(R.string.title_url)
+            return false
+        }
+
         var assetItem = MmkvManager.decodeAsset(editAssetId)
         var assetId = editAssetId
         if (assetItem != null) {
@@ -99,20 +113,6 @@ class UserAssetUrlActivity : BaseComponentActivity() {
 
         assetItem.remarks = remarks
         assetItem.url = url
-
-        val assetList = MmkvManager.decodeAssetUrls()
-        if (assetList.any { it.assetUrl.remarks == assetItem.remarks && it.guid != assetId }) {
-            toast(R.string.msg_remark_is_duplicate)
-            return false
-        }
-        if (TextUtils.isEmpty(assetItem.remarks)) {
-            toast(R.string.sub_setting_remarks)
-            return false
-        }
-        if (TextUtils.isEmpty(assetItem.url)) {
-            toast(R.string.title_url)
-            return false
-        }
 
         MmkvManager.encodeAsset(assetId, assetItem)
         toastSuccess(R.string.toast_success)


### PR DESCRIPTION
## Problem

Saving an edited asset source deletes its cached file before validating the submitted name and URL. An empty field or duplicate name therefore rejects the edit but still removes the downloaded asset, leaving the saved source unchanged and its file missing.

## Fix

Move the existing three validation checks ahead of cache deletion and asset mutation. Validate the submitted values directly and exclude the edited asset by its ID when checking duplicate names.

The validation messages and their order are unchanged. Successful saves still invalidate the cache; a rename deletes the **old** filename before updating the record.

This is a single-file ordering fix based on current master, independent of the accessibility work in #6159. No new helpers, dependencies, resources, or accessibility changes.

## Validation

- `:app:testPlaystoreDebugUnitTest`: 70 tests passed.
- `:app:compilePlaystoreDebugKotlin` and `:app:assemblePlaystoreDebug`: passed.
- Pixel 9 Pro emulator, Android 17 (API 37.1), x86_64: reproduced the empty-URL cache deletion on the previous build. On this branch, empty name, empty URL, and duplicate-name saves preserve both the cached file SHA-256 and the asset-store SHA-256. Closing and reopening the editor retains the original values.
- Accepted unchanged-name saves and renames still remove the old cached file; reopening verifies the saved name and URL.
- `git diff --check` passed. Merge checks with the current #6159 branch pass in either order with identical resulting trees.

**Not run:** a dedicated JVM test of the private Activity/MMKV save path; the regression was checked on the emulator without introducing a test-only production abstraction. Separate keyboard/D-pad and physical-device checks were not run; the input handling and UI are unchanged.
