### PR TITLE
UI/fix: Add direct routing-rule deletion and prevent duplicate-ID crashes

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/MmkvManager.kt
@@ -790,16 +790,43 @@ object MmkvManager {
         return JsonUtil.fromJsonSafe(ruleset, Array<RulesetItem>::class.java)?.toMutableList() ?: mutableListOf()
     }
 
+    private inline fun <T> withRoutingRulesetLock(block: () -> T): T = synchronized(settingsStorage, block)
+
+    /** Core configuration only needs rule contents; keyed UI additionally requires persisted IDs. */
+    fun decodeRoutingRulesetsForEditing(): MutableList<RulesetItem>? = withRoutingRulesetLock {
+        readRoutingRulesetsWithIds()
+    }
+
+    private fun readRoutingRulesetsWithIds(): MutableList<RulesetItem>? {
+        val rules = decodeRoutingRulesets() ?: return null
+        val normalized = withUniqueRoutingRuleIds(rules)
+        if (normalized != rules) {
+            check(writeRoutingRulesets(normalized)) { "Failed to persist routing rule IDs" }
+        }
+        return normalized.toMutableList()
+    }
+
+    fun removeRoutingRuleset(ruleId: String) = withRoutingRulesetLock {
+        val rules = readRoutingRulesetsWithIds() ?: return@withRoutingRulesetLock
+        val position = rules.indexOfFirst { it.id == ruleId }
+        if (position < 0) return@withRoutingRulesetLock
+        rules.removeAt(position)
+        check(writeRoutingRulesets(rules)) { "Failed to delete routing rule $ruleId" }
+    }
+
     /**
      * Encodes the routing rulesets.
      *
      * @param rulesetList The list of routing rulesets.
      */
-    fun encodeRoutingRulesets(rulesetList: MutableList<RulesetItem>?) {
-        if (rulesetList.isNullOrEmpty())
-            encodeSettings(PREF_ROUTING_RULESET, "")
-        else
-            encodeSettings(PREF_ROUTING_RULESET, JsonUtil.toJson(rulesetList))
+    fun encodeRoutingRulesets(rulesetList: MutableList<RulesetItem>?): Boolean = withRoutingRulesetLock {
+        writeRoutingRulesets(rulesetList)
+    }
+
+    private fun writeRoutingRulesets(rulesetList: List<RulesetItem>?): Boolean {
+        val normalized = rulesetList?.let { withUniqueRoutingRuleIds(it) }
+        val content = if (normalized.isNullOrEmpty()) "" else JsonUtil.toJson(normalized)
+        return encodeSettings(PREF_ROUTING_RULESET, content)
     }
 
     //endregion

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/RoutingRulesetIdentity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/RoutingRulesetIdentity.kt
@@ -1,0 +1,27 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.dto.entities.RulesetItem
+import java.util.UUID
+
+/** Preserve valid identities and rule contents; only absent or repeated IDs need replacements. */
+internal fun withUniqueRoutingRuleIds(
+    rules: List<RulesetItem>,
+    newId: () -> String = { UUID.randomUUID().toString() },
+): List<RulesetItem> {
+    // Legacy/imported JSON can contain null even though the Kotlin field is non-nullable.
+    val reserved = rules.mapTo(mutableSetOf<String?>()) { it.id }
+    val seen = mutableSetOf<String>()
+    return rules.map { rule ->
+        val id: String? = rule.id
+        if (!id.isNullOrBlank() && seen.add(id)) {
+            rule
+        } else {
+            var replacement: String
+            do {
+                replacement = newId()
+            } while (replacement.isBlank() || !reserved.add(replacement))
+            seen.add(replacement)
+            rule.copy(id = replacement)
+        }
+    }
+}

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/handler/SettingsManager.kt
@@ -111,15 +111,16 @@ object SettingsManager {
      * @param rulesetList The list of rulesets.
      */
     private fun resetRoutingRulesetsCommon(rulesetList: MutableList<RulesetItem>) {
-        val rulesetNew: MutableList<RulesetItem> = mutableListOf()
-        MmkvManager.decodeRoutingRulesets()?.forEach { key ->
-            if (key.locked == true) {
-                rulesetNew.add(key)
-            }
-        }
+        val rulesetNew = mergeRoutingRulesets(MmkvManager.decodeRoutingRulesets().orEmpty(), rulesetList)
+        check(MmkvManager.encodeRoutingRulesets(rulesetNew)) { "Failed to import routing rules" }
+    }
 
-        rulesetNew.addAll(rulesetList)
-        MmkvManager.encodeRoutingRulesets(rulesetNew)
+    internal fun mergeRoutingRulesets(current: List<RulesetItem>, imported: List<RulesetItem>): MutableList<RulesetItem> {
+        val locked = current.filter { it.locked == true }
+        // IDs may have been repaired since export. Skip copies of retained locked rules by
+        // their complete contents, not their ID or title; keep genuinely different rules.
+        val retained = locked.mapTo(mutableSetOf()) { it.copy(id = "") }
+        return (locked + imported.filterNot { it.copy(id = "") in retained }).toMutableList()
     }
 
     /**
@@ -133,7 +134,7 @@ object SettingsManager {
         val rulesetList = MmkvManager.decodeRoutingRulesets()
         if (rulesetList.isNullOrEmpty()) return null
 
-        return rulesetList[index]
+        return rulesetList.getOrNull(index)
     }
 
     /**
@@ -165,7 +166,7 @@ object SettingsManager {
         if (index < 0) return
 
         val rulesetList = MmkvManager.decodeRoutingRulesets()
-        if (rulesetList.isNullOrEmpty()) return
+        if (rulesetList.isNullOrEmpty() || index !in rulesetList.indices) return
 
         rulesetList.removeAt(index)
         MmkvManager.encodeRoutingRulesets(rulesetList)

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,6 +54,7 @@ import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.base.HelperBaseComponentActivity
 import com.v2ray.ang.ui.compose.AppDropdownMenuItems
 import com.v2ray.ang.ui.compose.AppTopBar
+import com.v2ray.ang.ui.compose.DeleteConfirmDialog
 import com.v2ray.ang.ui.compose.ItemDivider
 import com.v2ray.ang.ui.compose.NavigationBarsBottomPadding
 import com.v2ray.ang.ui.compose.ReorderableListItem
@@ -63,6 +65,7 @@ import com.v2ray.ang.ui.compose.verticalScrollbar
 import com.v2ray.ang.util.JsonUtil
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -103,6 +106,18 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
             onAddRule = { startActivity(Intent(this, RoutingEditActivity::class.java)) },
             onEditRule = { position ->
                 startActivity(Intent(this, RoutingEditActivity::class.java).putExtra("position", position))
+            },
+            onRemoveRule = { ruleId ->
+                lifecycleScope.launch {
+                    try {
+                        viewModel.remove(ruleId)
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (e: Exception) {
+                        LogUtil.e(AppConfig.TAG, "Failed to delete routing rule $ruleId", e)
+                        toastError(R.string.toast_failure)
+                    }
+                }
             },
             onDomainStrategySelected = { value ->
                 MmkvManager.encodeSettings(AppConfig.PREF_ROUTING_DOMAIN_STRATEGY, value)
@@ -195,6 +210,7 @@ fun RoutingSettingScreen(
     onBackClick: () -> Unit,
     onAddRule: () -> Unit,
     onEditRule: (Int) -> Unit,
+    onRemoveRule: (String) -> Unit,
     onDomainStrategySelected: (String) -> Unit,
     onImportPredefined: (RoutingType) -> Unit,
     onImportClipboard: () -> Unit,
@@ -205,6 +221,7 @@ fun RoutingSettingScreen(
     val domainStrategy by domainStrategyState.collectAsState()
     var showMenu by remember { mutableStateOf(false) }
     var showPresetDialog by remember { mutableStateOf(false) }
+    var deleteRuleId by rememberSaveable { mutableStateOf<String?>(null) }
 
     val domainStrategies = stringArrayResource(R.array.routing_domain_strategy).toList()
     val lazyListState = rememberLazyListState()
@@ -295,7 +312,8 @@ fun RoutingSettingScreen(
                             onEnabledChange = { checked ->
                                 val updated = ruleset.copy(enabled = checked)
                                 viewModel.update(index, updated)
-                            }
+                            },
+                            onDelete = { deleteRuleId = ruleset.id }
                         )
                     }
                     ItemDivider()
@@ -304,6 +322,17 @@ fun RoutingSettingScreen(
         }
     }
 
+
+    rulesets.firstOrNull { it.id == deleteRuleId }?.let { rule ->
+        DeleteConfirmDialog(
+            message = stringResource(R.string.confirm_delete_routing_rule),
+            onConfirm = {
+                deleteRuleId = null
+                onRemoveRule(rule.id)
+            },
+            onDismiss = { deleteRuleId = null }
+        )
+    }
 
     if (showPresetDialog) {
         SelectListDialog(
@@ -323,7 +352,8 @@ fun RoutingSettingScreen(
 private fun RoutingRulesetItem(
     ruleset: RulesetItem,
     onEdit: () -> Unit,
-    onEnabledChange: (Boolean) -> Unit
+    onEnabledChange: (Boolean) -> Unit,
+    onDelete: () -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -374,11 +404,19 @@ private fun RoutingRulesetItem(
             horizontalAlignment = Alignment.End,
             modifier = Modifier.padding(start = 8.dp)
         ) {
-            IconButton(onClick = onEdit) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_edit_24dp),
-                    contentDescription = stringResource(R.string.acc_edit)
-                )
+            Row {
+                IconButton(onClick = onEdit) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_edit_24dp),
+                        contentDescription = stringResource(R.string.acc_edit)
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_delete_24dp),
+                        contentDescription = stringResource(R.string.acc_delete)
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(4.dp))
             Switch(

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingActivity.kt
@@ -132,7 +132,20 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.reload()
+        lifecycleScope.launch { reloadRules() }
+    }
+
+    private suspend fun reloadRules(): Boolean {
+        return try {
+            viewModel.reload()
+            true
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (e: Exception) {
+            LogUtil.e(AppConfig.TAG, "Failed to load routing rules", e)
+            toastError(R.string.toast_failure)
+            false
+        }
     }
 
     private fun getDomainStrategy(): String {
@@ -144,10 +157,11 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             try {
                 SettingsManager.resetRoutingRulesetsFromPresets(this@RoutingSettingActivity, type)
-                launch(Dispatchers.Main) {
-                    viewModel.reload()
-                    toastSuccess(R.string.toast_success)
+                withContext(Dispatchers.Main) {
+                    if (reloadRules()) toastSuccess(R.string.toast_success)
                 }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (e: Exception) {
                 LogUtil.e(AppConfig.TAG, "Failed to import predefined ruleset", e)
             }
@@ -165,8 +179,7 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
             val result = SettingsManager.resetRoutingRulesets(clipboard)
             withContext(Dispatchers.Main) {
                 if (result) {
-                    viewModel.reload()
-                    toastSuccess(R.string.toast_success)
+                    if (reloadRules()) toastSuccess(R.string.toast_success)
                 } else {
                     toastError(R.string.toast_failure)
                 }
@@ -181,8 +194,7 @@ class RoutingSettingActivity : HelperBaseComponentActivity() {
                     val result = SettingsManager.resetRoutingRulesets(scanResult)
                     withContext(Dispatchers.Main) {
                         if (result) {
-                            viewModel.reload()
-                            toastSuccess(R.string.toast_success)
+                            if (reloadRules()) toastSuccess(R.string.toast_success)
                         } else {
                             toastError(R.string.toast_failure)
                         }
@@ -280,7 +292,8 @@ fun RoutingSettingScreen(
                 .verticalScrollbar(lazyListState),
             contentPadding = NavigationBarsBottomPadding()
         ) {
-            item(key = "domain_strategy") {
+            // Rule IDs are strings supplied by imports; keep header keys in a separate namespace.
+            item(key = 0) {
                 SettingsListItem(
                     title = stringResource(R.string.routing_settings_domain_strategy),
                     entries = domainStrategies,

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
@@ -6,9 +6,11 @@ import com.v2ray.ang.extension.moveItem
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.ui.base.BaseViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
 import java.util.UUID
 
 class RoutingSettingsViewModel(application: Application) : BaseViewModel(application) {
@@ -38,6 +40,19 @@ class RoutingSettingsViewModel(application: Application) : BaseViewModel(applica
         if (position in rulesets.indices) {
             rulesets[position] = item
             SettingsManager.saveRoutingRuleset(position, item)
+            _rulesetsFlow.value = rulesets.toList()
+        }
+    }
+
+    suspend fun remove(ruleId: String) {
+        withContext(Dispatchers.IO) {
+            val savedRules = MmkvManager.decodeRoutingRulesets() ?: return@withContext
+            val position = savedRules.indexOfFirst { it.id == ruleId }
+            if (position < 0) return@withContext
+            savedRules.removeAt(position)
+            MmkvManager.encodeRoutingRulesets(savedRules)
+        }
+        if (rulesets.removeAll { it.id == ruleId }) {
             _rulesetsFlow.value = rulesets.toList()
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModel.kt
@@ -11,26 +11,22 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
-import java.util.UUID
 
 class RoutingSettingsViewModel(application: Application) : BaseViewModel(application) {
     private val rulesets: MutableList<RulesetItem> = mutableListOf()
+    private var revision = 0
 
     private val _rulesetsFlow = MutableStateFlow<List<RulesetItem>>(emptyList())
     val rulesetsFlow: StateFlow<List<RulesetItem>> = _rulesetsFlow.asStateFlow()
 
     fun getAll(): List<RulesetItem> = rulesets.toList()
 
-    fun reload() {
-        val loaded = MmkvManager.decodeRoutingRulesets()?.toMutableList() ?: mutableListOf()
-        var needsSave = false
-        loaded.forEachIndexed { index, item ->
-            if (item.id.isEmpty()) {
-                item.id = UUID.randomUUID().toString()
-                SettingsManager.saveRoutingRuleset(index, item)
-                needsSave = true
-            }
+    suspend fun reload() {
+        val requestedRevision = ++revision
+        val loaded = withContext(Dispatchers.IO) {
+            MmkvManager.decodeRoutingRulesetsForEditing().orEmpty()
         }
+        if (requestedRevision != revision) return
         rulesets.clear()
         rulesets.addAll(loaded)
         _rulesetsFlow.value = rulesets.toList()
@@ -38,6 +34,7 @@ class RoutingSettingsViewModel(application: Application) : BaseViewModel(applica
 
     fun update(position: Int, item: RulesetItem) {
         if (position in rulesets.indices) {
+            revision++
             rulesets[position] = item
             SettingsManager.saveRoutingRuleset(position, item)
             _rulesetsFlow.value = rulesets.toList()
@@ -45,12 +42,9 @@ class RoutingSettingsViewModel(application: Application) : BaseViewModel(applica
     }
 
     suspend fun remove(ruleId: String) {
+        revision++
         withContext(Dispatchers.IO) {
-            val savedRules = MmkvManager.decodeRoutingRulesets() ?: return@withContext
-            val position = savedRules.indexOfFirst { it.id == ruleId }
-            if (position < 0) return@withContext
-            savedRules.removeAt(position)
-            MmkvManager.encodeRoutingRulesets(savedRules)
+            MmkvManager.removeRoutingRuleset(ruleId)
         }
         if (rulesets.removeAll { it.id == ruleId }) {
             _rulesetsFlow.value = rulesets.toList()
@@ -59,6 +53,7 @@ class RoutingSettingsViewModel(application: Application) : BaseViewModel(applica
 
     fun move(fromPosition: Int, toPosition: Int) {
         if (rulesets.moveItem(fromPosition, toPosition)) {
+            revision++
             MmkvManager.encodeRoutingRulesets(rulesets)
             _rulesetsFlow.value = rulesets.toList()
         }

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/handler/RoutingRulesetIdentityTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/handler/RoutingRulesetIdentityTest.kt
@@ -1,0 +1,74 @@
+package com.v2ray.ang.handler
+
+import com.v2ray.ang.dto.entities.RulesetItem
+import com.v2ray.ang.util.JsonUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RoutingRulesetIdentityTest {
+    @Test
+    fun legacyMissingNullBlankAndDuplicateIdsKeepTheirRuleContents() {
+        val rules = JsonUtil.fromJson(
+            """[{"remarks":"Missing"},{"id":null},{"id":" "},{"id":"same","remarks":"One"},{"id":"same","remarks":"Two"}]""",
+            Array<RulesetItem>::class.java,
+        )!!.toList()
+        val normalized = withUniqueRoutingRuleIds(rules)
+        assertTrue(normalized.all { it.id.isNotBlank() })
+        assertEquals(rules.size, normalized.map { it.id }.toSet().size)
+        assertEquals("same", normalized[3].id)
+        assertEquals(rules.map { it.copy(id = "") }, normalized.map { it.copy(id = "") })
+        assertEquals(normalized, withUniqueRoutingRuleIds(normalized))
+        assertEquals("same", rules[4].id)
+    }
+
+    @Test
+    fun replacementsCannotTakeAnyOriginalIdOrRepeatAGeneratedId() {
+        val candidates = listOf("later", "", "first-new", "first-new", "second-new").iterator()
+        val rules = listOf(RulesetItem(), RulesetItem(id = "later"), RulesetItem(id = "later"))
+        val normalized = withUniqueRoutingRuleIds(rules) { candidates.next() }
+        assertEquals(listOf("first-new", "later", "second-new"), normalized.map { it.id })
+    }
+
+    @Test
+    fun identicalObjectReferencesStillBecomeDistinctRowsWithoutChangingTheInput() {
+        val rule = RulesetItem(id = "same")
+        val result = withUniqueRoutingRuleIds(listOf(rule, rule))
+        assertEquals("same", result[0].id)
+        assertNotEquals(result[0].id, result[1].id)
+        assertEquals("same", rule.id)
+    }
+
+    @Test
+    fun oldExportsDoNotMultiplyRetainedLockedCopiesAfterIdRepair() {
+        val locked = RulesetItem(id = "duplicate", remarks = "Same", locked = true)
+        val other = RulesetItem(id = "duplicate", remarks = "Same", outboundTag = "direct")
+        val exported = listOf(locked, locked.copy(), other)
+        var current = withUniqueRoutingRuleIds(exported)
+        val expected = current
+        repeat(3) {
+            current = withUniqueRoutingRuleIds(SettingsManager.mergeRoutingRulesets(current, exported))
+            assertEquals(expected.take(2), current.take(2))
+            assertEquals(expected.map { it.copy(id = "") }, current.map { it.copy(id = "") })
+            assertEquals(3, current.map { it.id }.toSet().size)
+        }
+    }
+
+    @Test
+    fun differentRulesWithTheSameTitleOrIdAreNotDiscarded() {
+        val locked = RulesetItem(id = "same", remarks = "Same", locked = true)
+        val different = locked.copy(domain = listOf("example.invalid"))
+        val imported = listOf(locked.copy(id = "previous-id"), different, RulesetItem(id = "same", remarks = "Same"))
+        val merged = withUniqueRoutingRuleIds(SettingsManager.mergeRoutingRulesets(listOf(locked), imported))
+        assertEquals(listOf(locked, different, imported.last()).map { it.copy(id = "") }, merged.map { it.copy(id = "") })
+        assertEquals(3, merged.map { it.id }.toSet().size)
+    }
+
+    @Test
+    fun validHeaderLikeIdsAndEmptyListsArePreserved() {
+        val rules = listOf(RulesetItem(id = "domain_strategy"), RulesetItem(id = "0"))
+        assertEquals(rules, withUniqueRoutingRuleIds(rules))
+        assertEquals(emptyList<RulesetItem>(), withUniqueRoutingRuleIds(emptyList()))
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModelTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModelTest.kt
@@ -1,0 +1,110 @@
+package com.v2ray.ang.ui.routing
+
+import android.app.Application
+import com.tencent.mmkv.MMKV
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.dto.entities.RulesetItem
+import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.util.JsonUtil
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RoutingSettingsViewModelTest {
+    private lateinit var storage: MMKV
+    private lateinit var viewModel: RoutingSettingsViewModel
+    private var saved: String? = null
+
+    @Before
+    fun prepareStorage() {
+        mockStatic(MMKV::class.java).use { factory ->
+            factory.`when`<MMKV> { MMKV.mmkvWithID("SETTING", MMKV.MULTI_PROCESS_MODE) }.thenReturn(mock())
+            // Reuse the lazy handle if another storage test initialized it first.
+            val getter = MmkvManager::class.java.getDeclaredMethod("getSettingsStorage")
+            getter.isAccessible = true
+            storage = getter.invoke(MmkvManager) as MMKV
+        }
+        reset(storage)
+        whenever(storage.decodeString(AppConfig.PREF_ROUTING_RULESET)).thenAnswer { saved }
+        whenever(storage.encode(any<String>(), any<String>())).thenAnswer {
+            saved = it.getArgument(1)
+            true
+        }
+        viewModel = RoutingSettingsViewModel(mock<Application>())
+        assertEquals(emptyList<RulesetItem>(), viewModel.rulesetsFlow.value)
+    }
+
+    @Test
+    fun deletesByIdAfterStoredOrderChangesAndKeepsDuplicateNames() = runBlocking {
+        val first = RulesetItem(id = "first", remarks = "Same")
+        val second = RulesetItem(id = "second", remarks = "Same", locked = true)
+        saved = JsonUtil.toJson(listOf(first, second))
+        viewModel.reload()
+        saved = JsonUtil.toJson(listOf(second, first))
+
+        viewModel.remove("second")
+
+        assertEquals(listOf(first), viewModel.rulesetsFlow.value)
+        assertEquals(listOf(first), MmkvManager.decodeRoutingRulesets())
+        viewModel.reload()
+        assertEquals(listOf(first), viewModel.getAll())
+    }
+
+    @Test
+    fun missingTargetDoesNotWriteOrRemoveAnotherRule() = runBlocking<Unit> {
+        val rule = RulesetItem(id = "keep")
+        saved = JsonUtil.toJson(listOf(rule))
+        viewModel.reload()
+        viewModel.remove("missing")
+        assertEquals(listOf(rule), viewModel.rulesetsFlow.value)
+        verify(storage, never()).encode(any<String>(), any<String>())
+    }
+
+    @Test
+    fun alreadyRemovedTargetIsDroppedFromTheVisibleList() = runBlocking<Unit> {
+        saved = JsonUtil.toJson(listOf(RulesetItem(id = "gone")))
+        viewModel.reload()
+        saved = null
+        viewModel.remove("gone")
+        assertEquals(emptyList<RulesetItem>(), viewModel.rulesetsFlow.value)
+        verify(storage, never()).encode(any<String>(), any<String>())
+    }
+
+    @Test
+    fun deletingTheLastRulePersistsAnEmptyListAndCanBeRepeated() = runBlocking {
+        saved = JsonUtil.toJson(listOf(RulesetItem(id = "last")))
+        viewModel.reload()
+        viewModel.remove("last")
+        assertEquals("", saved)
+        assertEquals(emptyList<RulesetItem>(), viewModel.rulesetsFlow.value)
+        viewModel.remove("last")
+        viewModel.reload()
+        assertEquals(emptyList<RulesetItem>(), viewModel.getAll())
+    }
+
+    @Test
+    fun storageExceptionDoesNotRemoveTheVisibleRule() = runBlocking {
+        val rule = RulesetItem(id = "keep")
+        saved = JsonUtil.toJson(listOf(rule))
+        viewModel.reload()
+        val failure = IllegalStateException("Storage unavailable")
+        whenever(storage.encode(any<String>(), any<String>())).thenThrow(failure)
+        try {
+            viewModel.remove("keep")
+            fail("Expected storage failure")
+        } catch (actual: IllegalStateException) {
+            assertEquals(failure.message, actual.message)
+        }
+        assertEquals(listOf(rule), viewModel.rulesetsFlow.value)
+        assertEquals(listOf(rule), MmkvManager.decodeRoutingRulesets())
+    }
+}

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModelTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/ui/routing/RoutingSettingsViewModelTest.kt
@@ -5,9 +5,13 @@ import com.tencent.mmkv.MMKV
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.dto.entities.RulesetItem
 import com.v2ray.ang.handler.MmkvManager
+import com.v2ray.ang.handler.SettingsManager
 import com.v2ray.ang.util.JsonUtil
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -18,6 +22,8 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class RoutingSettingsViewModelTest {
     private lateinit var storage: MMKV
@@ -106,5 +112,91 @@ class RoutingSettingsViewModelTest {
         }
         assertEquals(listOf(rule), viewModel.rulesetsFlow.value)
         assertEquals(listOf(rule), MmkvManager.decodeRoutingRulesets())
+    }
+
+    @Test
+    fun legacyDuplicateIdsArePersistedBeforeDeletingOnlyTheChosenRow() = runBlocking {
+        saved = """[{"id":"same","remarks":"Same","locked":true},{"id":"same","remarks":"Same","locked":true},{"id":null}]"""
+        viewModel.reload()
+        val loaded = viewModel.getAll()
+        assertEquals(3, loaded.map { it.id }.toSet().size)
+        assertTrue(loaded.all { it.id.isNotBlank() })
+        assertEquals(loaded, MmkvManager.decodeRoutingRulesets())
+        viewModel.remove(loaded[1].id)
+        assertEquals(listOf(loaded[0], loaded[2]), MmkvManager.decodeRoutingRulesets())
+        assertEquals(listOf(loaded[0], loaded[2]), viewModel.getAll())
+    }
+
+    @Test
+    fun failedRepairDoesNotPublishTemporaryIdsOrOverwriteStoredRules() = runBlocking {
+        val original = """[{"id":"same"},{"id":"same"}]"""
+        saved = original
+        whenever(storage.encode(any<String>(), any<String>())).thenReturn(false)
+        assertTrue(runCatching { viewModel.reload() }.exceptionOrNull() is IllegalStateException)
+        assertEquals(original, saved)
+        assertEquals(emptyList<RulesetItem>(), viewModel.getAll())
+        assertEquals(2, MmkvManager.decodeRoutingRulesets()?.size)
+    }
+
+    @Test
+    fun refusedDeletionDoesNotRemoveTheVisibleRule() = runBlocking {
+        val rule = RulesetItem(id = "keep")
+        saved = JsonUtil.toJson(listOf(rule))
+        viewModel.reload()
+        whenever(storage.encode(any<String>(), any<String>())).thenReturn(false)
+        assertTrue(runCatching { viewModel.remove("keep") }.exceptionOrNull() is IllegalStateException)
+        assertEquals(listOf(rule), viewModel.getAll())
+        assertEquals(listOf(rule), MmkvManager.decodeRoutingRulesets())
+    }
+
+    @Test
+    fun importingAnOldExportRepeatedlyKeepsLockedCopiesAndDistinctRulesStable() = runBlocking {
+        val exported = """[{"id":"same","remarks":"Locked","locked":true},{"id":"same","remarks":"Locked","locked":true},{"remarks":"Other"}]"""
+        saved = exported
+        viewModel.reload()
+        val lockedIds = viewModel.getAll().take(2).map { it.id }
+        repeat(3) {
+            assertTrue(SettingsManager.resetRoutingRulesets(exported))
+            viewModel.reload()
+            val loaded = viewModel.getAll()
+            assertEquals(3, loaded.size)
+            assertEquals(lockedIds, loaded.take(2).map { it.id })
+            assertEquals(3, loaded.map { it.id }.toSet().size)
+        }
+    }
+
+    @Test
+    fun staleReloadCannotUndoANewerReorderOrToggle() = runBlocking {
+        saved = JsonUtil.toJson(listOf(RulesetItem(id = "one"), RulesetItem(id = "two")))
+        viewModel.reload()
+        for (toggle in listOf(false, true)) {
+            val readStarted = CountDownLatch(1)
+            whenever(storage.decodeString(AppConfig.PREF_ROUTING_RULESET)).thenAnswer {
+                val snapshot = saved
+                readStarted.countDown()
+                snapshot
+            }
+            val pending = launch(start = CoroutineStart.UNDISPATCHED) { viewModel.reload() }
+            assertTrue(readStarted.await(5, TimeUnit.SECONDS))
+            if (toggle) viewModel.update(0, viewModel.getAll()[0].copy(enabled = false))
+            else viewModel.move(0, 1)
+            val expected = viewModel.getAll()
+            pending.join()
+            assertEquals(expected, viewModel.rulesetsFlow.value)
+            assertEquals(expected, MmkvManager.decodeRoutingRulesets())
+        }
+    }
+
+    @Test
+    fun addAndOutOfRangeOperationsRetainTheirIndexBasedContract() {
+        assertEquals(null, SettingsManager.getRoutingRuleset(-1))
+        SettingsManager.saveRoutingRuleset(-1, RulesetItem(remarks = "New"))
+        val added = SettingsManager.getRoutingRuleset(0)!!
+        assertTrue(added.id.isNotBlank())
+        assertEquals("New", added.remarks)
+        assertEquals(null, SettingsManager.getRoutingRuleset(3))
+        SettingsManager.removeRoutingRuleset(-1)
+        SettingsManager.removeRoutingRuleset(3)
+        assertEquals(listOf(added), MmkvManager.decodeRoutingRulesets())
     }
 }


### PR DESCRIPTION
## Summary

Add a **Delete** button beside **Edit** in routing-rule rows, with the existing localized confirmation dialog. Harden rule identities so this new list action and the already-keyed Compose list remain safe with legacy data and repeated imports containing locked rules.

This is a standalone, non-accessibility extraction based on current `master` (`2020807c255b76b09c9ced4255c95600250aef48`). It does **not** restore the reverted ID-based editor migration.

## Background: the reverted change and closed PRs

- [c548e5f61 — Use ruleset IDs for routing edits](https://github.com/2dust/v2rayNG/commit/c548e5f615d87a9220fd066b9f31fa127551ff90) moved editor operations to IDs.
- [1af8f4677 — Revert "Use ruleset IDs for routing edits"](https://github.com/2dust/v2rayNG/commit/1af8f4677ccee032957aec63a328db9e96bf9a2f) reverted that migration.
- Closed [#6171 — Fix routing-rule creation and crash caused by duplicate IDs](https://github.com/2dust/v2rayNG/pull/6171) and [#6185 — Fix adding routing rulesets and harden ruleset id handling](https://github.com/2dust/v2rayNG/pull/6185) discussed two distinct problems: Add intentionally supplies no existing rule ID, and imported/stored rule IDs are not necessarily unique. Both PRs were closed after the revert.

The duplicate-ID problem is not limited to the reverted editor: the routing list still uses rule IDs as Compose/reorderable keys. A normal export/import round trip retains the current locked rules and imports their exported copies again. Repairing only empty IDs does not prevent duplicate nonempty keys, and merely assigning new IDs to every imported copy still allows locked-rule contents to multiply on successive imports. Duplicate names themselves are valid and must not be treated as duplicate identities.

This PR addresses those data/key prerequisites while leaving the current Add/Edit and toggle contracts in place.

## Addition: delete directly from the list

- Reuse the existing Delete icon label and routing-rule confirmation text; no new translation keys are needed.
- Remember the pending rule ID across activity recreation and resolve that ID against stored rules when confirming. A changed list position therefore does not redirect deletion to a neighbor.
- Run deletion on `Dispatchers.IO`; remove the visible row only after storage completes successfully. A missing target does not delete another rule, and write failures are logged and reported using the existing failure message.
- Keep explicit deletion of locked rules available, as it already is in the editor. The lock protects a rule during import, not against the user's confirmed deletion.

## Fixes and advantages

1. **Unique, persisted identities before composition.** Repair absent, null, blank, and repeated IDs when writing routing lists and before exposing them to the keyed UI. Preserve the first valid occurrence, list order, and every rule's contents. Reserve all original IDs before generating replacements, retry collisions, and persist the repaired list in one write instead of per-row saves. If persistence fails, do not expose temporary replacement IDs.
2. **Stable repeated imports without deleting user rules.** Retain all existing locked rules, including duplicates already present. Skip imported copies matching their complete contents apart from ID, since IDs may have changed after an older export. Different rules with matching names or IDs are retained and assigned distinct identities where needed; this is not title-based deduplication.
3. **No collision with list headers.** Use a non-string header key, so a valid imported string ID such as `domain_strategy` cannot collide with non-rule content.
4. **Consistent loading and failure handling.** Load on IO, publish on the calling UI coroutine, and discard reload results superseded by newer list changes. Serialize identity repair and ID deletion with routing writes within the process. Check repair/deletion write results instead of reporting false success.
5. **A smaller migration boundary.** Keep upstream's working Add/Edit flow; add bounds checks for obsolete index-based lookup/deletion requests. Raw core-routing reads remain unchanged: failure to persist UI identities does not turn usable routing contents into an empty core configuration. No editor ViewModel rewrite or general conversion of edit/toggle operations to IDs is included.

The user-facing benefit is fewer navigation steps for deletion. The correctness benefit is that the new action has an unambiguous target and the list can safely display ordinary legacy/imported data. The implementation is independent of the accessibility PRs and can be reviewed without their semantics, custom actions, or localization changes.

## Validation

- **87 Play Store debug JVM tests passed**, including 17 routing identity/deletion tests. Coverage includes legacy JSON, generated-ID collisions, repeated locked exports, distinct rules with identical titles/IDs, persistence failures, missing targets, changed stored order, last-rule deletion, stale reloads versus toggle/reorder, and Add/out-of-range operations.
- `:app:compilePlaystoreDebugKotlin` and `:app:assemblePlaystoreDebug -PABI_FILTERS=x86_64` passed; `git diff --check` passed.
- Android 13/API 33 Pixel 6a emulator: opened a fixture containing two identical locked rules with the same `domain_strategy` ID plus null/blank/missing IDs; confirmed five unique persisted identities and no list crash. Exported through the UI and reimported twice, then imported the pre-repair export three times through the normal settings import method. Counts and retained locked IDs remained stable.
- On the final revision, Add stayed open, Save added a rule, and list deletion removed it. Deleting the second identical locked rule removed exactly its repaired ID and retained the first; a runtime storage probe verified the result. No v2rayNG crash appeared in the crash buffer.
- Before the identity-hardening follow-up, the direct-delete addition also passed touch, Cancel, keyboard Enter, D-pad center, and confirmation-across-rotation checks. These were not all repeated after hardening.

**Not run:** physical devices/other Android versions, TalkBack speech, full theme matrices, QR-scanner/preset-import UI, F-Droid builds, and concurrent/cross-process mutation stress. Clipboard, QR, and preset imports share the tested merge/write path; the in-process synchronization is not a cross-process transaction guarantee. No new Android instrumentation-test source folder is included.

No import/export fields are renamed or removed, no native dependencies change, and no accessibility-specific behavior is bundled.
