### PR TITLE
I18n: Use completed-action wording and plurals for update results

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/base/BaseViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/base/BaseViewModel.kt
@@ -97,6 +97,13 @@ abstract class BaseViewModel(application: Application) : AndroidViewModel(applic
     }
 
     /**
+     * Get a localized quantity string from a plurals resource.
+     */
+    fun getQuantityString(resId: Int, quantity: Int, vararg formatArgs: Any): String {
+        return localizedContext.resources.getQuantityString(resId, quantity, *formatArgs)
+    }
+
+    /**
      * Send finish activity event.
      */
     fun finishActivity() {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -464,7 +464,13 @@ class MainViewModel(
                             toast(R.string.title_update_subscription_no_subscription)
 
                         result.successCount > 0 && result.failureCount + result.skipCount == 0 ->
-                            toast(dataSource.getString(R.string.title_update_config_count, result.configCount))
+                            toast(
+                                getQuantityString(
+                                    R.plurals.title_update_config_count,
+                                    result.configCount,
+                                    result.configCount,
+                                )
+                            )
 
                         else ->
                             toast(dataSource.getString(R.string.title_update_subscription_result, result.configCount, result.successCount, result.failureCount, result.skipCount))

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/subscription/SubscriptionsViewModel.kt
@@ -87,7 +87,13 @@ class SubscriptionsViewModel(application: Application) : BaseViewModel(applicati
                         toast(R.string.title_update_subscription_no_subscription)
 
                     result.successCount > 0 && result.failureCount + result.skipCount == 0 ->
-                        toast(getString(R.string.title_update_config_count, result.configCount))
+                        toast(
+                            getQuantityString(
+                                R.plurals.title_update_config_count,
+                                result.configCount,
+                                result.configCount,
+                            )
+                        )
 
                     else ->
                         toast(getString(R.string.title_update_subscription_result, result.configCount, result.successCount, result.failureCount, result.skipCount))

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/userasset/UserAssetActivity.kt
@@ -219,7 +219,13 @@ class UserAssetActivity : HelperBaseComponentActivity() {
                 viewModel.downloadGeoFiles(extDir, httpPort, proxyUsername, proxyPassword)
             }
             if (result.successCount > 0) {
-                toast(getString(R.string.title_update_asset_count, result.successCount))
+                toast(
+                    resources.getQuantityString(
+                        R.plurals.title_update_asset_count,
+                        result.successCount,
+                        result.successCount,
+                    )
+                )
             } else {
                 toast(getString(R.string.toast_failure))
             }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -351,8 +351,22 @@
     <string name="title_del_config_count">حذف %d من التكوينات</string>
     <string name="title_import_config_count">استيراد %d من التكوينات</string>
     <string name="title_export_config_count">تصدير %d من التكوينات</string>
-    <string name="title_update_config_count">تحديث %d من التكوينات</string>
-    <string name="title_update_asset_count">تم تحديث %d من ملفات الأصول</string>
+    <plurals name="title_update_config_count">
+        <item quantity="zero">لم يتم تحديث أي تكوينات</item>
+        <item quantity="one">تم تحديث تكوين واحد</item>
+        <item quantity="two">تم تحديث تكوينين</item>
+        <item quantity="few">تم تحديث %1$d تكوينات</item>
+        <item quantity="many">تم تحديث %1$d تكوينًا</item>
+        <item quantity="other">تم تحديث %1$d تكوين</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="zero">لم يتم تحديث أي ملفات أصول</item>
+        <item quantity="one">تم تحديث ملف أصول واحد</item>
+        <item quantity="two">تم تحديث ملفي أصول</item>
+        <item quantity="few">تم تحديث %1$d ملفات أصول</item>
+        <item quantity="many">تم تحديث %1$d ملف أصول</item>
+        <item quantity="other">تم تحديث %1$d ملف أصول</item>
+    </plurals>
     <string name="title_update_subscription_result">تم تحديث %1$d إعدادات (%2$d ناجحة، %3$d فاشلة، %4$d متخطاة)</string>
     <string name="title_update_subscription_no_subscription">لا توجد اشتراكات</string>
     <string name="toast_server_not_found_in_group">لم يُعثر على الخادم المحدد في المجموعة الحالية</string>

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -351,8 +351,14 @@
     <string name="title_del_config_count">%dটি কনফিগারেশন মুছুন</string>
     <string name="title_import_config_count">%dটি কনফিগারেশন আমদানি করুন</string>
     <string name="title_export_config_count">%dটি কনফিগারেশন রপ্তানি করুন</string>
-    <string name="title_update_config_count">%dটি কনফিগারেশন আপডেট করুন</string>
-    <string name="title_update_asset_count">%dটি অ্যাসেট ফাইল আপডেট হয়েছে</string>
+    <plurals name="title_update_config_count">
+        <item quantity="one">%1$dটি কনফিগারেশন আপডেট হয়েছে</item>
+        <item quantity="other">%1$dটি কনফিগারেশন আপডেট হয়েছে</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="one">%1$dটি অ্যাসেট ফাইল আপডেট হয়েছে</item>
+        <item quantity="other">%1$dটি অ্যাসেট ফাইল আপডেট হয়েছে</item>
+    </plurals>
     <string name="title_update_subscription_result">%1$dটি কনফিগ আপডেট হয়েছে (%2$d সফল, %3$d ব্যর্থ, %4$d এড়ানো)</string>
     <string name="title_update_subscription_no_subscription">কোনো সাবস্ক্রিপশন নেই</string>
     <string name="toast_server_not_found_in_group">বর্তমান গ্রুপে নির্বাচিত সার্ভারটি পাওয়া যায়নি</string>

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -351,8 +351,14 @@
     <string name="title_del_config_count">پاک کردن %d کانفیگ</string>
     <string name="title_import_config_count">و من ٱووردن %d کانفیگ</string>
     <string name="title_export_config_count">و در کشیڌن %d کانفیگ</string>
-    <string name="title_update_config_count">ورۊ کردن %d کانفیگ</string>
-    <string name="title_update_asset_count">%d فایل بونچک جغرافیایی ورۊ وابی</string>
+    <plurals name="title_update_config_count">
+        <item quantity="one">%1$d کانفیگ ورۊ وابی</item>
+        <item quantity="other">%1$d کانفیگ ورۊ وابی</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="one">%1$d فایل بونچک جوقرافیایی ورۊ وابی</item>
+        <item quantity="other">%1$d فایل بونچک جوقرافیایی ورۊ وابی</item>
+    </plurals>
     <string name="title_update_subscription_result">%1$d کانفیگ ورۊ وابی (مووفق: %2$d، شکست خرده: %3$d، رڌ وابیڌه: %4$d)</string>
     <string name="title_update_subscription_no_subscription">بؽ اشتراک</string>
     <string name="toast_server_not_found_in_group">سرور پسند وابیڌه من بونکۊ سکویی نجۊرست</string>

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -351,8 +351,14 @@
     <string name="title_del_config_count">حذف %d کانفیگ</string>
     <string name="title_import_config_count">وارد کردن %d کانفیگ</string>
     <string name="title_export_config_count">صادر کردن %d کانفیگ</string>
-    <string name="title_update_config_count">آپدیت کردن %d کانفیگ</string>
-    <string name="title_update_asset_count">%d فایل منبع بروزرسانی شد</string>
+    <plurals name="title_update_config_count">
+        <item quantity="one">%1$d کانفیگ به‌روزرسانی شد</item>
+        <item quantity="other">%1$d کانفیگ به‌روزرسانی شد</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="one">%1$d فایل منبع به‌روزرسانی شد</item>
+        <item quantity="other">%1$d فایل منبع به‌روزرسانی شد</item>
+    </plurals>
     <string name="title_update_subscription_result">بروزرسانی %1$d کانفیگ انجام شد (%2$d موفق، %3$d شکست خورده، %4$d نادیده گرفته شده)</string>
     <string name="title_update_subscription_no_subscription">هیچ اشتراکی وجود ندارد</string>
     <string name="toast_server_not_found_in_group">سرور انتخاب‌شده در گروه فعلی پیدا نشد</string>

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -351,8 +351,18 @@
     <string name="title_del_config_count">Удалено профилей: %d</string>
     <string name="title_import_config_count">Импортировано профилей: %d</string>
     <string name="title_export_config_count">Экспортировано профилей: %d</string>
-    <string name="title_update_config_count">Обновлено профилей: %d</string>
-    <string name="title_update_asset_count">Обновлено файлов ресурсов: %d</string>
+    <plurals name="title_update_config_count">
+        <item quantity="one">Обновлён %1$d профиль</item>
+        <item quantity="few">Обновлено %1$d профиля</item>
+        <item quantity="many">Обновлено %1$d профилей</item>
+        <item quantity="other">Обновлено %1$d профиля</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="one">Обновлён %1$d файл ресурсов</item>
+        <item quantity="few">Обновлено %1$d файла ресурсов</item>
+        <item quantity="many">Обновлено %1$d файлов ресурсов</item>
+        <item quantity="other">Обновлено %1$d файла ресурсов</item>
+    </plurals>
     <string name="title_update_subscription_result">Обновлено профилей: %1$d (успешно: %2$d, ошибки: %3$d, пропущено: %4$d)</string>
     <string name="title_update_subscription_no_subscription">Нет подписок</string>
     <string name="toast_server_not_found_in_group">Выбранный профиль не найден в текущей группе</string>

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -351,8 +351,12 @@
     <string name="title_del_config_count">Xóa %d cấu hình</string>
     <string name="title_import_config_count">Nhập %d cấu hình</string>
     <string name="title_export_config_count">Xuất %d cấu hình</string>
-    <string name="title_update_config_count">Cập nhật %d cấu hình</string>
-    <string name="title_update_asset_count">Đã cập nhật %d tệp tài nguyên</string>
+    <plurals name="title_update_config_count">
+        <item quantity="other">Đã cập nhật %1$d cấu hình</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="other">Đã cập nhật %1$d tệp tài nguyên</item>
+    </plurals>
     <string name="title_update_subscription_result">Đã cập nhật %1$d cấu hình (%2$d thành công, %3$d thất bại, %4$d bỏ qua)</string>
     <string name="title_update_subscription_no_subscription">Không có đăng ký</string>
     <string name="toast_server_not_found_in_group">Không tìm thấy máy chủ đã chọn trong nhóm hiện tại</string>

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -351,8 +351,12 @@
     <string name="title_del_config_count">删除 %d 个配置</string>
     <string name="title_import_config_count">导入 %d 个配置</string>
     <string name="title_export_config_count">导出 %d 个配置</string>
-    <string name="title_update_config_count">更新 %d 个配置</string>
-    <string name="title_update_asset_count">已更新 %d 个资源文件</string>
+    <plurals name="title_update_config_count">
+        <item quantity="other">已更新 %1$d 个配置</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="other">已更新 %1$d 个资源文件</item>
+    </plurals>
     <string name="title_update_subscription_result">更新了 %1$d 个配置（%2$d 个成功，%3$d 个失败，%4$d 个跳过）</string>
     <string name="title_update_subscription_no_subscription">无订阅</string>
     <string name="toast_server_not_found_in_group">当前分组中未找到选中的服务器</string>

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -351,8 +351,12 @@
     <string name="title_del_config_count">刪除 %d 個設定</string>
     <string name="title_import_config_count">匯入 %d 個設定</string>
     <string name="title_export_config_count">匯出 %d 個設定</string>
-    <string name="title_update_config_count">更新 %d 個設定</string>
-    <string name="title_update_asset_count">已更新 %d 個資源檔案</string>
+    <plurals name="title_update_config_count">
+        <item quantity="other">已更新 %1$d 個設定</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="other">已更新 %1$d 個資源檔案</item>
+    </plurals>
     <string name="title_update_subscription_result">更新了 %1$d 個設定（%2$d 個成功，%3$d 個失敗，%4$d 個跳過）</string>
     <string name="title_update_subscription_no_subscription">無訂閱</string>
     <string name="toast_server_not_found_in_group">目前群組中找不到所選伺服器</string>

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -351,8 +351,14 @@
     <string name="title_del_config_count">Delete %d configs</string>
     <string name="title_import_config_count">Import %d configs</string>
     <string name="title_export_config_count">Export %d configs</string>
-    <string name="title_update_config_count">Update %d configs</string>
-    <string name="title_update_asset_count">Updated %d asset files</string>
+    <plurals name="title_update_config_count">
+        <item quantity="one">Updated %1$d config</item>
+        <item quantity="other">Updated %1$d configs</item>
+    </plurals>
+    <plurals name="title_update_asset_count">
+        <item quantity="one">Updated %1$d asset file</item>
+        <item quantity="other">Updated %1$d asset files</item>
+    </plurals>
     <string name="title_update_subscription_result">Updated %1$d configs (%2$d success, %3$d failed, %4$d skipped)</string>
     <string name="title_update_subscription_no_subscription">No subscriptions</string>
     <string name="toast_server_not_found_in_group">Selected server not found in current group</string>


### PR DESCRIPTION
Describe completed updates instead of an update command, and select singular or plural forms using the actual config or successful asset count.

Route both subscription update entry points through the existing localized ViewModel context and use activity resources for asset results.