### PR TITLE
Enable disableFallbackIfMatch for built-in DNS

### DIFF
--- a/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/core/CoreConfigManager.kt
@@ -829,6 +829,7 @@ object CoreConfigManager {
             servers = servers,
             hosts = hosts,
             tag = AppConfig.TAG_DNS,
+            disableFallbackIfMatch = true,
             enableParallelQuery = if ((domesticDns.size + remoteDns.size) > 2) true else null
         )
 
@@ -889,6 +890,7 @@ object CoreConfigManager {
             servers = servers,
             hosts = hosts,
             tag = AppConfig.TAG_DNS,
+            disableFallbackIfMatch = true,
             enableParallelQuery = if ((domesticDns.size + remoteDns.size) > 2) true else null
         )
 

--- a/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
+++ b/V2rayNG/app/src/main/java/com/v2ray/ang/dto/V2rayConfig.kt
@@ -343,6 +343,7 @@ data class V2rayConfig(
         val disableCache: Boolean? = null,
         val queryStrategy: String? = null,
         val enableParallelQuery: Boolean? = null,
+        val disableFallbackIfMatch: Boolean? = null,
         val tag: String? = null
     ) {
         data class ServersBean(


### PR DESCRIPTION
Currenlty, domestic domains are resolved with remote DNS which is not the expected behavior. It is especially bad in situations when proxy provides IPv6 but there is no local IPv6 connectivity. In such cases domestic hosts with AAAA records become inaccessible. disableFallbackIfMatch fixes this by removing remote DNS from domestic domains resolution.

Change-Id: If24ec8f1eacf81c3e25a27820cd98a9f5b878ecd