### PR TITLE
Make release APKs reproducible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,6 @@ jobs:
           --channel=0 \
           --install "ndk;29.0.14206865"
         echo "NDK_HOME=$ANDROID_HOME/ndk/29.0.14206865" >> $GITHUB_ENV
-        sed -i '10i\
-        \
-            ndkVersion = "29.0.14206865"' ${{ github.workspace }}/V2rayNG/app/build.gradle.kts
 
     - name: Restore cached libhevtun
       id: cache-libhevtun-restore
@@ -84,7 +81,15 @@ jobs:
       uses: actions/setup-java@v6.0.0
       with:
         distribution: 'temurin'
-        java-version: '21'
+        # An exact build rather than '21', which takes whatever JDK 21 the
+        # runner image has preinstalled and so changes the output as the image
+        # is updated. This is Temurin 21.0.12.1+1, spelled as the Adoptium
+        # semver setup-java matches against. '21.0.12.1' only matches the
+        # preinstalled copy by accident of its folder name and breaks once the
+        # image moves on; '21.0.12+101' matches nothing. Next value: the
+        # `semver` field at
+        # https://api.adoptium.net/v3/info/release_versions?release_type=ga&version=%5B21,22)
+        java-version: '21.0.12+101.0.LTS'
 
     - name: Decode Keystore
       uses: timheuer/base64-to-file@v2.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,13 @@ jobs:
     - name: Fetch AndroidLibXrayLite tag
       run: |
         pushd AndroidLibXrayLite
-        CURRENT_TAG=$(git describe --tags --abbrev=0)
+        # The aar is downloaded from the release for this tag, so the submodule
+        # has to sit exactly on it. `--abbrev=0` fell back to the nearest older
+        # tag, shipping a core that did not match the submodule source.
+        if ! CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null); then
+          echo "::error::AndroidLibXrayLite is at $(git rev-parse --short HEAD), which is not a tagged release, so there is no aar that matches it. Tag and release it first."
+          exit 1
+        fi
         echo "Current tag in this repo: $CURRENT_TAG"
         echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
         popd

--- a/V2rayNG/app/build.gradle.kts
+++ b/V2rayNG/app/build.gradle.kts
@@ -9,6 +9,11 @@ android {
     namespace = "com.v2ray.ang"
     compileSdk = 37
 
+    // Pinned so release APKs can be rebuilt byte for byte: the NDK strips the
+    // jniLibs, so its version is part of the output. build.yml used to insert
+    // this line with sed, which only took effect inside CI.
+    ndkVersion = "29.0.14206865"
+
     defaultConfig {
         applicationId = "com.v2ray.ang"
         minSdk = 24


### PR DESCRIPTION

Companion to 2dust/AndroidLibXrayLite#207, which makes the released `libv2ray.aar` reproducible. With both, anyone can rebuild a published APK from source and compare it byte for byte, which is what IzzyOnDroid and F-Droid's reproducible-builds verification needs. Each commit here stands on its own.

### Changes

1. **NDK**: declare `ndkVersion` in `build.gradle.kts` and drop the `sed` in `build.yml` that inserted it at a hardcoded line number. The NDK strips the jniLibs, so its version is part of the APK, and the `sed` only took effect inside CI.
2. **JDK**: pin Temurin 21.0.12.1+1 instead of `'21'`, which resolves to whatever JDK 21 the runner image has preinstalled. It is written as `21.0.12+101.0.LTS`, the form `setup-java` matches against Adoptium; `'21.0.12.1'` only matches the preinstalled copy by accident, and `'21.0.12+101'` matches nothing.
3. **AndroidLibXrayLite tag**: use `git describe --tags --exact-match` instead of `--abbrev=0`. When the submodule is past a tag, `--abbrev=0` resolves to the nearest older tag and the older aar is shipped. That happened for 1.10.30 to 1.10.32: the submodule pointed at `4ba2d04a` and `1655d531` ("Updating xray-core to v25.12.8"), neither tagged, and `--abbrev=0` resolved both to v25.12.2, so `build.yml` downloaded the v25.12.2 aar for all three. The step now fails with an explanation instead. 27 of the last 30 submodule updates were on a tag, where nothing changes.

### Validation

- A from-source workflow in a fork built this `ndkVersion` in three independent GitHub-hosted runs, all producing identical APKs: [34460850995](https://github.com/AcideFluorhydrique/v2rayNG/actions/runs/34460850995), [34466248610](https://github.com/AcideFluorhydrique/v2rayNG/actions/runs/34466248610), [34475374598](https://github.com/AcideFluorhydrique/v2rayNG/actions/runs/34475374598). The third used this JDK pin and a newer runner image; the first two used the runner's preinstalled copy of the same JDK build. All three passed `:app:assemblePlaystoreDebug` and `:app:testPlaystoreDebugUnitTest` with a `build.gradle.kts` identical to this branch's apart from the comment.
- The exact-match step was run against a submodule sitting on a tag (passes, exports the tag) and one commit past it (fails with the message).
- Not run: `build.yml` on this branch, since it needs the release keystore.
