### PR TITLE
UI/UX: Preserve asset-editor drafts during recompose

### DIFF
--- a/V2rayNG/app/src/main/AndroidManifest.xml
+++ b/V2rayNG/app/src/main/AndroidManifest.xml
@@ -153,6 +153,7 @@
             android:exported="false" />
         <activity
             android:name=".ui.userasset.UserAssetUrlActivity"
+            android:windowSoftInputMode="stateUnchanged|adjustResize"
             android:exported="false" />
 
         <activity

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetUrlActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetUrlActivity.kt
@@ -4,15 +4,19 @@ import android.os.Bundle
 import android.text.TextUtils
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -138,9 +142,9 @@ fun UserAssetUrlScreen(
     onSave: (String, String) -> Boolean,
     onDelete: () -> Unit
 ) {
-    var remarks by remember { mutableStateOf(initialRemarks) }
-    var url by remember { mutableStateOf(initialUrl) }
-    var showDeleteConfirm by remember { mutableStateOf(false) }
+    var remarks by rememberSaveable(editAssetId, initialRemarks) { mutableStateOf(initialRemarks) }
+    var url by rememberSaveable(editAssetId, initialUrl) { mutableStateOf(initialUrl) }
+    var showDeleteConfirm by rememberSaveable(editAssetId) { mutableStateOf(false) }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0),
@@ -171,6 +175,9 @@ fun UserAssetUrlScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
+                .imePadding()
+                .verticalScroll(rememberScrollState())
                 .padding(vertical = 8.dp)
         ) {
             FormTextField(


### PR DESCRIPTION
Keep the asset name, URL, and delete-confirmation visibility in saveable Compose state so activity recreation (screen rotation, light/dark mode switches) does not discard an unfinished edit. Key the state by asset identity and initial field values.

Make the form vertically scrollable, consume the Scaffold padding, and apply IME padding so its fields remain reachable when the keyboard reduces the available height.