### PR TITLE
Performance: Coalesce bulk probe UI updates

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingResult.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/RealPingResult.kt
@@ -1,0 +1,9 @@
+package com.v2ray.ang.dto
+
+import java.io.Serializable
+
+/** One persisted delay-test result delivered from the task process to the UI. */
+data class RealPingResult(
+    val guid: String,
+    val delayMillis: Long,
+) : Serializable

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/service/CoreTestService.kt
@@ -10,6 +10,7 @@ import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.core.CoreNativeManager
 import com.v2ray.ang.dto.RealPingEvent
+import com.v2ray.ang.dto.RealPingResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.enums.NotificationChannelType
 import com.v2ray.ang.extension.serializable
@@ -151,7 +152,12 @@ class CoreTestService : Service() {
 
             is RealPingEvent.Result -> {
                 MmkvManager.encodeServerTestDelayMillis(event.guid, event.delayMillis)
-                MessageHelper.sendMsg2UI(this, AppConfig.MSG_MEASURE_CONFIG_SUCCESS, event.guid, requestId)
+                MessageHelper.sendMsg2UI(
+                    this,
+                    AppConfig.MSG_MEASURE_CONFIG_SUCCESS,
+                    RealPingResult(event.guid, event.delayMillis),
+                    requestId,
+                )
             }
 
             is RealPingEvent.Finish -> {

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainRepository.kt
@@ -9,6 +9,7 @@ import com.v2ray.ang.AngApplication
 import com.v2ray.ang.AppConfig
 import com.v2ray.ang.R
 import com.v2ray.ang.dto.ConnectionTestResult
+import com.v2ray.ang.dto.RealPingResult
 import com.v2ray.ang.dto.SubscriptionUpdateResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
@@ -24,10 +25,9 @@ import com.v2ray.ang.handler.SubscriptionUpdater
 import com.v2ray.ang.helper.MessageHelper
 import com.v2ray.ang.util.LogUtil
 import com.v2ray.ang.util.Utils
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import java.util.concurrent.atomic.AtomicBoolean
 
 class MainRepository(
@@ -39,13 +39,10 @@ class MainRepository(
 
     private val closed = AtomicBoolean(false)
 
-    private val _mainServiceEvent = MutableSharedFlow<MainServiceEvent>(
-        replay = 0,
-        extraBufferCapacity = 64,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
+    // Probe results are finite and must remain lossless until the ViewModel coalesces them.
+    private val mainServiceEventChannel = Channel<MainServiceEvent>(Channel.UNLIMITED)
 
-    override val mainServiceEvent: SharedFlow<MainServiceEvent> = _mainServiceEvent.asSharedFlow()
+    override val mainServiceEvent: Flow<MainServiceEvent> = mainServiceEventChannel.receiveAsFlow()
 
     private val serviceReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
@@ -63,7 +60,9 @@ class MainRepository(
                     ?.let { MainServiceEvent.MeasureDelayResult(it, requestId) }
                 AppConfig.MSG_MEASURE_DELAY_CANCEL -> MainServiceEvent.MeasureDelayCancelled(requestId)
 
-                AppConfig.MSG_MEASURE_CONFIG_SUCCESS -> MainServiceEvent.MeasureConfigSuccess(requestId)
+                AppConfig.MSG_MEASURE_CONFIG_SUCCESS -> safeIntent
+                    .serializable<RealPingResult>("content")
+                    ?.let { MainServiceEvent.MeasureConfigSuccess(it, requestId) }
                 AppConfig.MSG_MEASURE_CONFIG_NOTIFY -> MainServiceEvent.MeasureConfigNotify(
                     safeIntent.getStringExtra("content").orEmpty(), requestId
                 )
@@ -75,7 +74,7 @@ class MainRepository(
 
                 else -> null
             }
-            event?.let { _mainServiceEvent.tryEmit(it) }
+            event?.let { mainServiceEventChannel.trySend(it) }
         }
     }
 
@@ -101,6 +100,7 @@ class MainRepository(
         }.onFailure {
             LogUtil.e(AppConfig.TAG, "Failed to unregister main service receiver", it)
         }
+        mainServiceEventChannel.close()
     }
 
     override fun getSelectedSubscriptionId(): String =
@@ -219,7 +219,7 @@ class MainRepository(
 
     override fun testCurrentServerRealPing(requestId: String) {
         MessageHelper.sendMsg2ServiceForResult(app, AppConfig.MSG_MEASURE_DELAY, requestId) { handled ->
-            if (!handled) _mainServiceEvent.tryEmit(MainServiceEvent.MeasureDelayCancelled(requestId))
+            if (!handled) mainServiceEventChannel.trySend(MainServiceEvent.MeasureDelayCancelled(requestId))
         }
     }
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainServiceEvent.kt
@@ -1,6 +1,7 @@
 package com.v2ray.ang.ui.main
 
 import com.v2ray.ang.dto.ConnectionTestResult
+import com.v2ray.ang.dto.RealPingResult
 
 sealed class MainServiceEvent {
     data object StateRunning : MainServiceEvent()
@@ -10,7 +11,7 @@ sealed class MainServiceEvent {
     data object StateStopSuccess : MainServiceEvent()
     data class MeasureDelayResult(val result: ConnectionTestResult, val requestId: String) : MainServiceEvent()
     data class MeasureDelayCancelled(val requestId: String) : MainServiceEvent()
-    data class MeasureConfigSuccess(val requestId: String) : MainServiceEvent()
+    data class MeasureConfigSuccess(val result: RealPingResult, val requestId: String) : MainServiceEvent()
     data class MeasureConfigNotify(val progress: String, val requestId: String) : MainServiceEvent()
     data class MeasureConfigFinish(val requestId: String) : MainServiceEvent()
     data class MeasureConfigCancelled(val requestId: String) : MainServiceEvent()

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/ui/main/MainViewModel.kt
@@ -9,6 +9,7 @@ import com.v2ray.ang.R
 import com.v2ray.ang.dto.ConnectionTestResult
 import com.v2ray.ang.dto.GroupMapItem
 import com.v2ray.ang.dto.LocateTarget
+import com.v2ray.ang.dto.RealPingResult
 import com.v2ray.ang.dto.TestServiceMessage
 import com.v2ray.ang.dto.entities.ProfileItem
 import com.v2ray.ang.dto.entities.ServersCache
@@ -24,6 +25,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +41,30 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.PatternSyntaxException
+
+private fun applyTestDelayResults(
+    servers: List<ServersCache>,
+    updates: Map<String, Long>,
+): List<ServersCache> = servers.map { server ->
+    val delayMillis = updates[server.guid]
+    if (delayMillis == null || delayMillis == server.testDelayMillis) {
+        server
+    } else {
+        server.copy(testDelayMillis = delayMillis)
+    }
+}
+
+private fun applyTestDelayResultsToRows(
+    rows: List<ServerRowUiModel>,
+    updates: Map<String, Long>,
+): List<ServerRowUiModel> = rows.map { row ->
+    val delayMillis = updates[row.guid]
+    if (delayMillis == null || delayMillis == row.testDelayMillis) {
+        row
+    } else {
+        row.copy(testDelayMillis = delayMillis)
+    }
+}
 
 class MainViewModel(
     application: Application,
@@ -77,6 +103,8 @@ class MainViewModel(
     private var preloadJob: Job? = null
     private var selectedGroupLoadJob: Job? = null
     private var reloadJob: Job? = null
+    private var testResultFlushJob: Job? = null
+    private val pendingTestResults = linkedMapOf<String, Long>()
 
     private val testRequests = MainTestRequests()
     private var bulkTestJob: Job? = null
@@ -119,11 +147,7 @@ class MainViewModel(
 
             is MainServiceEvent.MeasureConfigSuccess -> {
                 val request = testRequests.bulk?.takeIf { it.id == event.requestId } ?: return
-                viewModelScope.launch(ioDispatcher) {
-                    val gid = request.groupId
-                    cacheMutex.withLock { groupDataCache.remove(gid) }
-                    updateGroupUi(gid, loadGroup(gid, forceRefresh = true))
-                }
+                queueTestResult(event.result, request)
             }
 
             is MainServiceEvent.MeasureConfigNotify -> {
@@ -133,7 +157,14 @@ class MainViewModel(
             }
 
             is MainServiceEvent.MeasureConfigFinish -> {
-                onTestsFinished(event.requestId)
+                val request = testRequests.bulk?.takeIf { it.id == event.requestId } ?: return
+                val scheduledFlush = testResultFlushJob
+                testResultFlushJob = viewModelScope.launch {
+                    scheduledFlush?.cancelAndJoin()
+                    if (testRequests.bulk?.id != request.id) return@launch
+                    flushPendingTestResults(request)
+                    onTestsFinished(request.id)
+                }
             }
 
             is MainServiceEvent.MeasureDelayCancelled -> {
@@ -141,8 +172,45 @@ class MainViewModel(
             }
 
             is MainServiceEvent.MeasureConfigCancelled -> {
-                if (testRequests.completeBulk(event.requestId) != null) resetTestStatus()
+                if (testRequests.completeBulk(event.requestId) != null) {
+                    cancelPendingTestResults()
+                    resetTestStatus()
+                }
             }
+        }
+    }
+
+    private fun queueTestResult(result: RealPingResult, request: MainTestRequests.Bulk) {
+        pendingTestResults[result.guid] = result.delayMillis
+        if (testResultFlushJob?.isActive == true) return
+
+        testResultFlushJob = viewModelScope.launch {
+            while (pendingTestResults.isNotEmpty()) {
+                delay(TEST_RESULT_FLUSH_INTERVAL_MS)
+                flushPendingTestResults(request)
+            }
+        }
+    }
+
+    private suspend fun flushPendingTestResults(request: MainTestRequests.Bulk) {
+        if (pendingTestResults.isEmpty()) return
+        if (testRequests.bulk?.id != request.id) return
+
+        val updates = cacheMutex.withLock {
+            val drained = pendingTestResults.toMap()
+            pendingTestResults.clear()
+            groupDataCache[request.groupId]?.let { cached ->
+                groupDataCache[request.groupId] = applyTestDelayResults(cached, drained)
+            }
+            drained
+        }
+        if (updates.isEmpty()) return
+        if (testRequests.bulk?.id != request.id) return
+        mutableServerGroupState(request.groupId).update { current ->
+            current.copy(
+                servers = applyTestDelayResults(current.servers, updates),
+                rows = applyTestDelayResultsToRows(current.rows, updates),
+            )
         }
     }
 
@@ -740,6 +808,7 @@ class MainViewModel(
         bulkTestJob = null
         testRequests.cancelBulk()
         testRequests.invalidateCurrent()
+        cancelPendingTestResults()
         resetTestStatus()
         dataSource.cancelAllPing()
     }
@@ -789,13 +858,25 @@ class MainViewModel(
         }
         bulkTestJob = viewModelScope.launch {
             withContext(ioDispatcher) {
+                dataSource.clearAllTestDelayResults(serverGuids)
+                val resetGuids = serverGuids.toHashSet()
                 cacheMutex.withLock {
-                    dataSource.clearAllTestDelayResults(serverGuids)
-                    groupDataCache.remove(groupId)
+                    groupDataCache[groupId]?.let { cached ->
+                        groupDataCache[groupId] = cached.map { server ->
+                            if (server.guid !in resetGuids || server.testDelayMillis == 0L) server
+                            else server.copy(testDelayMillis = 0L)
+                        }
+                    }
                 }
             }
             dataSource.sendMsg2TestService(message, request.id)
         }
+    }
+
+    private fun cancelPendingTestResults() {
+        testResultFlushJob?.cancel()
+        testResultFlushJob = null
+        pendingTestResults.clear()
     }
 
     fun testCurrentServerRealPing() {
@@ -868,5 +949,9 @@ class MainViewModel(
             }
             throw IllegalArgumentException("Unknown ViewModel class")
         }
+    }
+
+    private companion object {
+        const val TEST_RESULT_FLUSH_INTERVAL_MS = 500L
     }
 }


### PR DESCRIPTION
## Problem

Upstream runs bulk RealDelay work in its dedicated `:tasks` process, but the UI
path still treats every successful profile as a reason to invalidate and reload
the entire selected group from MMKV. With large subscriptions, hundreds of result
broadcasts therefore trigger hundreds of full-list rebuilds and Compose updates.

This PR keeps upstream's probing implementation unchanged and optimizes only that
result-delivery path.

## What changes

- Include the profile GUID and persisted delay in each existing successful-result
  broadcast.
- Deliver service events through a lossless channel instead of dropping bursts
  after 64 buffered events.
- Key pending probe results by GUID and coalesce visible updates every 500 ms.
- Patch the cached server objects and prebuilt row models directly, preserving
  unchanged row instances instead of invalidating and reloading the complete group.
- Force the last pending batch into UI state before applying the existing finished
  state.
- Discard pending UI batches when a scan is cancelled or replaced.

The service continues to persist every result to MMKV as before. This PR does not
change the probe worker, request scheduling, or native-core lifecycle.

## Reconciliation with merged #6203

This branch is rebased directly on current upstream `173f60a1dabe57e822a56381931be6354f7c7f61`,
which includes #6203. The conflict resolution preserves #6203's request-lifecycle
contract and layers the coalescing on top:

- successful events carry both `RealPingResult` and the request ID;
- stale results are rejected before they enter the pending batch;
- each pending batch remains bound to the request's original group;
- the final batch is flushed before that request is completed;
- cancellation clears pending results only for the matching active request; and
- #6205's lossless event channel is used by both broadcasts and the current-server
  fallback path.

## Difference from rejected PR #6125

#6125 tried to address process isolation, concurrency, progress, notification
cancellation, stale sessions, policy groups, and UI delivery together. That made
the patch substantially broader and introduced maintenance concerns.

This PR extracts only the independently measurable UI performance improvement and
builds it directly on top of upstream's minimal process-isolation approach:

| Area | #6125 | This PR |
|---|---|---|
| Process/service architecture | Reworked | **Upstream unchanged** |
| Probe concurrency and scheduling | Changed | **Upstream unchanged** |
| Progress and notification cancellation | Changed | **Upstream unchanged** |
| Policy-group behavior | Changed, then skipped | **Upstream unchanged** |
| Result delivery | Session-aware and coalesced | **Request-aware, GUID-addressed, and coalesced** |
| AndroidLib / xray-core | Unchanged | **Unchanged** |
| Xray Observatory | Not used | **Not used** |

The only service-side adjustment here is the result payload required for a targeted
UI update: `{ profile GUID, persisted delay }`. There is no new service, process,
probing policy, or native API.

## Original 500-profile performance comparison

These measurements were collected for the original PR revision before the #6203
rebase. Per request, the performance benchmark was not repeated for the conflict
resolution; the current branch received fresh correctness and emulator validation
instead.

Controlled workload:

- upstream `2020807c255b76b09c9ced4255c95600250aef48` versus the original PR
  revision `035769c71b0b9fb5a80c770141b5c7bbdc0b93c0`;
- one Android 13/API 33 x86_64 Pixel 6a emulator with four virtual CPUs;
- one deterministic subscription containing 500 SOCKS profiles;
- emulator-local SOCKS and HTTP fixtures with a 100 ms HTTP response delay;
- configured concurrency 16;
- one excluded warmup and five accepted measured runs per build;
- `/proc/<pid>/stat` sampled every 250 ms for all app processes and
  `dumpsys meminfo` sampled approximately once per second; and
- the same upstream AndroidLib gitlink and byte-identical AAR in both measured
  builds.

Values are `median; mean +/- sample SD; min-max`. Percentage changes compare
medians; negative is better for CPU, memory, time, and jank.

| Metric | Upstream | This PR | Median change |
|---|---:|---:|---:|
| Total app CPU (s) | 20.10; 20.11 +/- 0.13; 19.98-20.32 | 12.87; 12.99 +/- 0.24; 12.78-13.38 | **-36.0%** |
| Main-process CPU (s) | 13.52; 13.44 +/- 0.28; 12.97-13.67 | 6.13; 6.21 +/- 0.20; 6.02-6.49 | **-54.7%** |
| `:tasks` worker CPU (s) | 5.59; 5.60 +/- 0.18; 5.44-5.90 | 5.68; 5.69 +/- 0.08; 5.60-5.77 | +1.6% |
| Average app CPU (% of one core) | 179.08; 176.90 +/- 6.65; 167.17-183.61 | 117.35; 118.21 +/- 3.12; 114.92-122.99 | **-34.5%** |
| Peak combined PSS (KiB) | 348745; 348569 +/- 14894; 325679-365929 | 309355; 304908 +/- 7798; 295543-311436 | **-11.3%** |
| Peak main-process PSS (KiB) | 164333; 166879 +/- 14835; 145962-184278 | 125997; 125644 +/- 626; 124708-126197 | **-23.3%** |
| Janky frames (%) | 51.25; 50.34 +/- 2.15; 47.13-52.53 | 37.97; 38.70 +/- 1.51; 37.12-40.45 | **-25.9%** |
| Frame p50 (ms) | 32; 32.8 +/- 1.1; 32-34 | 23; 21.8 +/- 2.9; 17-24 | **-28.1%** |
| Frame p90 (ms) | 73; 75.4 +/- 5.4; 69-81 | 46; 45.6 +/- 2.6; 42-48 | **-37.0%** |
| Frame p95 (ms) | 117; 113.8 +/- 7.2; 101-117 | 69; 67.4 +/- 2.2; 65-69 | **-41.0%** |
| Network span (s) | 8.128; 8.165 +/- 0.185; 7.968-8.444 | 8.089; 8.099 +/- 0.082; 8.004-8.208 | -0.5% |
| UI-observed completion (s) | 11.206; 11.382 +/- 0.396; 10.947-11.952 | 10.950; 10.989 +/- 0.097; 10.879-11.121 | -2.3% |

The reduction is concentrated where expected: median main-process CPU fell 54.7%,
while the unchanged `:tasks` worker moved 1.6% and the actual network span moved
0.5%. The UI rendered more frames with fewer janky frames and substantially lower
p50/p90/p95 frame times. This supports the intended narrow conclusion: the
improvement came from eliminating per-result full-list reload/recomposition work,
not from changing how probes run.

All ten accepted measured runs completed exactly 1,000 HTTP GETs, 1,000 SOCKS
CONNECTs, and 1,500 socket accepts. Observed HTTP and SOCKS concurrency was exactly
16, every run reached the final UI state, and measured logcats contained no crash,
ANR, native abort, or SIGSEGV marker. One upstream sample and the first candidate
warmup briefly measured 17 simultaneous SOCKS accepts; the strict harness rejected
those captures and replacement runs passed at exactly 16.

## Current validation

- `git diff --check` against current upstream.
- Full `:app:testPlaystoreDebugUnitTest` suite passed, including the retained local
  coalescing harness; no test source is tracked by this branch.
- Play Store x86_64 debug APK built, installed, and exercised on the single API 33
  Pixel 6a emulator.
- A 500-profile RealDelay run completed all 1,000 fixture HTTP requests at observed
  concurrency 16; visible rows updated, progress cleared, and the `:tasks` service
  exited.
- Notification cancellation stopped an in-progress batch, cleared the UI testing
  state, and left no active fixture work; a fresh 500-profile run immediately after
  cancellation also completed all 1,000 requests.
- Emulator crash buffer remained empty.
- Current AndroidLib gitlink is
  `d0c6c4ae1b09c912070c8288bd0dbcc2e492ac29`; validation used its official v26.9.9
  four-ABI AAR (`SHA-256 9ECF4C921568D8F4CB8550D3BAFE08FF6F1D1984F45A6AD183DCDF52EE9302DE`).
- No benchmark harness, test source, or native artifact is included in this branch.

This targets the UI-side result backlog implicated in #6089 without claiming that
the controlled emulator reproduces every OEM-specific failure mode reported there.
