### PR TITLE
UI/UX: Deliver background feedback through regular notifications

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreServiceManager.kt
@@ -100,7 +100,7 @@ object CoreServiceManager {
         } catch (e: Exception) {
             val message = e.message?.takeUnless { it.isBlank() } ?: e.javaClass.simpleName
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: $message", e)
-            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+            MessageHelper.sendServiceEvent(service, AppConfig.MSG_STATE_START_FAILURE, message)
             NotificationManager.cancelNotification()
             return false
         }
@@ -172,7 +172,7 @@ object CoreServiceManager {
         }
 
         if (!isReload) {
-            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_SUCCESS, "")
+            MessageHelper.sendServiceEvent(service, AppConfig.MSG_STATE_START_SUCCESS)
         }
         NotificationManager.startSpeedNotification()
         LogUtil.i(AppConfig.TAG, "StartCore-Manager: Core started successfully")
@@ -185,12 +185,13 @@ object CoreServiceManager {
      */
     fun stopCoreLoop(): Boolean {
         val service = getService() ?: return false
+        val wasRunning = isRunning()
 
         networkMonitor?.unregister()
         networkMonitor = null
         currentVpnInterface = null
 
-        if (isRunning()) {
+        if (wasRunning) {
             CoroutineScope(Dispatchers.IO).launch {
                 try {
                     coreController.stopLoop()
@@ -207,7 +208,10 @@ object CoreServiceManager {
             browserDialer = null
         }
 
-        MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_STOP_SUCCESS, "")
+        // Failed-start cleanup must not replace the failure feedback with a successful stop.
+        if (wasRunning) {
+            MessageHelper.sendServiceEvent(service, AppConfig.MSG_STATE_STOP_SUCCESS)
+        }
         NotificationManager.cancelNotification()
 
         try {
@@ -264,7 +268,7 @@ object CoreServiceManager {
         } catch (e: Exception) {
             val message = e.message?.takeUnless { it.isBlank() } ?: e.javaClass.simpleName
             LogUtil.e(AppConfig.TAG, "StartCore-Manager: Failed to reload core: $message", e)
-            MessageHelper.sendMsg2UI(service, AppConfig.MSG_STATE_START_FAILURE, message)
+            MessageHelper.sendServiceEvent(service, AppConfig.MSG_STATE_START_FAILURE, message)
             false
         } finally {
             isReloading = false

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/extension/ToastExt.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/extension/ToastExt.kt
@@ -1,9 +1,7 @@
 package com.v2ray.ang.extension
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
-import android.widget.Toast
+import com.v2ray.ang.helper.NotificationHelper
 import com.v2ray.ang.ui.compose.AppSnackbarManager
 import com.v2ray.ang.ui.compose.ToastType
 
@@ -14,9 +12,7 @@ import com.v2ray.ang.ui.compose.ToastType
  */
 fun Context.toast(message: Int) {
     val text = getString(message)
-    dispatchMessage(text, ToastType.NORMAL) {
-        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(text, ToastType.NORMAL)
 }
 
 /**
@@ -25,9 +21,7 @@ fun Context.toast(message: Int) {
  * @param message The text of the message to show.
  */
 fun Context.toast(message: CharSequence) {
-    dispatchMessage(message, ToastType.NORMAL) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(message, ToastType.NORMAL)
 }
 
 /**
@@ -37,9 +31,7 @@ fun Context.toast(message: CharSequence) {
  */
 fun Context.toastSuccess(message: Int) {
     val text = getString(message)
-    dispatchMessage(text, ToastType.SUCCESS) {
-        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(text, ToastType.SUCCESS)
 }
 
 /**
@@ -48,9 +40,7 @@ fun Context.toastSuccess(message: Int) {
  * @param message The text of the message to show.
  */
 fun Context.toastSuccess(message: CharSequence) {
-    dispatchMessage(message, ToastType.SUCCESS) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(message, ToastType.SUCCESS)
 }
 
 /**
@@ -60,9 +50,7 @@ fun Context.toastSuccess(message: CharSequence) {
  */
 fun Context.toastError(message: Int) {
     val text = getString(message)
-    dispatchMessage(text, ToastType.ERROR) {
-        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(text, ToastType.ERROR)
 }
 
 /**
@@ -71,9 +59,7 @@ fun Context.toastError(message: Int) {
  * @param message The text of the message to show.
  */
 fun Context.toastError(message: CharSequence) {
-    dispatchMessage(message, ToastType.ERROR) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(message, ToastType.ERROR)
 }
 
 /**
@@ -83,9 +69,7 @@ fun Context.toastError(message: CharSequence) {
  */
 fun Context.toastInfo(message: Int) {
     val text = getString(message)
-    dispatchMessage(text, ToastType.INFO) {
-        Toast.makeText(this, text, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(text, ToastType.INFO)
 }
 
 /**
@@ -94,31 +78,16 @@ fun Context.toastInfo(message: Int) {
  * @param message The text of the message to show.
  */
 fun Context.toastInfo(message: CharSequence) {
-    dispatchMessage(message, ToastType.INFO) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
-    }
+    dispatchMessage(message, ToastType.INFO)
 }
 
-private inline fun runOnMain(crossinline block: () -> Unit) {
-    if (Looper.myLooper() == Looper.getMainLooper()) {
-        block()
-    } else {
-        Handler(Looper.getMainLooper()).post { block() }
-    }
-}
-
-private inline fun dispatchMessage(
+private fun Context.dispatchMessage(
     message: CharSequence,
     type: ToastType,
-    long: Boolean = false,
-    crossinline fallback: () -> Unit
 ) {
-    val handledBySnackbar = AppSnackbarManager.show(
-        message = message,
-        type = type,
-        long = long
-    )
-    if (!handledBySnackbar) {
-        runOnMain { fallback() }
+    if (AppSnackbarManager.show(message, type)) {
+        NotificationHelper.cancelTransientMessage(this)
+    } else {
+        NotificationHelper.notifyTransientMessage(this, message)
     }
 }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/MessageHelper.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/MessageHelper.kt
@@ -6,10 +6,13 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
 import com.v2ray.ang.dto.SubscriptionUpdateMessage
 import com.v2ray.ang.dto.TestServiceMessage
+import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.service.CoreTestService
 import com.v2ray.ang.service.SubscriptionUpdateService
 import com.v2ray.ang.util.LogUtil
@@ -38,6 +41,33 @@ object MessageHelper {
         what: Int,
         content: Serializable,
         onResult: (handled: Boolean) -> Unit,
+    ) = sendMsgForResult(ctx, AppConfig.BROADCAST_ACTION_SERVICE, what, content, onResult)
+
+    /** State receivers still receive the event, but only a resumed message host acknowledges it. */
+    internal fun sendServiceEvent(ctx: Context, what: Int, content: String = "") {
+        val messageRes = requireNotNull(serviceMessageResource(what))
+        sendMsgForResult(ctx, AppConfig.BROADCAST_ACTION_ACTIVITY, what, content) { handled ->
+            if (!handled) {
+                val message = AppLocaleManager.localizedContext(ctx).getString(messageRes)
+                NotificationHelper.notifyTransientMessage(ctx, message)
+            }
+        }
+    }
+
+    @StringRes
+    internal fun serviceMessageResource(what: Int): Int? = when (what) {
+        AppConfig.MSG_STATE_START_SUCCESS -> R.string.toast_services_success
+        AppConfig.MSG_STATE_START_FAILURE -> R.string.toast_services_failure
+        AppConfig.MSG_STATE_STOP_SUCCESS -> R.string.toast_services_stop
+        else -> null
+    }
+
+    private fun sendMsgForResult(
+        ctx: Context,
+        action: String,
+        what: Int,
+        content: Serializable,
+        onResult: (handled: Boolean) -> Unit,
     ) {
         val resultReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {
@@ -46,7 +76,7 @@ object MessageHelper {
         }
         try {
             ctx.sendOrderedBroadcast(
-                messageIntent(AppConfig.BROADCAST_ACTION_SERVICE, what, content),
+                messageIntent(action, what, content),
                 null,
                 resultReceiver,
                 null,
@@ -55,7 +85,7 @@ object MessageHelper {
                 null,
             )
         } catch (e: Exception) {
-            LogUtil.e(AppConfig.TAG, "Failed to send ordered message to service", e)
+            LogUtil.e(AppConfig.TAG, "Failed to send ordered message with action: $action", e)
             onResult(false)
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/helper/NotificationHelper.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/helper/NotificationHelper.kt
@@ -1,14 +1,23 @@
 package com.v2ray.ang.helper
 
+import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import com.v2ray.ang.R
 import com.v2ray.ang.enums.NotificationChannelType
+import com.v2ray.ang.handler.AppLocaleManager
+import com.v2ray.ang.ui.main.MainActivity
+import com.v2ray.ang.util.LogUtil
 
 /**
  * Unified notification helper for different notification channels.
@@ -22,6 +31,58 @@ object NotificationHelper {
     // Cached instances for performance
     private var cachedNotificationManager: NotificationManager? = null
     private val builderCache = mutableMapOf<Int, NotificationCompat.Builder>()
+
+    /** Background feedback replaces the previous message; it never replaces a service notification. */
+    fun notifyTransientMessage(context: Context, content: CharSequence) {
+        if (content.isBlank()) return
+        val appContext = context.applicationContext
+        if (!NotificationManagerCompat.from(appContext).areNotificationsEnabled()) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) return
+
+        val localizedContext = AppLocaleManager.localizedContext(appContext)
+        val manager = getNotificationManager(appContext)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val name = localizedContext.getString(R.string.notification_channel_other)
+                val channel = manager.getNotificationChannel(TRANSIENT_MESSAGE_CHANNEL_ID)
+                    ?: NotificationChannel(TRANSIENT_MESSAGE_CHANNEL_ID, name, NotificationManager.IMPORTANCE_LOW)
+                // Rename an existing channel without changing the user's behavior settings.
+                channel.name = name
+                manager.createNotificationChannel(channel)
+            }
+            val contentIntent = PendingIntent.getActivity(
+                appContext,
+                TRANSIENT_MESSAGE_NOTIFICATION_ID,
+                Intent(appContext, MainActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                },
+                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+            )
+            val notification = NotificationCompat.Builder(appContext, TRANSIENT_MESSAGE_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_stat_name)
+                .setContentTitle(localizedContext.getString(R.string.app_name))
+                .setContentText(content)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(content))
+                .setContentIntent(contentIntent)
+                .setAutoCancel(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+                .setTimeoutAfter(TRANSIENT_MESSAGE_TIMEOUT_MS)
+                .build()
+            manager.notify(TRANSIENT_MESSAGE_NOTIFICATION_ID, notification)
+        } catch (e: SecurityException) {
+            LogUtil.w(message = "NotificationHelper: failed to post transient message", throwable = e)
+        }
+    }
+
+    /** New foreground feedback supersedes any message left in the notification drawer. */
+    fun cancelTransientMessage(context: Context) {
+        getNotificationManager(context.applicationContext).cancel(TRANSIENT_MESSAGE_NOTIFICATION_ID)
+    }
 
     /**
      * Notify with a regular notification (non-foreground).
@@ -165,3 +226,7 @@ object NotificationHelper {
             .apply { action?.let(::addAction) }
     }
 }
+
+private const val TRANSIENT_MESSAGE_CHANNEL_ID = "transient_message_channel"
+private const val TRANSIENT_MESSAGE_NOTIFICATION_ID = 14
+private const val TRANSIENT_MESSAGE_TIMEOUT_MS = 10_000L

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreVpnService.kt
@@ -21,6 +21,7 @@ import com.v2ray.ang.handler.AppLocaleManager
 import com.v2ray.ang.handler.MmkvManager
 import com.v2ray.ang.handler.NotificationManager
 import com.v2ray.ang.handler.SettingsManager
+import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.root.RootLanSharing
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
@@ -89,6 +90,7 @@ class CoreVpnService : VpnService(), ServiceControl {
         LogUtil.i(AppConfig.TAG, "StartCore-VPN: Service command received, systemVpnStart=$isSystemVpnStart")
         if (!setupVpnService()) {
             unlockStart()
+            MessageHelper.sendServiceEvent(this, AppConfig.MSG_STATE_START_FAILURE, "VPN setup failed")
             // Stop service if setup fails to avoid infinite restart loops (START_STICKY)
             stopSelf()
             return START_NOT_STICKY

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/SnackBar.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/compose/SnackBar.kt
@@ -1,5 +1,10 @@
 package com.v2ray.ang.ui.compose
 
+import android.app.Activity
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -24,14 +29,19 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import com.v2ray.ang.AppConfig
 import com.v2ray.ang.extension.delay
+import com.v2ray.ang.helper.MessageHelper
+import com.v2ray.ang.helper.NotificationHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -135,15 +145,44 @@ fun AppSnackbarBridge(
     controller: AppSnackbarController
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
 
-    LaunchedEffect(controller, lifecycleOwner) {
+    LaunchedEffect(controller, lifecycleOwner, context) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-            AppSnackbarManager.messages.collect { event ->
-                controller.show(
-                    message = event.message,
-                    type = event.type,
-                    long = event.long
-                )
+            // A repository subscriber can outlive a visible screen. Acknowledge feedback here,
+            // where it is actually handed to a resumed host, not when service state is queued.
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    if (!isOrderedBroadcast || resultCode == Activity.RESULT_OK) return
+                    if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return
+                    val what = intent.getIntExtra("key", 0)
+                    val messageRes = MessageHelper.serviceMessageResource(what) ?: return
+                    val type = when (what) {
+                        AppConfig.MSG_STATE_START_FAILURE -> ToastType.ERROR
+                        AppConfig.MSG_STATE_START_SUCCESS -> ToastType.SUCCESS
+                        else -> ToastType.NORMAL
+                    }
+                    controller.show(context.getString(messageRes), type)
+                    NotificationHelper.cancelTransientMessage(context)
+                    resultCode = Activity.RESULT_OK
+                }
+            }
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                IntentFilter(AppConfig.BROADCAST_ACTION_ACTIVITY),
+                ContextCompat.RECEIVER_NOT_EXPORTED,
+            )
+            try {
+                AppSnackbarManager.messages.collect { event ->
+                    controller.show(
+                        message = event.message,
+                        type = event.type,
+                        long = event.long
+                    )
+                }
+            } finally {
+                context.unregisterReceiver(receiver)
             }
         }
     }

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -101,16 +101,8 @@ class MainViewModel(
         when (event) {
             MainServiceEvent.StateRunning -> updateRunningState(true, clearTestingText = false)
             MainServiceEvent.StateNotRunning -> updateRunningState(false, clearTestingText = false)
-            MainServiceEvent.StateStartSuccess -> {
-                toastSuccess(R.string.toast_services_success)
-                updateRunningState(true)
-            }
-
-            MainServiceEvent.StateStartFailure -> {
-                toastError(R.string.toast_services_failure)
-                updateRunningState(false)
-            }
-
+            MainServiceEvent.StateStartSuccess -> updateRunningState(true)
+            MainServiceEvent.StateStartFailure -> updateRunningState(false)
             MainServiceEvent.StateStopSuccess -> updateRunningState(false)
             is MainServiceEvent.MeasureDelayResult -> {
                 _uiState.update { it.copy(status = MainStatus.ConnectionTest(event.result)) }

--- a/V2rayNG/app/src/main/res/values-ar/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ar/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">تعذر الحصول على إذن الإشعارات</string>
     <string name="notification_action_more">انقر للمزيد</string>
     <string name="toast_services_start">بدء الخدمات</string>
-    <string name="toast_services_stop">إيقاف الخدمات</string>
+    <string name="toast_services_stop">تم إيقاف الخدمة</string>
+    <string name="notification_channel_other">الإشعارات الأخرى</string>
     <string name="toast_services_success">نجاح بدء الخدمات</string>
     <string name="toast_services_failure">فشل بدء الخدمات</string>
 

--- a/V2rayNG/app/src/main/res/values-bn/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bn/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">বিজ্ঞপ্তির অনুমতি পাওয়া যায়নি</string>
     <string name="notification_action_more">আরও দেখতে ক্লিক করুন</string>
     <string name="toast_services_start">সার্ভিস শুরু করুন</string>
-    <string name="toast_services_stop">সার্ভিস বন্ধ করুন</string>
+    <string name="toast_services_stop">সার্ভিস বন্ধ হয়েছে</string>
+    <string name="notification_channel_other">অন্যান্য বিজ্ঞপ্তি</string>
     <string name="toast_services_success">সার্ভিস সফলভাবে শুরু হয়েছে</string>
     <string name="toast_services_failure">সার্ভিস শুরু হতে ব্যর্থ হয়েছে</string>
 

--- a/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
+++ b/V2rayNG/app/src/main/res/values-bqi-rIR/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">گرؽڌن موجوز وارسۊوی مومکن نؽڌ</string>
     <string name="notification_action_more">سی دووسمندیا قلوه کیلیک کوݩ</string>
     <string name="toast_services_start">ره وستن سرویس</string>
-    <string name="toast_services_stop">واڌاشتن سرویس</string>
+    <string name="toast_services_stop">واڌاشتن سرویس وا مووفقیت ٱنجوم وابی</string>
+    <string name="notification_channel_other">وارسۊوی یل دی</string>
     <string name="toast_services_success">ره وستن سرویس وا مووفقیت ٱنجوم وابی</string>
     <string name="toast_services_failure">ره وستن سرویس وا مووفقیت ٱنجوم نوابی</string>
 

--- a/V2rayNG/app/src/main/res/values-fa/strings.xml
+++ b/V2rayNG/app/src/main/res/values-fa/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">امکان دریافت مجوز ارسال اعلان وجود ندارد</string>
     <string name="notification_action_more">برای اطلاعات بیشتر کلیک کنید</string>
     <string name="toast_services_start">شروع خدمات</string>
-    <string name="toast_services_stop">توقف سرویس</string>
+    <string name="toast_services_stop">سرویس متوقف شد</string>
+    <string name="notification_channel_other">سایر اعلان‌ها</string>
     <string name="toast_services_success">سرویس با موفقیت شروع شد</string>
     <string name="toast_services_failure">شروع سرویس با شکست مواجه شد</string>
 

--- a/V2rayNG/app/src/main/res/values-ru/strings.xml
+++ b/V2rayNG/app/src/main/res/values-ru/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">Разрешение на отображение уведомлений не получено</string>
     <string name="notification_action_more">Ещё…</string>
     <string name="toast_services_start">Запуск служб</string>
-    <string name="toast_services_stop">Остановка служб</string>
+    <string name="toast_services_stop">Служба остановлена</string>
+    <string name="notification_channel_other">Другие уведомления</string>
     <string name="toast_services_success">Службы успешно запущены</string>
     <string name="toast_services_failure">Сбой при запуске служб</string>
 

--- a/V2rayNG/app/src/main/res/values-vi/strings.xml
+++ b/V2rayNG/app/src/main/res/values-vi/strings.xml
@@ -20,6 +20,7 @@
     <string name="notification_action_more">Nhấn để biết thêm…</string>
     <string name="toast_services_start">Đang khởi động v2rayNG…</string>
     <string name="toast_services_stop">Đã dừng v2rayNG!</string>
+    <string name="notification_channel_other">Thông báo khác</string>
     <string name="toast_services_success">Đã khởi động v2rayNG!</string>
     <string name="toast_services_failure">Không thể khởi động v2rayNG, kiểm tra lại cấu hình!</string>
 

--- a/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">无法取得通知权限</string>
     <string name="notification_action_more">点击了解更多</string>
     <string name="toast_services_start">启动服务</string>
-    <string name="toast_services_stop">关闭服务</string>
+    <string name="toast_services_stop">服务已停止</string>
+    <string name="notification_channel_other">其他通知</string>
     <string name="toast_services_success">启动服务成功</string>
     <string name="toast_services_failure">启动服务失败</string>
 

--- a/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
+++ b/V2rayNG/app/src/main/res/values-zh-rTW/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">無法取得此通知權限</string>
     <string name="notification_action_more">瞭解更多</string>
     <string name="toast_services_start">啟動服務</string>
-    <string name="toast_services_stop">停止服務</string>
+    <string name="toast_services_stop">服務已停止</string>
+    <string name="notification_channel_other">其他通知</string>
     <string name="toast_services_success">啟動服務成功</string>
     <string name="toast_services_failure">啟動服務失敗</string>
 

--- a/V2rayNG/app/src/main/res/values/strings.xml
+++ b/V2rayNG/app/src/main/res/values/strings.xml
@@ -19,7 +19,8 @@
     <string name="toast_permission_denied_notification">Notification permission denied</string>
     <string name="notification_action_more">Tap for more</string>
     <string name="toast_services_start">Starting service</string>
-    <string name="toast_services_stop">Stopping service</string>
+    <string name="toast_services_stop">Service stopped</string>
+    <string name="notification_channel_other">Other notifications</string>
     <string name="toast_services_success">Service started successfully</string>
     <string name="toast_services_failure">Failed to start service</string>
 

--- a/V2rayNG/app/src/test/java/com/v2ray/ang/helper/ServiceFeedbackTest.kt
+++ b/V2rayNG/app/src/test/java/com/v2ray/ang/helper/ServiceFeedbackTest.kt
@@ -1,0 +1,28 @@
+package com.v2ray.ang.helper
+
+import com.v2ray.ang.AppConfig
+import com.v2ray.ang.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ServiceFeedbackTest {
+    @Test
+    fun terminalEventsUseTheSameMessagesForForegroundAndBackgroundDelivery() {
+        assertEquals(R.string.toast_services_success, MessageHelper.serviceMessageResource(AppConfig.MSG_STATE_START_SUCCESS))
+        assertEquals(R.string.toast_services_failure, MessageHelper.serviceMessageResource(AppConfig.MSG_STATE_START_FAILURE))
+        assertEquals(R.string.toast_services_stop, MessageHelper.serviceMessageResource(AppConfig.MSG_STATE_STOP_SUCCESS))
+    }
+
+    @Test
+    fun stateQueriesAndProgressDoNotProduceTerminalFeedback() {
+        listOf(
+            AppConfig.MSG_STATE_RUNNING,
+            AppConfig.MSG_STATE_NOT_RUNNING,
+            AppConfig.MSG_STATE_START,
+            AppConfig.MSG_STATE_STOP,
+            AppConfig.MSG_MEASURE_CONFIG_NOTIFY,
+            AppConfig.MSG_MEASURE_DELAY_RESULT,
+        ).forEach { assertNull(MessageHelper.serviceMessageResource(it)) }
+    }
+}


### PR DESCRIPTION
Keep foreground snackbar presentation intact and replace its platform-toast fallback with one permission-aware notification that opens the app on tap and expires after ten seconds on Android 8+.

Send terminal service events through acknowledged, package-scoped broadcasts. A resumed snackbar host acknowledges the presentation handoff; repository, widget and tile state consumers do not suppress the notification fallback. Remove duplicate ViewModel messages, clear stale feedback after foreground delivery, report VPN setup failures and avoid successful-stop feedback during failed-start cleanup.